### PR TITLE
specs: add UX-quality requirements (FR-038..041, SC-011, R13, Phase 8)

### DIFF
--- a/specs/001-ptstalk-report-mvp/checklists/ux-quality.md
+++ b/specs/001-ptstalk-report-mvp/checklists/ux-quality.md
@@ -35,16 +35,19 @@ Applies to every rendered surface, independent of section.
 - [ ] **G-1** Every font size on every rendered surface MUST be
       expressed via one of the four named CSS custom properties
       `var(--font-h2)`, `var(--font-h3)`, `var(--font-body)`, or
-      `var(--font-caption)`. No literal `font-size:` declaration
-      appears in `render/assets/app.css` outside the `:root`-level
-      custom property definitions. Auditable by grep against the
-      shipped stylesheet; reviewer taste is not in scope.
+      `var(--font-caption)`. Check is performed **against the
+      embedded stylesheet in the rendered HTML** (the single
+      top-level `<style>` block the report ships, not the source
+      file): extract that block and assert no literal `font-size:`
+      declaration appears outside the `:root`-level custom property
+      definitions. Fully auditable from the shipped report alone.
 - [ ] **G-2** Spacing rhythm is pinned to a single `8px` base grid
       exposed as `var(--grid)` on `:root`. Every margin, padding,
-      and gap value in `render/assets/app.css` MUST be either
-      `0`, `var(--grid)`, or `calc(var(--grid) * N)` for an integer
-      `N`. Grep confirms no literal non-zero `px` spacing values
-      outside the `:root` declaration of `--grid`.
+      and gap value in the rendered report's embedded `<style>`
+      block MUST be either `0`, `var(--grid)`, or
+      `calc(var(--grid) * N)` for an integer `N`. Same extraction
+      method as G-1; the audit does not require access to
+      `render/assets/app.css` in source form.
 - [ ] **G-3** Colour palette: one primary accent, one muted-text
       tone, one warning tone, one success tone. Charts use the same
       named palette across all sections.

--- a/specs/001-ptstalk-report-mvp/checklists/ux-quality.md
+++ b/specs/001-ptstalk-report-mvp/checklists/ux-quality.md
@@ -69,7 +69,8 @@ Applies to every rendered surface, independent of section.
 - [ ] **H-3** `GeneratedAt` timestamp is labelled as the sole
       non-deterministic field and rendered via the shared formatter.
 - [ ] **H-4** Tool version (`my-gather <semver>`) + short commit
-      visible in the header or footer.
+      visible in the header or footer (`render/templates/report.html.tmpl`;
+      no standalone FR — FR-023 governs the CLI counterpart).
 - [ ] **H-5** No duplicated metadata between header, footer, and
       section breadcrumbs.
 
@@ -96,8 +97,9 @@ Applies to every rendered surface, independent of section.
       labelled; peak-utilization device identifiable at a glance.
 - [ ] **OS-2** Top CPU processes chart (`-top`): each plotted
       process identified by both PID and command, not just PID.
-- [ ] **OS-3** vmstat saturation chart (`-vmstat`): 13-series
-      legend is readable without overlapping the plot; a collapsed-
+- [ ] **OS-3** vmstat saturation chart (`-vmstat`): all 13 declared
+      series (`VmstatData.Series` in `data-model.md`) are
+      legend-labelled without overlapping the plot; a collapsed-
       legend affordance exists when screen real estate is tight.
 - [ ] **OS-4** Three subview anchors — `os-disk-util`, `os-top-cpu`,
       `os-vmstat` — present and nav-linked (SC-005 / T096).
@@ -155,8 +157,8 @@ Applies to every rendered surface, independent of section.
 - [ ] **PD-2** Each diagnostic row: file basename, location (line
       or byte), severity (Warning or Error), single-line message.
 - [ ] **PD-3** `SeverityInfo` diagnostics appear here and only here
-      (FR-027 / R8 D snapshot-boundary info is the canonical
-      example).
+      (FR-027 / FR-030; snapshot-boundary info from R8 improvement D
+      is the canonical example).
 - [ ] **PD-4** Warnings / Errors are colour-coded AND prefixed with
       a word (`[warning]` / `[error]`) — not colour-only (G-7).
 - [ ] **PD-5** No diagnostic is duplicated from a subview banner
@@ -187,7 +189,9 @@ Run the full audit against each of these fixture classes.
       against `testdata/example2/` passes all § 0–7 items.
 - [ ] **R-M** Maximum collection (approaching 1 GB / 200 MB per
       FR-025): axis labels not clipped; legend not overlapping plot;
-      no subview overflows its container.
+      no subview overflows its container. (The near-1 GB synthetic
+      fixture is built as part of T116; no pre-committed testdata
+      path exists for this class.)
 - [ ] **R-MS** Multi-snapshot collection (`testdata/example2/` has
       two): snapshot-scoped subviews show one block per snapshot;
       time-series subviews show vertical boundary markers.
@@ -207,9 +211,12 @@ Run the full audit against each of these fixture classes.
       for key values (e.g., a distinctive variable name, a specific
       PID) and confirm each appears in only one subview outside of
       the Parser Diagnostics panel.
-- [ ] **D-2** Any summary or overview widget (if present in a future
-      feature) sources from a canonical subview via anchor link; it
-      does NOT re-plot or re-tabulate the underlying data.
+- [ ] **D-2** No section introduces a summary or overview widget that
+      re-plots or re-tabulates data already present in another
+      section's canonical subview (confirm by scanning the rendered
+      HTML for any element that aggregates or repeats values from a
+      non-home source). When a widget is added in a future feature,
+      add a corresponding audit row to this section at that time.
 - [ ] **D-3** Cross-references between sections are navigation aids
       only (anchor links, `<a href="#sec-...">`), never duplicated
       data displays.
@@ -227,7 +234,7 @@ File path: `specs/001-ptstalk-report-mvp/ux-audits/<YYYY-MM-DD>-<label>.md`
 **Reviewed commit**: `<short-sha>`
 **Reference fixtures**: testdata/example2/, <synthetic-1-sample>, …
 **Browsers**: Chromium <v>, Firefox <v>, Safari <v>
-**Viewports**: 1440×900, 1920×1080, 375×667
+**Viewports**: 1440×900, 1920×1080, 375×667 (crash-check only — mobile UX out of scope per spec Assumptions)
 
 ## Results
 

--- a/specs/001-ptstalk-report-mvp/checklists/ux-quality.md
+++ b/specs/001-ptstalk-report-mvp/checklists/ux-quality.md
@@ -56,15 +56,18 @@ Applies to every rendered surface, independent of section.
       axis falls back to raw `toLocaleString()`.
 - [ ] **G-5** Every rendered timestamp — including server-rendered
       header / banner / table text, chart tooltips and other
-      JavaScript-rendered timestamp labels, and timestamp fields
-      in the embedded JSON payload — uses the shared UTC ISO-8601
-      formatter (Principle IV). No rendered surface or payload
-      field uses locale-dependent (`toLocaleDateString`,
-      `toLocaleString`) or raw-epoch time. A grep of `app.js` for
-      `toLocaleDate`, `toLocaleString`, or `toLocaleTime` returns
-      no hits in rendering paths (note: `toLocaleString()` on
-      non-timestamp numeric values — e.g., integer formatting — is
-      still permitted and is governed by G-4, not G-5).
+      JavaScript-rendered timestamp labels, and timestamp fields in
+      the embedded JSON payload — uses the shared UTC ISO-8601
+      formatter (Principle IV). No timestamp-formatting call site
+      uses locale-dependent (`toLocaleDateString`, `toLocaleTime…`)
+      or raw-epoch time. Auditable via inspection of every function
+      in `app.js` that takes a timestamp or `Date` argument and
+      returns a human-readable string: each MUST route through the
+      shared UTC formatter helper. `toLocaleString()` is NOT
+      forbidden outright — it remains permitted for non-timestamp
+      numeric formatting (e.g., integer separators), which is
+      governed by G-4. The audit check is "no locale-dependent
+      timestamp formatting", not "no `toLocaleString` anywhere".
 - [ ] **G-6** Every interactive element (button, dropdown, chip,
       checkbox, search input) is reachable and operable by keyboard
       alone (FR-031, FR-036).

--- a/specs/001-ptstalk-report-mvp/checklists/ux-quality.md
+++ b/specs/001-ptstalk-report-mvp/checklists/ux-quality.md
@@ -1,0 +1,257 @@
+# UX-Quality Audit Checklist
+
+**Normative**: FR-038, FR-039, FR-040, FR-041, SC-011
+**Research**: R13
+**Principle**: Constitution XI ("Reports Optimized for Humans Under
+Pressure")
+
+---
+
+## How to run an audit
+
+1. Render the report against `testdata/example2/` (multi-snapshot)
+   and, where specified, against a 0-sample / 1-sample / large
+   synthetic fixture.
+2. Open the rendered HTML in the three reference browsers (latest
+   stable Chromium, Firefox, Safari) at 1440×900, 1920×1080, and
+   375×667 (mobile is out of scope per Assumptions but the
+   layout MUST NOT crash below 800 px — it collapses to top-horizontal
+   nav per FR-031).
+3. Walk every row below. Mark **PASS** / **FAIL** / **DEFERRED**.
+   DEFERRED items MUST link a follow-up task ID (T###).
+4. Commit the result as
+   `specs/001-ptstalk-report-mvp/ux-audits/<YYYY-MM-DD>-<label>.md`.
+
+A PASS run is the precondition for any feature-001 release cut
+(SC-011). FAIL items block merge; DEFERRED items require owner
+approval recorded in the same audit file.
+
+---
+
+## 0. Global invariants
+
+Applies to every rendered surface, independent of section.
+
+- [ ] **G-1** Typography scale is a single harmonic progression (no
+      arbitrary font sizes). Every `h2` shares one size; every `h3`
+      shares one size; body text is one size; captions are one size.
+- [ ] **G-2** Spacing rhythm is a single base grid (`4px` or `8px`).
+      No section introduces ad-hoc margin/padding values outside the
+      grid.
+- [ ] **G-3** Colour palette: one primary accent, one muted-text
+      tone, one warning tone, one success tone. Charts use the same
+      named palette across all sections.
+- [ ] **G-4** All chart axes format numbers via the shared
+      `formatYTick` helper (compact: `1.2K` / `3.4M` / `1.2B`). No
+      axis falls back to raw `toLocaleString()`.
+- [ ] **G-5** All timestamps render UTC ISO-8601 via the shared
+      formatter (Principle IV). No section prints locale-dependent
+      or raw-epoch time.
+- [ ] **G-6** Every interactive element (button, dropdown, chip,
+      checkbox, search input) is reachable and operable by keyboard
+      alone (FR-031, FR-036).
+- [ ] **G-7** No visible element relies on colour alone to convey
+      meaning (pass/fail badge, modified/default badge, severity
+      icon); each uses both colour **and** a text label or shape
+      cue.
+- [ ] **G-8** The shared `render/assets/app.css` expresses all the
+      above as CSS custom properties (`--fg`, `--accent`,
+      `--muted`, `--warn`, `--ok`, `--grid`, `--font-h2`,
+      `--font-h3`, `--font-body`). Per-template inline `<style>`
+      blocks are forbidden (FR-039).
+
+## 1. Header + banners
+
+- [ ] **H-1** Verbatim-passthrough banner (FR-026) is visible above
+      the fold at 1440×900 for a 2-section-minimum report.
+- [ ] **H-2** Report title (hostname + snapshot count) is
+      immediately scannable.
+- [ ] **H-3** `GeneratedAt` timestamp is labelled as the sole
+      non-deterministic field and rendered via the shared formatter.
+- [ ] **H-4** Tool version (`my-gather <semver>`) + short commit
+      visible in the header or footer.
+- [ ] **H-5** No duplicated metadata between header, footer, and
+      section breadcrumbs.
+
+## 2. Navigation rail
+
+- [ ] **N-1** Every named subview is listed once and reachable in a
+      single click (SC-009).
+- [ ] **N-2** At ≥ 801 px the rail is `position: sticky`; at
+      < 801 px it collapses to top-horizontal (R9).
+- [ ] **N-3** Without JavaScript the rail degrades to a plain anchor
+      list (FR-031).
+- [ ] **N-4** Cmd/Ctrl+`\` toggles the rail (FR-036); the
+      accelerator is discoverable via a title attribute or visible
+      cue.
+- [ ] **N-5** Collapse state of each nav group persists across
+      reloads via the `Report.ReportID`-keyed localStorage scheme
+      (FR-032).
+- [ ] **N-6** Rail does NOT re-present any data; only titles and
+      anchors (FR-038).
+
+## 3. OS Usage section
+
+- [ ] **OS-1** Disk utilization chart (`-iostat`): per-device series
+      labelled; peak-utilization device identifiable at a glance.
+- [ ] **OS-2** Top CPU processes chart (`-top`): each plotted
+      process identified by both PID and command, not just PID.
+- [ ] **OS-3** vmstat saturation chart (`-vmstat`): 13-series
+      legend is readable without overlapping the plot; a collapsed-
+      legend affordance exists when screen real estate is tight.
+- [ ] **OS-4** Three subview anchors — `os-disk-util`, `os-top-cpu`,
+      `os-vmstat` — present and nav-linked (SC-005 / T096).
+- [ ] **OS-5** Multi-snapshot: all three time-series charts show
+      snapshot-boundary markers at the right timestamps (FR-018 /
+      FR-030, T054).
+- [ ] **OS-6** When one of `-iostat` / `-top` / `-vmstat` is absent
+      the corresponding subview shows "data not available" naming
+      the missing file; the other two render normally (FR-007).
+- [ ] **OS-7** No OS-Usage chart re-plots data that canonically
+      belongs to Database Usage (e.g., no mysqladmin-derived series
+      embedded in vmstat) and vice versa (FR-038).
+
+## 4. Variables section
+
+- [ ] **V-1** Search input (`<input type="search">`) is visible
+      without scrolling below the first screenful of variables.
+- [ ] **V-2** The modified-vs-default badge (FR-033) is visible
+      without hover; variables absent from the defaults map render
+      without either badge.
+- [ ] **V-3** Entries sorted alphabetically; duplicates deduped
+      with a Diagnostic recorded (FR-012).
+- [ ] **V-4** Multi-snapshot: one readable `<details>` block per
+      snapshot, each with its own table (FR-018).
+- [ ] **V-5** Client-side filter toggles `hidden` on `<tr>` rows
+      whose `data-variable-name` doesn't substring-match (FR-013);
+      filter is bypassable by clearing the input.
+- [ ] **V-6** No variable row spills beyond its container at any
+      screen width ≥ 800 px.
+
+## 5. Database Usage section
+
+- [ ] **DB-1** InnoDB scalars (FR-014): four subviews — semaphores,
+      pending I/O, AHI activity, HLL — laid out side-by-side when
+      multiple snapshots exist; visual form matches the shape of
+      the data.
+- [ ] **DB-2** Counter-deltas chart (FR-015): keyboard-accessible
+      toggle UI surfaces all variables; category chooser (FR-034)
+      lists every declared category from
+      `render/assets/mysqladmin-categories.json` in declared order.
+- [ ] **DB-3** Counter-deltas chart respects `defaultVisible`
+      (FR-035): column 0 (initial tally) is NOT in the default
+      series; viewer may opt in via the toggle.
+- [ ] **DB-4** Thread-states stacked chart (FR-017): legend listing
+      every state does not obscure the plot; "Other" bucket present
+      when unknown states exist.
+- [ ] **DB-5** Multi-snapshot boundary markers visible on the
+      counter-deltas and thread-states time-series (FR-018 /
+      FR-030, T054).
+- [ ] **DB-6** No DB-Usage widget re-plots OS-Usage data (FR-038).
+
+## 6. Parser Diagnostics panel
+
+- [ ] **PD-1** Collapsed by default (FR-032, Principle XI).
+- [ ] **PD-2** Each diagnostic row: file basename, location (line
+      or byte), severity (Warning or Error), single-line message.
+- [ ] **PD-3** `SeverityInfo` diagnostics appear here and only here
+      (FR-027 / R8 D snapshot-boundary info is the canonical
+      example).
+- [ ] **PD-4** Warnings / Errors are colour-coded AND prefixed with
+      a word (`[warning]` / `[error]`) — not colour-only (G-7).
+- [ ] **PD-5** No diagnostic is duplicated from a subview banner
+      (FR-038).
+
+## 7. Print layout (FR-037)
+
+- [ ] **P-1** `@media print` expands every `<details>`.
+- [ ] **P-2** Sticky nav rail is hidden in print.
+- [ ] **P-3** Layout collapses to a single scrolling column.
+- [ ] **P-4** Verbatim-passthrough banner (FR-026) is visible on
+      the first printed page.
+- [ ] **P-5** Charts render at a legible size and don't split
+      awkwardly across page breaks (use `page-break-inside: avoid`
+      on chart containers).
+- [ ] **P-6** Colour palette degrades acceptably under greyscale
+      printing.
+
+## 8. Robustness across the data envelope (FR-040)
+
+Run the full audit against each of these fixture classes.
+
+- [ ] **R-0** Zero-sample collection: every subview shows its FR-007
+      banner; no empty `<canvas>`, no bare header.
+- [ ] **R-1** One-sample collection: every subview renders a scalar
+      callout or single-row table; never an empty plot area.
+- [ ] **R-2** Typical collection (~10²–10³ samples): reference run
+      against `testdata/example2/` passes all § 0–7 items.
+- [ ] **R-M** Maximum collection (approaching 1 GB / 200 MB per
+      FR-025): axis labels not clipped; legend not overlapping plot;
+      no subview overflows its container.
+- [ ] **R-MS** Multi-snapshot collection (`testdata/example2/` has
+      two): snapshot-scoped subviews show one block per snapshot;
+      time-series subviews show vertical boundary markers.
+- [ ] **R-PC** Partial collector (file truncated mid-sample): the
+      subview renders whatever parsed samples are available, shows
+      a "partial data" sub-banner, and records a Warning diagnostic
+      (FR-008).
+- [ ] **R-UV** Unsupported pt-stalk version (format signature
+      matches neither V1 nor V2): subview shows "unsupported
+      pt-stalk version" banner naming the file; no abort (FR-024).
+
+## 9. No-duplication invariant (FR-038)
+
+- [ ] **D-1** Each of the seven canonical data surfaces (iostat,
+      top, vmstat, variables, innodbstatus, mysqladmin, processlist)
+      has exactly one home view. Spot-check: grep the rendered HTML
+      for key values (e.g., a distinctive variable name, a specific
+      PID) and confirm each appears in only one subview outside of
+      the Parser Diagnostics panel.
+- [ ] **D-2** Any summary or overview widget (if present in a future
+      feature) sources from a canonical subview via anchor link; it
+      does NOT re-plot or re-tabulate the underlying data.
+- [ ] **D-3** Cross-references between sections are navigation aids
+      only (anchor links, `<a href="#sec-...">`), never duplicated
+      data displays.
+
+---
+
+## Audit record template
+
+File path: `specs/001-ptstalk-report-mvp/ux-audits/<YYYY-MM-DD>-<label>.md`
+
+```markdown
+# UX Audit — <label> — <YYYY-MM-DD>
+
+**Auditor**: <name>
+**Reviewed commit**: `<short-sha>`
+**Reference fixtures**: testdata/example2/, <synthetic-1-sample>, …
+**Browsers**: Chromium <v>, Firefox <v>, Safari <v>
+**Viewports**: 1440×900, 1920×1080, 375×667
+
+## Results
+
+| ID | Status | Notes |
+|---|---|---|
+| G-1 | PASS | — |
+| G-2 | PASS | — |
+| …   | …    | … |
+| OS-3 | DEFERRED → T??? | vmstat legend overlaps at 1280 px |
+| …   | …    | … |
+
+## Deferred items
+
+| ID | Follow-up task | Owner | Target |
+|---|---|---|---|
+| OS-3 | T??? | @matias-sanchez | next cut |
+
+## Summary
+
+<one paragraph: what's shippable, what's not, any thematic observations>
+```
+
+---
+
+## Changelog
+
+- 2026-04-22 — Initial version (feature 001 MVP baseline).

--- a/specs/001-ptstalk-report-mvp/checklists/ux-quality.md
+++ b/specs/001-ptstalk-report-mvp/checklists/ux-quality.md
@@ -32,21 +32,36 @@ approval recorded in the same audit file.
 
 Applies to every rendered surface, independent of section.
 
-- [ ] **G-1** Typography scale is a single harmonic progression (no
-      arbitrary font sizes). Every `h2` shares one size; every `h3`
-      shares one size; body text is one size; captions are one size.
-- [ ] **G-2** Spacing rhythm is a single base grid (`4px` or `8px`).
-      No section introduces ad-hoc margin/padding values outside the
-      grid.
+- [ ] **G-1** Every font size on every rendered surface MUST be
+      expressed via one of the four named CSS custom properties
+      `var(--font-h2)`, `var(--font-h3)`, `var(--font-body)`, or
+      `var(--font-caption)`. No literal `font-size:` declaration
+      appears in `render/assets/app.css` outside the `:root`-level
+      custom property definitions. Auditable by grep against the
+      shipped stylesheet; reviewer taste is not in scope.
+- [ ] **G-2** Spacing rhythm is pinned to a single `8px` base grid
+      exposed as `var(--grid)` on `:root`. Every margin, padding,
+      and gap value in `render/assets/app.css` MUST be either
+      `0`, `var(--grid)`, or `calc(var(--grid) * N)` for an integer
+      `N`. Grep confirms no literal non-zero `px` spacing values
+      outside the `:root` declaration of `--grid`.
 - [ ] **G-3** Colour palette: one primary accent, one muted-text
       tone, one warning tone, one success tone. Charts use the same
       named palette across all sections.
 - [ ] **G-4** All chart axes format numbers via the shared
       `formatYTick` helper (compact: `1.2K` / `3.4M` / `1.2B`). No
       axis falls back to raw `toLocaleString()`.
-- [ ] **G-5** All timestamps render UTC ISO-8601 via the shared
-      formatter (Principle IV). No section prints locale-dependent
-      or raw-epoch time.
+- [ ] **G-5** Every rendered timestamp — including server-rendered
+      header / banner / table text, chart tooltips and other
+      JavaScript-rendered timestamp labels, and timestamp fields
+      in the embedded JSON payload — uses the shared UTC ISO-8601
+      formatter (Principle IV). No rendered surface or payload
+      field uses locale-dependent (`toLocaleDateString`,
+      `toLocaleString`) or raw-epoch time. A grep of `app.js` for
+      `toLocaleDate`, `toLocaleString`, or `toLocaleTime` returns
+      no hits in rendering paths (note: `toLocaleString()` on
+      non-timestamp numeric values — e.g., integer formatting — is
+      still permitted and is governed by G-4, not G-5).
 - [ ] **G-6** Every interactive element (button, dropdown, chip,
       checkbox, search input) is reachable and operable by keyboard
       alone (FR-031, FR-036).
@@ -137,9 +152,13 @@ Applies to every rendered surface, independent of section.
       multiple snapshots exist; visual form matches the shape of
       the data.
 - [ ] **DB-2** Counter-deltas chart (FR-015): keyboard-accessible
-      toggle UI surfaces all variables; category chooser (FR-034)
-      lists every declared category from
-      `render/assets/mysqladmin-categories.json` in declared order.
+      toggle UI surfaces every variable present in the embedded
+      `report-data` JSON payload (reviewer reads the payload's
+      `variables` array and confirms every entry is reachable from
+      the UI). Category chooser (FR-034) lists every category
+      present in the payload's `categories` array, in array order.
+      Reviewer reads both from the rendered HTML alone — no source
+      file lookup required.
 - [ ] **DB-3** Counter-deltas chart respects `defaultVisible`
       (FR-035): column 0 (initial tally) is NOT in the default
       series; viewer may opt in via the toggle.
@@ -154,11 +173,15 @@ Applies to every rendered surface, independent of section.
 ## 6. Parser Diagnostics panel
 
 - [ ] **PD-1** Collapsed by default (FR-032, Principle XI).
-- [ ] **PD-2** Each diagnostic row: file basename, location (line
-      or byte), severity (Warning or Error), single-line message.
+- [ ] **PD-2** Each diagnostic row carries: file basename,
+      location (line or byte when known, otherwise `—`), severity
+      (one of `Info` / `Warning` / `Error`), and a single-line
+      message.
 - [ ] **PD-3** `SeverityInfo` diagnostics appear here and only here
-      (FR-027 / FR-030; snapshot-boundary info from R8 improvement D
-      is the canonical example).
+      (never on stderr, per FR-027 / FR-030). Snapshot-boundary
+      info from R8 improvement D is the canonical example and MUST
+      appear in this panel for any multi-Snapshot `-mysqladmin`
+      input.
 - [ ] **PD-4** Warnings / Errors are colour-coded AND prefixed with
       a word (`[warning]` / `[error]`) — not colour-only (G-7).
 - [ ] **PD-5** No diagnostic is duplicated from a subview banner

--- a/specs/001-ptstalk-report-mvp/plan.md
+++ b/specs/001-ptstalk-report-mvp/plan.md
@@ -113,7 +113,7 @@ Evaluated against `.specify/memory/constitution.md` v1.0.1.
 | VIII | Reference Fixtures & Golden Tests | ✅ PASS (design) / ⚠ partial (shipped) | Design provides for fixtures under `testdata/example1/` (reserved for the preceding pt-stalk version per FR-024) and `testdata/example2/` drawn from `_references/examples/`. Only `testdata/example2/` is committed in v1; `example1` is tracked by tasks.md T019 and the Reconciliation Summary. Build currently fails if a parser is added without a fixture (enforced by `tests/coverage/testdata_coverage_test.go`); golden outputs under `testdata/golden/` are generated via `go test ./... -update` once per-collector tests land, and full golden-coverage enforcement lands in T080. |
 | IX | Zero Network | ✅ PASS | `net/http`, `net`, and `net/url` (except `url.PathEscape`-style stdlib helpers) are banned in shipped code via a `go vet`-style linter check in CI. |
 | X | Minimal Dependencies | ✅ PASS | Zero direct Go module dependencies. One vendored JavaScript asset, justified in `research.md`. |
-| XI | Human Pressure Optimization | ✅ PASS | Section order in report hardcoded to OS → Variables → DB (spec FR-005); Parser Diagnostics panel is collapsible secondary section. No cluttering metric dumps. |
+| XI | Human Pressure Optimization | ✅ PASS | Section order in report hardcoded to OS → Variables → DB (spec FR-005); Parser Diagnostics panel is collapsible secondary section. No cluttering metric dumps. FR-038–FR-041 concretise this principle as no-duplication, consistent visual hierarchy, robust rendering across the data envelope, and a committed audit gate (SC-011, research R13). |
 | XII | Pinned Go Version | ✅ PASS | `go.mod` pins `go 1.24`; CI matrix uses exactly that version. |
 
 **Pre-design gate: PASS.** No violations requiring Complexity Tracking.
@@ -134,7 +134,10 @@ specs/001-ptstalk-report-mvp/
 │   ├── cli.md              # CLI surface contract
 │   └── packages.md         # parse/model/render public-API contracts
 ├── checklists/
-│   └── requirements.md     # From /speckit.specify
+│   ├── requirements.md     # From /speckit.specify
+│   └── ux-quality.md       # FR-038–FR-041 / SC-011 — structured UX audit
+├── ux-audits/              # Dated audit records (SC-011)
+│   └── <YYYY-MM-DD>-<label>.md
 └── tasks.md                # Phase 2 output (NOT created here)
 ```
 
@@ -289,7 +292,14 @@ Artifacts produced:
    godoc-style contracts.
 4. **`quickstart.md`** — developer setup: clone, Go install, test,
    build, run against `_references/examples/example2`, open the report.
-5. **Agent context update** — `CLAUDE.md` is updated to point to
+5. **`checklists/ux-quality.md`** — structured UX-quality audit
+   checklist (FR-038–FR-041, SC-011, research R13). Section-by-section
+   pass/fail criteria that gate every feature-001 release cut. Audit
+   runs are committed under
+   `specs/001-ptstalk-report-mvp/ux-audits/<YYYY-MM-DD>-<label>.md`.
+6. **`checklists/requirements.md`** — spec quality checklist from the
+   `/speckit-specify` pass (pre-existing).
+7. **Agent context update** — `CLAUDE.md` is updated to point to
    this plan between `<!-- SPECKIT START -->` and `<!-- SPECKIT END -->`
    markers.
 
@@ -310,7 +320,7 @@ Re-evaluated after completing Phase 1 artifacts (see `data-model.md`,
 | VIII | Reference Fixtures & Golden Tests | ✅ PASS (design) / ⚠ partial (shipped) | `testdata/example{1,2}/` structure locked in Project Structure; `testdata/example2/` committed; `testdata/example1/` reserved for the preceding pt-stalk version (tasks.md T019). Golden tests per collector; `testdata_coverage_test.go` guard documented in tasks. Goldens under `testdata/golden/` are generated incrementally as per-collector tests land (tasks.md T043–T070). |
 | IX | Zero Network | ✅ PASS | CI linter will reject any import of `net/http`, `net/rpc`, etc. in shipped packages. |
 | X | Minimal Dependencies | ✅ PASS | `go.mod` has zero direct non-stdlib dependencies. The one vendored JS asset is justified in `research.md` with size and license. |
-| XI | Human Pressure Optimization | ✅ PASS | Template order locked; Parser Diagnostics rendered as a collapsible `<details>` section at the bottom, not between primary views. |
+| XI | Human Pressure Optimization | ✅ PASS | Template order locked; Parser Diagnostics rendered as a collapsible `<details>` section at the bottom, not between primary views. FR-038–FR-041 + SC-011 + research R13 layer a structured audit gate on top: every release cut produces a dated checklist record under `specs/001-ptstalk-report-mvp/ux-audits/` enforcing no-duplication, consistent visual hierarchy, and robust rendering across the data envelope. |
 | XII | Pinned Go Version | ✅ PASS | `go 1.24` directive in `go.mod`; CI uses matching version. |
 
 **Post-design gate: PASS.** Ready to emit Phase 2 tasks via

--- a/specs/001-ptstalk-report-mvp/research.md
+++ b/specs/001-ptstalk-report-mvp/research.md
@@ -664,6 +664,75 @@ through the toggle UI. Normative in spec FR-035.
 
 ---
 
+## R13. UX-quality audit via committed checklist + dated audit records
+
+**Decision**: Adopt a **checklist-driven audit gate** rather than
+ad-hoc review to guarantee the report's visual, compositional, and
+robustness quality. The checklist lives at
+`specs/001-ptstalk-report-mvp/checklists/ux-quality.md` and is
+structured section-by-section (Global · Header · Navigation · OS
+Usage · Variables · Database Usage · Parser Diagnostics · Print ·
+Robustness · No-duplication). Each audit run is committed as a
+dated Markdown file under
+`specs/001-ptstalk-report-mvp/ux-audits/` with one row per
+checklist item and PASS / FAIL / DEFERRED marks. Failing items
+block the cut until addressed. The approach is normative in
+spec FR-038–FR-041 and SC-011.
+
+**Rationale**:
+
+- **Reviewable over opinionated**: a written checklist externalises
+  the quality bar so every contributor sees the same criteria
+  and no single reviewer's taste drives acceptance.
+- **Constitution alignment**: Principle XI ("Reports Optimized for
+  Humans Under Pressure") is abstract; the checklist is the
+  operational concretisation. Every checklist item maps back to a
+  principle or an FR, so the audit does not invent fresh policy.
+- **No new runtime dependencies**: the audit is plain Markdown —
+  no visual-regression framework, no headless browser CI job, no
+  screenshot-diff harness. It is human review, but **structured**
+  human review. If richer automation is needed later (pixel-diff
+  goldens, axe-core a11y CI), it lands as a dedicated follow-up
+  research entry; v1 remains stdlib-only.
+- **Observable drift**: committed audit files serve as a time
+  series. Anyone can `git log specs/001-ptstalk-report-mvp/ux-audits/`
+  to see how the quality bar moved.
+- **Graceful triage**: the DEFERRED state lets an audit proceed
+  even when a fix is non-trivial, as long as a follow-up task
+  owns it. Unacknowledged failures never merge.
+
+**Alternatives considered**:
+
+- **Screenshot / pixel diffing as CI gate** — rejected for v1.
+  Requires a headless-browser runtime in CI (violates Principle X
+  minimalism without a justification entry), is flaky under chart
+  anti-aliasing differences across CI runners, and masks genuine
+  layout issues behind "same pixels" acceptance.
+- **No formal audit, rely on code review** — rejected because the
+  user explicitly called out that the current bar is too low and
+  needs an explicit, recurring gate rather than case-by-case
+  reviewer judgement.
+- **One-off audit recorded in the PR description only** — rejected
+  because PR descriptions are not grep-able history; committed
+  audit files are.
+- **Single monolithic audit item ("the report looks good")** —
+  rejected as unactionable. Each section-by-section checklist item
+  is independently testable and independently fixable.
+
+**Implementation notes**:
+
+- The v1 checklist is scoped to the current report surface; when
+  a future feature adds a new section or subview, adding the
+  corresponding checklist rows is part of that feature's scope
+  (same pattern as the fixture-coverage guard for parsers).
+- The audit gate is complementary to — not a replacement for —
+  Constitution Principle XI's general mandate, `go test ./...`,
+  the determinism CI job, and per-collector golden tests. It
+  catches a different class of failure (composition / robustness
+  / duplication) that unit tests cannot express.
+
+---
+
 ## Summary of decisions
 
 | ID | Decision |
@@ -680,5 +749,6 @@ through the toggle UI. Normative in spec FR-035.
 | R10 | Embed hand-curated MySQL 8.0 defaults asset for modified-vs-default badging in the Variables section. |
 | R11 | Embed hand-curated mysqladmin category taxonomy for one-click "load this class of counters" workflows. |
 | R12 | Renderer drops column 0 (raw initial tally) from the default counter-deltas chart view; model preserves it. |
+| R13 | UX-quality audit via committed checklist + dated audit records; no screenshot-diff CI; human review made structured. |
 
 All Phase 0 items resolved. Phase 1 artifacts proceed below.

--- a/specs/001-ptstalk-report-mvp/spec.md
+++ b/specs/001-ptstalk-report-mvp/spec.md
@@ -630,11 +630,14 @@ matching their respective golden files.
   marked PASS — or carries an explicit DEFERRED status with a
   follow-up task ID. Freshness is enforced by a **diff-based
   invariant** (not by commit timestamps, which are unreliable
-  under rebase / cherry-pick): any PR or commit range that
-  changes a report-shaping code path — `render/`, `render/assets/`,
-  `model/`, or `parse/` — MUST also add or modify at least one
-  file under `specs/001-ptstalk-report-mvp/ux-audits/`. A missing
-  audit update blocks the cut. A `testdata_coverage`-style guard
+  under rebase / cherry-pick): any PR or commit range that changes
+  a **report-shaping runtime file** — i.e. a non-test `.go` file
+  under `render/`, `model/`, or `parse/`, or any file under
+  `render/assets/` — MUST also add or modify at least one file
+  under `specs/001-ptstalk-report-mvp/ux-audits/`. Test files
+  (`*_test.go`) and other non-runtime artifacts are explicitly
+  **excluded** from the gate because they cannot change the
+  rendered output. A missing audit update blocks the cut. A `testdata_coverage`-style guard
   (`tests/coverage/ux_audit_freshness_test.go` or equivalent,
   T119) implements the check against the PR's diff; wiring it as
   a regular Go test avoids introducing a new CI lane.

--- a/specs/001-ptstalk-report-mvp/spec.md
+++ b/specs/001-ptstalk-report-mvp/spec.md
@@ -466,21 +466,28 @@ matching their respective golden files.
   attach a PDF to a customer ticket without losing any collapsed
   content.
 
-- **FR-038**: The report MUST NOT present the same factual
-  observation in more than one place unless the duplication is an
-  explicit, labelled navigation aid (e.g., a ToC link that repeats
-  a section title). Every primary data surface — chart, table,
-  scalar callout, diagnostic list — has a single canonical home:
-  `-iostat` samples in OS-Usage → Disk utilization; `-top` samples
-  in OS-Usage → Top CPU processes; `-vmstat` samples in OS-Usage →
-  vmstat saturation; `-variables` global values in Variables;
-  `-innodbstatus1` scalars in Database Usage → InnoDB status;
-  `-mysqladmin` deltas in Database Usage → Counter deltas;
-  `-processlist` thread-state samples in Database Usage → Thread
-  states; parser diagnostics in the Parser Diagnostics panel. Any
-  summary or overview widget introduced in a future feature MUST
-  source from and link to its canonical subview rather than
-  re-plot or re-tabulate the underlying data.
+- **FR-038**: The report MUST NOT render the same underlying
+  factual observation on more than one canonical data surface.
+  For the purposes of this rule, a **canonical data surface** is
+  one of: a chart, a data table, a scalar callout, or the Parser
+  Diagnostics list — i.e., any element that visualises sample
+  values, variable values, or diagnostic records. Repetition used
+  purely for **navigation or labelling** — section titles, ToC
+  and nav-rail entries, chart legends, axis labels, anchor
+  links, and tooltips that identify a series or variable without
+  re-rendering its values — does NOT count as duplication and is
+  explicitly permitted. The canonical data surfaces in v1 and
+  their homes are: `-iostat` samples → OS-Usage → Disk
+  utilization; `-top` samples → OS-Usage → Top CPU processes;
+  `-vmstat` samples → OS-Usage → vmstat saturation; `-variables`
+  global values → Variables; `-innodbstatus1` scalars → Database
+  Usage → InnoDB status; `-mysqladmin` deltas → Database Usage →
+  Counter deltas; `-processlist` thread-state samples → Database
+  Usage → Thread states; and every `Diagnostic` record → the
+  Parser Diagnostics panel. Any summary or overview widget
+  introduced by a future feature MUST source from and link to
+  its canonical subview rather than re-plot or re-tabulate the
+  underlying data.
 
 - **FR-039**: Every rendered section MUST follow a consistent
   three-level visual hierarchy: `h2` section title → `h3` subview
@@ -621,10 +628,16 @@ matching their respective golden files.
   `specs/001-ptstalk-report-mvp/ux-audits/<YYYY-MM-DD>-<label>.md`
   whose every checklist item from `checklists/ux-quality.md` is
   marked PASS — or carries an explicit DEFERRED status with a
-  follow-up task ID. A CI check (or the `testdata_coverage` style
-  guard, at implementer's discretion) asserts that the latest
-  audit file is newer than the most recent commit that touches
-  `render/` or `render/assets/`; a stale audit blocks the cut.
+  follow-up task ID. Freshness is enforced by a **diff-based
+  invariant** (not by commit timestamps, which are unreliable
+  under rebase / cherry-pick): any PR or commit range that
+  changes a report-shaping code path — `render/`, `render/assets/`,
+  `model/`, or `parse/` — MUST also add or modify at least one
+  file under `specs/001-ptstalk-report-mvp/ux-audits/`. A missing
+  audit update blocks the cut. A `testdata_coverage`-style guard
+  (`tests/coverage/ux_audit_freshness_test.go` or equivalent,
+  T119) implements the check against the PR's diff; wiring it as
+  a regular Go test avoids introducing a new CI lane.
 
 ## Assumptions
 

--- a/specs/001-ptstalk-report-mvp/spec.md
+++ b/specs/001-ptstalk-report-mvp/spec.md
@@ -16,6 +16,10 @@
 - Q: Does the MVP emit any machine-readable side-car output (JSON, CSV) alongside the HTML? → A: No. HTML is the only CLI output in this feature; no `--json`, no side-car files. The `model/` package remains importable (required by Principle VI) but is not advertised, stabilised, or documented for third-party consumers in v1.
 - Q: What is the normative algorithm for computing `-mysqladmin` deltas between samples? → A: The algorithm is **ported to native Go** inside `parse/mysqladmin.go`. The C++ reference at `_references/pt-mext/pt-mext-improved.cpp` is retained as the *behavioural specification source*: the worked example in its tail comments (input table lines 146–177 → expected output lines 181–189) is committed verbatim as a test fixture and golden file under `testdata/pt-mext/`. The Go implementation MUST reproduce that expected output for counter variables. Non-counter variables (e.g., `Threads_running`, `Uptime`) are classified as gauges and stored as raw values, not deltas — this is a deliberate improvement over the C++ reference, which treats everything as a counter.
 
+### Session 2026-04-22
+
+- Q: What is the acceptable baseline for the report's visual and compositional quality? → A: The baseline is set by **Constitution Principle XI** ("Reports Optimized for Humans Under Pressure") and enforced concretely by FR-038–FR-041: no accidental duplication of facts across sections, a consistent three-level visual hierarchy expressed via shared CSS custom properties, robust rendering across the full valid-data envelope (0 / 1 / typical / maximum samples), and a structured audit gate whose criteria live under `specs/001-ptstalk-report-mvp/checklists/ux-quality.md`. Any perceived "visual break" between sections, any duplicated data surface, any subview that renders an empty `<canvas>` or overflows its container under a legal input, is a spec-level failure — not a matter of taste. The audit is run before every release cut (SC-011).
+
 ## User Scenarios & Testing *(mandatory)*
 
 ### User Story 1 - First-look triage report from a pt-stalk collection (Priority: P1)
@@ -462,6 +466,69 @@ matching their respective golden files.
   attach a PDF to a customer ticket without losing any collapsed
   content.
 
+- **FR-038**: The report MUST NOT present the same factual
+  observation in more than one place unless the duplication is an
+  explicit, labelled navigation aid (e.g., a ToC link that repeats
+  a section title). Every primary data surface — chart, table,
+  scalar callout, diagnostic list — has a single canonical home:
+  `-iostat` samples in OS-Usage → Disk utilization; `-top` samples
+  in OS-Usage → Top CPU processes; `-vmstat` samples in OS-Usage →
+  vmstat saturation; `-variables` global values in Variables;
+  `-innodbstatus1` scalars in Database Usage → InnoDB status;
+  `-mysqladmin` deltas in Database Usage → Counter deltas;
+  `-processlist` thread-state samples in Database Usage → Thread
+  states; parser diagnostics in the Parser Diagnostics panel. Any
+  summary or overview widget introduced in a future feature MUST
+  source from and link to its canonical subview rather than
+  re-plot or re-tabulate the underlying data.
+
+- **FR-039**: Every rendered section MUST follow a consistent
+  three-level visual hierarchy: `h2` section title → `h3` subview
+  title → content. Typography scale, spacing rhythm, axis and
+  legend formatting, colour accents (one primary accent, one
+  muted-text tone, one warning tone), and chart palette MUST be
+  identical across sections so that a viewer scrolling from OS
+  Usage to Database Usage does NOT perceive a stylistic break.
+  These invariants MUST be expressed as named CSS custom
+  properties on a single shared stylesheet (`render/assets/app.css`)
+  so that changes propagate globally; per-section `<style>` blocks
+  are prohibited.
+
+- **FR-040**: Every subview MUST render acceptably for every legal
+  point in the data envelope permitted by FR-025:
+  * **0 samples** (file present but empty or fully unparseable) →
+    the FR-007 "data not available" banner is rendered in the
+    subview's content area; no empty `<canvas>`, no bare header.
+  * **1 sample** → a single-value scalar callout (for time-series
+    subviews) or a single-row table (for tabular subviews); never
+    an empty plot area whose axes imply a time range.
+  * **Typical (10²–10³ samples)** → the normal rendering path.
+  * **Maximum (approaching the 1 GB / 200 MB envelope of FR-025)**
+    → the subview still renders without clipping axis labels,
+    collapsing the legend into the plot area, or producing a chart
+    whose plotted series overflow their container.
+  * **Multi-snapshot** (FR-018) → concatenated time series carry
+    the FR-030 vertical boundary marker; snapshot-scoped subviews
+    (Variables, InnoDB status) render one labelled sub-block per
+    snapshot.
+  No subview may ship HTML that visually breaks under any of the
+  above; failures are tracked per FR-041.
+
+- **FR-041**: Before any cut of feature 001 (and of any future
+  feature that changes the report), a structured UX-quality audit
+  MUST walk every section, subview, and shared surface against the
+  committed checklist at
+  `specs/001-ptstalk-report-mvp/checklists/ux-quality.md`. Each
+  checklist item carries a pass / fail criterion; the audit record
+  (a dated Markdown file under
+  `specs/001-ptstalk-report-mvp/ux-audits/`) captures per-item
+  status plus a short rationale or evidence link. Failing items
+  block the cut until fixed, unless the failure is deferred to a
+  tracked follow-up feature with explicit owner approval recorded
+  in the same audit document. The audit gate is complementary to —
+  not a replacement for — the Constitution Check (Principle XI) and
+  the existing test suite.
+
 ### Key Entities
 
 - **Collection**: A pt-stalk output directory. Attributes: root path,
@@ -548,6 +615,16 @@ matching their respective golden files.
   unit test against `render/assets/app.js` asserts the load/save
   round-trip using an in-memory localStorage stub and the
   `Report.ReportID` keying scheme.
+
+- **SC-011**: Every cut of feature 001 ships with a dated UX-quality
+  audit record at
+  `specs/001-ptstalk-report-mvp/ux-audits/<YYYY-MM-DD>-<label>.md`
+  whose every checklist item from `checklists/ux-quality.md` is
+  marked PASS — or carries an explicit DEFERRED status with a
+  follow-up task ID. A CI check (or the `testdata_coverage` style
+  guard, at implementer's discretion) asserts that the latest
+  audit file is newer than the most recent commit that touches
+  `render/` or `render/assets/`; a stale audit blocks the cut.
 
 ## Assumptions
 

--- a/specs/001-ptstalk-report-mvp/tasks.md
+++ b/specs/001-ptstalk-report-mvp/tasks.md
@@ -279,7 +279,12 @@ written.
 ### Synthesis + gate
 
 - [ ] T118 Commit the full audit record at `specs/001-ptstalk-report-mvp/ux-audits/<YYYY-MM-DD>-<label>.md` using the template at the bottom of `checklists/ux-quality.md`. Every checklist item is PASS or carries an explicit DEFERRED → T### link with owner approval recorded in the same file.
-- [ ] T119 CI gate for SC-011: implement a **diff-based** freshness check (not timestamp-based — commit times are unreliable under rebase / cherry-pick). Concretely: a `tests/coverage/ux_audit_freshness_test.go::TestUXAuditFreshness` test that, given the merge-base against `origin/main`, asserts that any change in the PR's diff under `render/`, `render/assets/`, `model/`, or `parse/` is accompanied by at least one change under `specs/001-ptstalk-report-mvp/ux-audits/`. Implementation runs `git diff --name-only $(git merge-base HEAD origin/main)..HEAD` — or the equivalent env-provided PR-base in CI — and enforces the invariant. No new CI lane; the guard lives inside the regular `go test ./...` pass.
+- [ ] T119 CI gate for SC-011: implement a **diff-based** freshness check (not timestamp-based — commit times are unreliable under rebase / cherry-pick). Concretely: a `tests/coverage/ux_audit_freshness_test.go::TestUXAuditFreshness` test that resolves a base commit in the following priority order and fails only when the base is resolvable AND the diff violates the invariant:
+      1. `GITHUB_BASE_REF` env var (GitHub Actions sets this on PR builds to the target branch name — `main` in practice). The test runs `git rev-parse "origin/${GITHUB_BASE_REF}"` to get the base SHA.
+      2. `MYGATHER_UX_AUDIT_BASE` env var (developer-overridable for local runs).
+      3. `git merge-base HEAD origin/main` as a best-effort fallback.
+      If none of the above resolves to a valid commit (fork CI without the remote, a shallow clone missing the base, a local clone detached from any remote), the test **SKIPs with a logged reason** rather than failing — the gate is for PR / release contexts, not for every dev invocation.
+      When the base IS resolved, the test runs `git diff --name-only <base>..HEAD` and asserts that any diff under `render/`, `render/assets/`, `model/`, or `parse/` is accompanied by at least one diff under `specs/001-ptstalk-report-mvp/ux-audits/`. No new CI lane; the guard lives inside the regular `go test ./...` pass.
 
 **Checkpoint**: a clean Phase 8 pass means the report ships at a quality bar that any senior reviewer who just read the constitution and the checklist can independently confirm — not a matter of reviewer taste.
 

--- a/specs/001-ptstalk-report-mvp/tasks.md
+++ b/specs/001-ptstalk-report-mvp/tasks.md
@@ -247,6 +247,44 @@ written.
 
 ---
 
+## Phase 8: UX Quality Audit (Priority: Release Gate) 🔒
+
+**Purpose**: Concretise Constitution Principle XI and the new FR-038–FR-041 / SC-011 via a structured, committed audit pass against `specs/001-ptstalk-report-mvp/checklists/ux-quality.md`. Phase 8 is a **release-cut gate**: a passing audit record (or explicit DEFERRED entries with owner approval) is the precondition for merging any feature-001 cut to `main`. Each section task below produces one reviewable deliverable; the pieces compose into a full audit record under `specs/001-ptstalk-report-mvp/ux-audits/<YYYY-MM-DD>-<label>.md`.
+
+**Independent Test**: After completing the audit, a reviewer can open the audit record and, from that document alone, reproduce every PASS / FAIL / DEFERRED decision against the same rendered report without consulting Slack, PR comments, or the auditor's memory.
+
+### Prerequisites for Phase 8
+
+- [x] T107 Commit the UX-quality audit checklist at `specs/001-ptstalk-report-mvp/checklists/ux-quality.md` (this branch). Normative reference for FR-038–FR-041 / SC-011 / research R13.
+
+### Shared stylesheet invariants (FR-039)
+
+- [ ] T108 Refactor `render/assets/app.css` to express the typography scale, spacing grid, colour palette, chart palette, and axis/legend rules as named CSS custom properties (`--fg`, `--accent`, `--muted`, `--warn`, `--ok`, `--grid`, `--font-h2`, `--font-h3`, `--font-body`, `--chart-series-1…N`). No per-template `<style>` blocks survive the refactor (FR-039). Covered by G-8 in the checklist.
+- [ ] T109 [P] `render/render_test.go::TestNoPerTemplateStyleBlocks` (FR-039 coverage): parse the rendered HTML; assert the document contains exactly one top-level `<style>` block sourced from `render/assets/app.css` via `//go:embed`, and that every `<section>` / `<details>` it contains is free of inline `<style>` children.
+
+### Section audits (one audit item per subview; produces the per-section PASS/FAIL table for the audit record)
+
+- [ ] T110 OS Usage audit: walk § 3 of `checklists/ux-quality.md` (OS-1 through OS-7) against `testdata/example2/`. Produce a short Markdown fragment (`ux-audits/_pending-os.md` or inline in the audit PR) with per-item status. Fix any FAIL items inline or open a remediation task (TXXX with clear scope).
+- [ ] T111 Variables audit: walk § 4 (V-1 through V-6) against `testdata/example2/`; same deliverable shape.
+- [ ] T112 Database Usage audit: walk § 5 (DB-1 through DB-6) against `testdata/example2/`; same deliverable shape.
+- [ ] T113 [P] Navigation + Header + Banners audit: walk § 1 (H-1..H-5) + § 2 (N-1..N-6).
+- [ ] T114 [P] Parser Diagnostics audit: walk § 6 (PD-1..PD-5). Requires a fixture with at least one Warning and one Info diagnostic (e.g., a truncated source file + a multi-snapshot mysqladmin).
+- [ ] T115 [P] Print layout audit: walk § 7 (P-1..P-6). Uses the browser's print-preview; greyscale pass included.
+
+### Cross-cutting audits (the harder ones; run after § 3–7 are PASS)
+
+- [ ] T116 Robustness audit (§ 8, FR-040): build synthetic 0-sample, 1-sample, and "near the 1 GB envelope" fixtures and rerun the full checklist against each. Captures R-0, R-1, R-2, R-M, R-MS, R-PC, R-UV. Produces a sub-table of the audit record.
+- [ ] T117 No-duplication audit (§ 9, FR-038): grep-based spot-check plus a manual walk. For every canonical data surface, grep the rendered HTML for a distinctive value (a specific PID, a variable name, a counter name) and assert it appears in exactly one subview outside of the Parser Diagnostics panel. Produces D-1 / D-2 / D-3 rows of the audit record.
+
+### Synthesis + gate
+
+- [ ] T118 Commit the full audit record at `specs/001-ptstalk-report-mvp/ux-audits/<YYYY-MM-DD>-<label>.md` using the template at the bottom of `checklists/ux-quality.md`. Every checklist item is PASS or carries an explicit DEFERRED → T### link with owner approval recorded in the same file.
+- [ ] T119 CI gate for SC-011: add a lightweight check (at implementer's discretion — Go test or Makefile target) that asserts the newest file under `specs/001-ptstalk-report-mvp/ux-audits/` is newer than the most recent commit that touches `render/` or `render/assets/`. A stale audit blocks the cut. Covered by the SC-011 clause; wiring can live in `tests/coverage/` as a `TestUXAuditFreshness` test to avoid introducing a new CI lane.
+
+**Checkpoint**: a clean Phase 8 pass means the report ships at a quality bar that any senior reviewer who just read the constitution and the checklist can independently confirm — not a matter of reviewer taste.
+
+---
+
 ## Dependencies & Execution Order
 
 ### Phase Dependencies
@@ -256,6 +294,7 @@ written.
 - **US1 (Phase 3)** — depends on Phase 2; is the MVP; no cross-story dependency.
 - **US2 / US3 / US4 (Phases 4–6)** — each depends on Phase 2 and on US1's render skeleton (`Render`, template tree, asset loading). Can be developed in parallel by different contributors after US1 lands.
 - **Polish (Phase 7)** — depends on every user story that is targeted for the release.
+- **UX Quality Audit (Phase 8)** — depends on Phase 7 being substantively complete and on the UX checklist (T107) being committed. Phase 8 is a **release gate**: a clean or fully-DEFERRED audit record is the precondition for merging any feature-001 cut. Running Phase 8 mid-development (e.g., after US2 lands) is encouraged as a diagnostic, not a replacement for the release-cut audit.
 
 ### Within Each User Story
 
@@ -312,10 +351,11 @@ Task: "Write render/nav_test.go::TestNavCoverage"
 2. + US3 (7 tasks, T056–T062) → Variables section live.
 3. + US4 (15 tasks, T063–T077) → Database Usage section live.
 4. + Polish (29 tasks, T078–T106) → performance guarantees, a11y, docs, coverage gaps from analyze pass 3 (F27–F32, F36) plus the FR-033–FR-037 impl/test pairs added in the 2026-04-22 reconciliation (T097–T106).
+5. + UX Quality Audit (13 tasks, T107–T119) → release-gate audit pass covering FR-038–FR-041 / SC-011 / research R13. Produces a committed, structured audit record that blocks release cuts on any un-DEFERRED FAIL.
 
 ### Solo-developer strategy (current context)
 
-Serial execution by user-story priority: T001 → T106 (106 tasks total). Treat each `[P]`-marked group as "tasks you can draft in one sitting" rather than tasks to run in separate worktrees.
+Serial execution by user-story priority: T001 → T119 (119 tasks total). Treat each `[P]`-marked group as "tasks you can draft in one sitting" rather than tasks to run in separate worktrees.
 
 ---
 
@@ -333,7 +373,7 @@ Serial execution by user-story priority: T001 → T106 (106 tasks total). Treat 
 
 ## Reconciliation Summary (last updated 2026-04-22)
 
-A mechanical pass compared every task ID against the real repository state for the full current range, **T001–T106 (106 tasks total)**. `62 / 106 tasks (≈58 %) carry an [x] mark`. The pipeline builds, `go test ./...` is green, and the binary produces a deterministic three-section report against `testdata/example2/`. The 2026-04-22 spec-drift reconciliation added five new shipping features captured as FR-033–FR-037 (MySQL-defaults badging, mysqladmin category chooser, default-hidden initial-tally column, `Cmd/Ctrl+\` nav shortcut, `@media print` stylesheet); their implementation tasks (T097, T099, T101, T103, T105) are already live in `render/assets/` and `render/render.go` and carry `[x]` marks, while their paired tests (T098, T100, T102, T104, T106) are tracked `[ ]`. What remains across the whole feature is almost entirely **missing tests** plus a handful of documentation and coverage gaps — no core implementation is unshipped.
+A mechanical pass compared every task ID against the real repository state for the full current range, **T001–T119 (119 tasks total)**. `63 / 119 tasks (≈53 %) carry an [x] mark`. The pipeline builds, `go test ./...` is green, and the binary produces a deterministic three-section report against `testdata/example2/`. The 2026-04-22 spec-drift reconciliation added five shipping features captured as FR-033–FR-037 (MySQL-defaults badging, mysqladmin category chooser, default-hidden initial-tally column, `Cmd/Ctrl+\` nav shortcut, `@media print` stylesheet); their implementation tasks (T097, T099, T101, T103, T105) are already live in `render/assets/` and `render/render.go` and carry `[x]` marks, while their paired tests (T098, T100, T102, T104, T106) are tracked `[ ]`. The 2026-04-22 UX-quality reconciliation added FR-038–FR-041 + SC-011 (research R13) with a committed audit checklist (T107 `[x]`) and Phase 8 release-gate tasks T108–T119 `[ ]`, including a shared-stylesheet refactor (T108) that extracts typography / spacing / palette / chart invariants into named CSS custom properties. What remains across the whole feature is almost entirely **missing tests**, **the UX audit pass itself**, plus a handful of documentation and coverage gaps — no core implementation is unshipped.
 
 ### What's done
 

--- a/specs/001-ptstalk-report-mvp/tasks.md
+++ b/specs/001-ptstalk-report-mvp/tasks.md
@@ -260,7 +260,7 @@ written.
 ### Shared stylesheet invariants (FR-039)
 
 - [ ] T108 Refactor `render/assets/app.css` to express the typography scale, spacing grid, colour palette, chart palette, and axis/legend rules as named CSS custom properties (`--fg`, `--accent`, `--muted`, `--warn`, `--ok`, `--grid`, `--font-h2`, `--font-h3`, `--font-body`, `--chart-series-1…N`). No per-template `<style>` blocks survive the refactor (FR-039). Covered by G-8 in the checklist.
-- [ ] T109 [P] `render/render_test.go::TestNoPerTemplateStyleBlocks` (FR-039 coverage): parse the rendered HTML; assert the document contains exactly one top-level `<style>` block sourced from `render/assets/app.css` via `//go:embed`, and that every `<section>` / `<details>` it contains is free of inline `<style>` children.
+- [ ] T109 [P] `render/render_test.go::TestNoPerTemplateStyleBlocks` (FR-039 coverage): parse the rendered HTML; assert the document contains exactly one top-level `<style>` block (the existing `render.go` concatenation of `embeddedChartCSS + embeddedAppCSS` is acceptable), that the block contains the named CSS custom-property invariants introduced by T108 (`--fg`, `--accent`, `--muted`, `--warn`, `--ok`, `--grid`, `--font-h2`, `--font-h3`, `--font-body`, `--font-caption`), and that every `<section>` / `<details>` in the document is free of inline `<style>` children. The test does NOT prescribe the block's origin — only the invariant set it carries and the per-template absence.
 
 ### Section audits (one audit item per subview; produces the per-section PASS/FAIL table for the audit record)
 
@@ -279,7 +279,7 @@ written.
 ### Synthesis + gate
 
 - [ ] T118 Commit the full audit record at `specs/001-ptstalk-report-mvp/ux-audits/<YYYY-MM-DD>-<label>.md` using the template at the bottom of `checklists/ux-quality.md`. Every checklist item is PASS or carries an explicit DEFERRED → T### link with owner approval recorded in the same file.
-- [ ] T119 CI gate for SC-011: add a lightweight check (at implementer's discretion — Go test or Makefile target) that asserts the newest file under `specs/001-ptstalk-report-mvp/ux-audits/` is newer than the most recent commit that touches `render/` or `render/assets/`. A stale audit blocks the cut. Covered by the SC-011 clause; wiring can live in `tests/coverage/` as a `TestUXAuditFreshness` test to avoid introducing a new CI lane.
+- [ ] T119 CI gate for SC-011: implement a **diff-based** freshness check (not timestamp-based — commit times are unreliable under rebase / cherry-pick). Concretely: a `tests/coverage/ux_audit_freshness_test.go::TestUXAuditFreshness` test that, given the merge-base against `origin/main`, asserts that any change in the PR's diff under `render/`, `render/assets/`, `model/`, or `parse/` is accompanied by at least one change under `specs/001-ptstalk-report-mvp/ux-audits/`. Implementation runs `git diff --name-only $(git merge-base HEAD origin/main)..HEAD` — or the equivalent env-provided PR-base in CI — and enforces the invariant. No new CI lane; the guard lives inside the regular `go test ./...` pass.
 
 **Checkpoint**: a clean Phase 8 pass means the report ships at a quality bar that any senior reviewer who just read the constitution and the checklist can independently confirm — not a matter of reviewer taste.
 

--- a/specs/001-ptstalk-report-mvp/tasks.md
+++ b/specs/001-ptstalk-report-mvp/tasks.md
@@ -284,7 +284,7 @@ written.
       2. `MYGATHER_UX_AUDIT_BASE` env var (developer-overridable for local runs).
       3. `git merge-base HEAD origin/main` as a best-effort fallback.
       If none of the above resolves to a valid commit (fork CI without the remote, a shallow clone missing the base, a local clone detached from any remote), the test **SKIPs with a logged reason** rather than failing — the gate is for PR / release contexts, not for every dev invocation.
-      When the base IS resolved, the test runs `git diff --name-only <base>..HEAD` and asserts that any diff under `render/`, `render/assets/`, `model/`, or `parse/` is accompanied by at least one diff under `specs/001-ptstalk-report-mvp/ux-audits/`. No new CI lane; the guard lives inside the regular `go test ./...` pass.
+      When the base IS resolved, the test runs `git diff --name-only <base>..HEAD` and filters the diff to **report-shaping runtime files only**: a non-test `.go` file (i.e. NOT matching `*_test.go`) under `render/`, `model/`, or `parse/`, OR any file under `render/assets/`. If any such file changed, at least one file under `specs/001-ptstalk-report-mvp/ux-audits/` MUST also have changed. Test-only edits (`*_test.go`), `testdata/` additions, and `specs/` edits outside `ux-audits/` are explicitly **excluded** — they cannot change the rendered HTML so they don't need to refresh the audit. No new CI lane; the guard lives inside the regular `go test ./...` pass.
 
 **Checkpoint**: a clean Phase 8 pass means the report ships at a quality bar that any senior reviewer who just read the constitution and the checklist can independently confirm — not a matter of reviewer taste.
 


### PR DESCRIPTION
## Summary

Capture a new **release-gate quality bar** for the rendered pt-stalk report as normative spec text. The user flagged that the current output still has overlapping information, inconsistent composition, and subviews that are not robust under edge-case inputs. This PR does NOT touch any runtime code — it commits the requirements, the research decision, the audit checklist, and the task phase that together turn "the report needs to be better" into an explicit, reviewable standard.

Nothing about the binary's behaviour changes with this merge. Every follow-up PR will be measured against the new bar.

## What's new

**Spec (`spec.md`)**
- Clarifications Session 2026-04-22 entry stating that Constitution Principle XI is concretised by the new FRs / SC below — visual breaks, duplicated data surfaces, and empty canvases under legal input are now spec-level failures, not reviewer taste.
- **FR-038** — No accidental duplication. Each of the seven canonical data surfaces has a single home subview; cross-references are navigation aids only.
- **FR-039** — Consistent visual hierarchy. Three levels (`h2` → `h3` → content), one typography scale, one spacing grid, one accent palette, one chart palette. Invariants live as named CSS custom properties on the shared stylesheet; per-template `<style>` blocks are prohibited.
- **FR-040** — Robust rendering across the full data envelope: 0 / 1 / typical / maximum samples, multi-snapshot, partial collector, unsupported version. No empty canvases, no overflows, no clipped axis labels.
- **FR-041** — Audit gate. Every release cut walks the committed checklist and produces a dated audit record under `specs/001-ptstalk-report-mvp/ux-audits/`. FAIL items block; DEFERRED items require owner approval in the same file.
- **SC-011** — Measurable outcome: every cut ships with a non-stale audit record whose items are PASS or explicitly DEFERRED with a follow-up task.

**Research (`research.md`)**
- **R13** — Decision: structured checklist + dated audit records; NO screenshot-diff CI lane (Principle X). Explains alternatives and why committed-markdown audits win over pixel-diff CI for v1.

**Plan (`plan.md`)**
- Phase 1 artifacts list now includes `checklists/ux-quality.md` and the `ux-audits/` folder.
- Constitution Check tables (pre-design + post-design) Principle XI rationale names FR-038..041 and the audit gate as the operational concretisation of "Humans Under Pressure".

**New artifact: `checklists/ux-quality.md`**
- Section-by-section audit items: Global (G-1..G-8), Header/Banners (H-1..H-5), Navigation (N-1..N-6), OS Usage (OS-1..OS-7), Variables (V-1..V-6), Database Usage (DB-1..DB-6), Parser Diagnostics (PD-1..PD-5), Print (P-1..P-6), Robustness (R-0, R-1, R-2, R-M, R-MS, R-PC, R-UV), No-duplication (D-1..D-3).
- "How to run an audit" procedure (fixtures, browsers, viewports) + audit record template.

**Tasks (`tasks.md`)**
- New **Phase 8 — UX Quality Audit (Release Gate)** with T107..T119 (13 tasks).
- T107 `[x]` commits the checklist (done in this branch).
- T108/T109: shared-stylesheet refactor into CSS custom properties + its test.
- T110..T115: per-section audits (OS / Variables / DB / Nav+Header / Diagnostics / Print).
- T116/T117: cross-cutting audits (Robustness across data envelope, No-duplication invariant).
- T118: commits the synthesised audit record.
- T119: CI freshness gate for SC-011 (stale audit blocks the cut).
- Reconciliation Summary refreshed: **63 / 119 tasks `[x]`** (was 62 / 106). Solo-developer strategy updated to `T001 → T119`.

## Concrete plan: how we finish feature 001

This PR is the first of a sequenced series. Each follow-up lives on its own branch so reviews stay tight and the Phase 8 audit has a stable target as it runs.

| # | Branch | Scope | Depends on |
|---|---|---|---|
| 0 | `claude/ux-quality-requirements` (THIS PR) | Specs + checklist + Phase 8 tasks | — |
| 1 | `claude/boundary-markers-T054` | Renderer draws snapshot-boundary markers on time-series charts (FR-018 / FR-030). Closes an already-declared FR whose data is exported but not consumed by `app.js`. | Merge of this PR (so the audit references the final tasks.md). |
| 2 | `claude/shared-stylesheet-T108-T109` | Refactor `render/assets/app.css` into CSS custom properties per FR-039; add `TestNoPerTemplateStyleBlocks`. | Independent of branch #1; can run in parallel with #1. |
| 3 | `claude/parser-goldens-first-wave` | Variables + processlist parsers + goldens (T056, T068) — the two simplest parsers, as pilots for the golden-regeneration workflow. | Independent. |
| 4 | `claude/parser-goldens-second-wave` | iostat + top + vmstat parsers + goldens + iostat partial-recovery (T043–T045, T047). | Sibling of #3. |
| 5 | `claude/parser-goldens-db` | innodbstatus + mysqladmin (full) + processlist goldens (T063, T064, T066, T067). | Siblings of #3/#4. |
| 6 | `claude/render-goldens` | Render goldens per section (T046, T057, T069). | Requires #3–#5 so parser goldens exist. |
| 7 | `claude/cli-integration-tests` | CLI + integration tests (T030–T035, T088, T091–T095). | Independent of #3–#6 but easier after them. |
| 8 | `claude/fr-033-037-tests` | Test pairs for the five shipping features (T098, T100, T102, T104, T106). | Independent. |
| 9 | `claude/ux-audit-sections` | Phase 8 per-section audits (T110–T115). Each audit may spawn small remediation PRs. | Requires #2 (shared stylesheet) + #1 (boundary markers). |
| 10 | `claude/ux-audit-robustness` | Phase 8 robustness (T116) + no-duplication (T117). | Requires #9. |
| 11 | `claude/ux-audit-record` | Synthesise the first audit record (T118) + wire the SC-011 freshness gate (T119). | Requires #10. |
| 12 | `claude/polish-bucket` | Performance + memory + a11y smoke + determinism stress (T078–T082, T086, T089, T090). | Independent; can interleave with #9–#11. |

**Parallel-friendly groupings**: {#1, #2, #3, #4, #5, #7, #8, #12} can all be drafted concurrently. #6 depends on #3–#5. #9–#11 depend on the stylesheet + boundary markers and close the cut.

**Target sequence** (my recommendation): **#1 → #2 → #3 → #4 → #5 → #6 → #7 → #8 → #9 → #10 → #11 → #12**. Each branch is deliberately scoped to be revewable in one sitting; Copilot + Codex get a fresh narrow diff each time.

## Constitution fidelity

- **XI — Humans Under Pressure**: directly concretised. Every new FR traces back to this principle.
- **X — Minimal dependencies**: preserved. No new Go deps, no new runtime deps, no headless-browser CI (deliberately rejected in R13).
- **IV — Deterministic output**: preserved. FR-039 tightens (shared CSS custom properties centralise colour/space invariants) rather than weakens determinism.
- **IX — Zero network**: preserved. Every asset stays `//go:embed`'d; the audit is plain text.
- **VIII — Reference Fixtures & Golden Tests**: Phase 8 deliberately does NOT introduce screenshot goldens (R13); existing parser/render goldens cover structural invariants, the checklist covers composition/robustness that unit tests cannot express.

## Test plan

- [ ] `go test ./...` remains green (no runtime code touched).
- [ ] `grep -c "^- \[x\]" specs/001-ptstalk-report-mvp/tasks.md` reports 63.
- [ ] `grep -c "^- \[ \]" specs/001-ptstalk-report-mvp/tasks.md` reports 56.
- [ ] `rg -c "^- \*\*FR-" specs/001-ptstalk-report-mvp/spec.md` reports 41 (was 37 before this PR).
- [ ] `rg -c "^- \*\*SC-" specs/001-ptstalk-report-mvp/spec.md` reports 11 (was 10).
- [ ] `research.md` summary-of-decisions table lists R1–R13.
- [ ] `specs/001-ptstalk-report-mvp/checklists/ux-quality.md` exists and contains every audit-item ID referenced in Phase 8 tasks.
- [ ] `plan.md` Project Structure tree shows the new `checklists/ux-quality.md` + `ux-audits/` entries.
- [ ] No per-template `<style>` blocks were added anywhere (grep the diff).
- [ ] All new text is in English per `CLAUDE.md`.

## Review guidance (same rules as PR #1)

- Project is in **active development, NOT production**. Do NOT suggest code duplication, fallback mechanisms, defensive validation for impossible cases, or backwards-compatibility shims.
- Every suggestion should **reduce code, sharpen an invariant, or close a real drift**.
- Specific to this PR: if any FR-038..041 wording is ambiguous or untestable, call it out — the whole point is that the audit bar is reproducible by any reviewer.
- Skip style nits on specs that match the rest of the project's tone.

https://claude.ai/code/session_01EzEaXYpKAsnJqyef4wydMP