### PR TITLE
test: guard edge cases on top of #13 (meminfo, innodb semaphores, dedup cycles)

### DIFF
--- a/parse/innodbstatus.go
+++ b/parse/innodbstatus.go
@@ -63,10 +63,13 @@ func parseInnodbStatus(r io.Reader, sourcePath string) (*model.InnodbStatusData,
 		mutex string
 	}
 	siteCounts := map[siteKey]int{}
-	// awaitingMutex holds the pending thread's file/line while we
-	// look for its partner "Mutex ..." line on the next non-blank
-	// row. Only one pending record at a time: pt-stalk always emits
-	// the pair consecutively separated by at most whitespace lines.
+	// pendingFile / pendingLine buffer the current `--Thread ...` line
+	// until its paired `Mutex at ...` partner lands on a subsequent
+	// line. Canonical InnoDB output always emits the pair contiguously
+	// (whitespace lines allowed in between). Anything else — another
+	// thread before the partner, a section switch, or EOF mid-pair —
+	// drops the pending record; the `siteSum != threadWaited`
+	// diagnostic below reports the miss.
 	var pendingFile string
 	var pendingLine int
 	havePending := false
@@ -82,14 +85,8 @@ func parseInnodbStatus(r io.Reader, sourcePath string) (*model.InnodbStatusData,
 			"INSERT BUFFER AND ADAPTIVE HASH INDEX", "LOG",
 			"BUFFER POOL AND MEMORY", "ROW OPERATIONS",
 			"TRANSACTIONS":
-			// LOW #7: flush any pending semaphore record before we
-			// leave its section, otherwise the last thread-line of a
-			// SEMAPHORES block with no "Mutex ..." partner would be
-			// lost when the section switches.
-			if havePending {
-				siteCounts[siteKey{file: pendingFile, line: pendingLine, mutex: ""}]++
-				havePending = false
-			}
+			// Section state does not leak across sections.
+			havePending = false
 			inSection = trimmed
 			anySectionSeen = true
 			continue
@@ -99,12 +96,6 @@ func parseInnodbStatus(r io.Reader, sourcePath string) (*model.InnodbStatusData,
 		case "SEMAPHORES":
 			if m := reInnodbThreadWaited.FindStringSubmatch(trimmed); m != nil {
 				threadWaited++
-				// Flush a previous unmatched pending record with no
-				// mutex name so consecutive thread lines (rare but
-				// possible) don't lose their file:line.
-				if havePending {
-					siteCounts[siteKey{file: pendingFile, line: pendingLine, mutex: ""}]++
-				}
 				pendingFile = m[1]
 				pendingLine, _ = strconv.Atoi(m[2])
 				havePending = true
@@ -116,16 +107,11 @@ func parseInnodbStatus(r io.Reader, sourcePath string) (*model.InnodbStatusData,
 					havePending = false
 					continue
 				}
-				// If we hit a blank line or an unrelated line, the
-				// mutex partner was missing — record with empty
-				// mutex name so the count is still attributed.
 				if trimmed == "" {
 					continue
 				}
-				// Defensive: any non-blank line that wasn't the
-				// partner and isn't another thread flushes the
-				// pending record.
-				siteCounts[siteKey{file: pendingFile, line: pendingLine, mutex: ""}]++
+				// Non-canonical: thread without its paired mutex. Drop
+				// the pending record.
 				havePending = false
 			}
 		case "TRANSACTIONS":
@@ -181,11 +167,6 @@ func parseInnodbStatus(r io.Reader, sourcePath string) (*model.InnodbStatusData,
 		})
 	}
 
-	// Flush any trailing pending record (file reached EOF with no mutex partner).
-	if havePending {
-		siteCounts[siteKey{file: pendingFile, line: pendingLine, mutex: ""}]++
-	}
-
 	data.SemaphoreCount = threadWaited
 
 	// Materialise sites sorted desc by count, stable tie-break by
@@ -207,11 +188,11 @@ func parseInnodbStatus(r io.Reader, sourcePath string) (*model.InnodbStatusData,
 		data.SemaphoreSites = sites
 	}
 
-	// LOW #6: parser-time invariant check. threadWaited counts thread
-	// lines; siteSum counts the resulting (file, line, mutex) entries.
-	// They should always match — a mismatch means a thread was either
-	// recorded twice or swallowed silently, and the reader deserves a
-	// warning so the Semaphores card isn't trusted blindly.
+	// Invariant check: threadWaited counts thread lines; siteSum counts
+	// successfully paired (file, line, mutex) entries. A mismatch means
+	// the SEMAPHORES section was not canonical and the breakdown is
+	// partial — surface that to the reader instead of silently showing
+	// incomplete rows.
 	if siteSum != threadWaited {
 		diagnostics = append(diagnostics, model.Diagnostic{
 			SourceFile: sourcePath,

--- a/parse/innodbstatus_test.go
+++ b/parse/innodbstatus_test.go
@@ -75,87 +75,41 @@ func TestInnoDBStatusGolden(t *testing.T) {
 	goldens.Compare(t, goldenPath, got)
 }
 
-// TestInnoDBSemaphoreSiteSumInvariant asserts that the parser keeps
-// SemaphoreSites wait-count sum in lock-step with SemaphoreCount
-// (thread-waited lines). A violation would silently under- or over-
-// count contention in the report — the parser emits a Warning in
-// that case, so this test guards against both drift and false alarms
-// by exercising the three documented paths: (a) paired thread + mutex,
-// (b) orphan thread at EOF with no partner, (c) two thread lines in a
-// row (defensive flush).
-func TestInnoDBSemaphoreSiteSumInvariant(t *testing.T) {
-	cases := []struct {
-		name       string
-		body       string
-		wantCount  int
-		wantSites  int
-		wantMutex  string
-		wantOrphan bool
-	}{
-		{
-			name: "paired thread and mutex",
-			body: "SEMAPHORES\n" +
-				"--Thread 140148200982272 has waited at ibuf0ibuf.cc line 3922 for 0 seconds the semaphore:\n" +
-				"Mutex at 0x7f0000000000, Mutex IBUF created ibuf0ibuf.cc:612, locked by...\n",
-			wantCount: 1,
-			wantSites: 1,
-			wantMutex: "IBUF",
-		},
-		{
-			name: "orphan thread at EOF",
-			body: "SEMAPHORES\n" +
-				"--Thread 140148200982272 has waited at ibuf0ibuf.cc line 3922 for 0 seconds the semaphore:\n",
-			wantCount:  1,
-			wantSites:  1,
-			wantOrphan: true,
-		},
-		{
-			name: "consecutive thread lines flush defensively",
-			body: "SEMAPHORES\n" +
-				"--Thread 140148200982272 has waited at ibuf0ibuf.cc line 3922 for 0 seconds the semaphore:\n" +
-				"--Thread 140148200982999 has waited at trx0sys.cc line 599 for 0 seconds the semaphore:\n" +
-				"Mutex at 0x7f0000000000, Mutex TRX_SYS created trx0sys.cc:599, locked by...\n",
-			wantCount: 2,
-			wantSites: 2,
-		},
-	}
+// TestInnoDBSemaphoreCanonicalPair exercises the single canonical
+// SEMAPHORES shape — a `--Thread ...` line immediately followed by
+// its paired `Mutex at ... Mutex <NAME> created ...` partner — and
+// asserts that both the thread count and the resulting SemaphoreSites
+// entry are populated, that sum(SemaphoreSites.WaitCount) equals
+// SemaphoreCount, and that no invariant-violation Warning is emitted.
+func TestInnoDBSemaphoreCanonicalPair(t *testing.T) {
+	body := "SEMAPHORES\n" +
+		"--Thread 140148200982272 has waited at ibuf0ibuf.cc line 3922 for 0 seconds the semaphore:\n" +
+		"Mutex at 0x7f0000000000, Mutex IBUF created ibuf0ibuf.cc:612, locked by...\n"
 
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			data, diags := parseInnodbStatus(strings.NewReader(tc.body), "unit-test")
-			if data == nil {
-				t.Fatalf("parseInnodbStatus returned nil data (diags: %+v)", diags)
-			}
-			if data.SemaphoreCount != tc.wantCount {
-				t.Errorf("SemaphoreCount = %d; want %d", data.SemaphoreCount, tc.wantCount)
-			}
-			if got := len(data.SemaphoreSites); got != tc.wantSites {
-				t.Fatalf("len(SemaphoreSites) = %d; want %d", got, tc.wantSites)
-			}
-			sum := 0
-			for _, s := range data.SemaphoreSites {
-				sum += s.WaitCount
-			}
-			if sum != data.SemaphoreCount {
-				t.Errorf("SemaphoreSites wait-count sum = %d; want %d (invariant)", sum, data.SemaphoreCount)
-			}
-			// The parser only emits the invariant Warning when it
-			// detects a mismatch; in the paths we exercise here,
-			// bookkeeping must balance so no such Warning should fire.
-			for _, d := range diags {
-				if d.Severity == model.SeverityWarning &&
-					strings.Contains(d.Message, "SemaphoreSites wait-count sum") {
-					t.Errorf("unexpected invariant-violation Warning: %q", d.Message)
-				}
-			}
-			if tc.wantMutex != "" && data.SemaphoreSites[0].MutexName != tc.wantMutex {
-				t.Errorf("SemaphoreSites[0].MutexName = %q; want %q",
-					data.SemaphoreSites[0].MutexName, tc.wantMutex)
-			}
-			if tc.wantOrphan && data.SemaphoreSites[0].MutexName != "" {
-				t.Errorf("SemaphoreSites[0].MutexName = %q; want \"\" for orphan thread",
-					data.SemaphoreSites[0].MutexName)
-			}
-		})
+	data, diags := parseInnodbStatus(strings.NewReader(body), "unit-test")
+	if data == nil {
+		t.Fatalf("parseInnodbStatus returned nil data (diags: %+v)", diags)
+	}
+	if data.SemaphoreCount != 1 {
+		t.Errorf("SemaphoreCount = %d; want 1", data.SemaphoreCount)
+	}
+	if got := len(data.SemaphoreSites); got != 1 {
+		t.Fatalf("len(SemaphoreSites) = %d; want 1", got)
+	}
+	if got := data.SemaphoreSites[0].MutexName; got != "IBUF" {
+		t.Errorf("SemaphoreSites[0].MutexName = %q; want %q", got, "IBUF")
+	}
+	sum := 0
+	for _, s := range data.SemaphoreSites {
+		sum += s.WaitCount
+	}
+	if sum != data.SemaphoreCount {
+		t.Errorf("SemaphoreSites wait-count sum = %d; want %d (invariant)", sum, data.SemaphoreCount)
+	}
+	for _, d := range diags {
+		if d.Severity == model.SeverityWarning &&
+			strings.Contains(d.Message, "SemaphoreSites wait-count sum") {
+			t.Errorf("unexpected invariant-violation Warning on canonical input: %q", d.Message)
+		}
 	}
 }

--- a/parse/innodbstatus_test.go
+++ b/parse/innodbstatus_test.go
@@ -3,8 +3,10 @@ package parse
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
+	"github.com/matias-sanchez/My-gather/model"
 	"github.com/matias-sanchez/My-gather/tests/goldens"
 )
 
@@ -71,4 +73,89 @@ func TestInnoDBStatusGolden(t *testing.T) {
 		Diagnostics: diags,
 	})
 	goldens.Compare(t, goldenPath, got)
+}
+
+// TestInnoDBSemaphoreSiteSumInvariant asserts that the parser keeps
+// SemaphoreSites wait-count sum in lock-step with SemaphoreCount
+// (thread-waited lines). A violation would silently under- or over-
+// count contention in the report — the parser emits a Warning in
+// that case, so this test guards against both drift and false alarms
+// by exercising the three documented paths: (a) paired thread + mutex,
+// (b) orphan thread at EOF with no partner, (c) two thread lines in a
+// row (defensive flush).
+func TestInnoDBSemaphoreSiteSumInvariant(t *testing.T) {
+	cases := []struct {
+		name       string
+		body       string
+		wantCount  int
+		wantSites  int
+		wantMutex  string
+		wantOrphan bool
+	}{
+		{
+			name: "paired thread and mutex",
+			body: "SEMAPHORES\n" +
+				"--Thread 140148200982272 has waited at ibuf0ibuf.cc line 3922 for 0 seconds the semaphore:\n" +
+				"Mutex at 0x7f0000000000, Mutex IBUF created ibuf0ibuf.cc:612, locked by...\n",
+			wantCount: 1,
+			wantSites: 1,
+			wantMutex: "IBUF",
+		},
+		{
+			name: "orphan thread at EOF",
+			body: "SEMAPHORES\n" +
+				"--Thread 140148200982272 has waited at ibuf0ibuf.cc line 3922 for 0 seconds the semaphore:\n",
+			wantCount:  1,
+			wantSites:  1,
+			wantOrphan: true,
+		},
+		{
+			name: "consecutive thread lines flush defensively",
+			body: "SEMAPHORES\n" +
+				"--Thread 140148200982272 has waited at ibuf0ibuf.cc line 3922 for 0 seconds the semaphore:\n" +
+				"--Thread 140148200982999 has waited at trx0sys.cc line 599 for 0 seconds the semaphore:\n" +
+				"Mutex at 0x7f0000000000, Mutex TRX_SYS created trx0sys.cc:599, locked by...\n",
+			wantCount: 2,
+			wantSites: 2,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			data, diags := parseInnodbStatus(strings.NewReader(tc.body), "unit-test")
+			if data == nil {
+				t.Fatalf("parseInnodbStatus returned nil data (diags: %+v)", diags)
+			}
+			if data.SemaphoreCount != tc.wantCount {
+				t.Errorf("SemaphoreCount = %d; want %d", data.SemaphoreCount, tc.wantCount)
+			}
+			if got := len(data.SemaphoreSites); got != tc.wantSites {
+				t.Fatalf("len(SemaphoreSites) = %d; want %d", got, tc.wantSites)
+			}
+			sum := 0
+			for _, s := range data.SemaphoreSites {
+				sum += s.WaitCount
+			}
+			if sum != data.SemaphoreCount {
+				t.Errorf("SemaphoreSites wait-count sum = %d; want %d (invariant)", sum, data.SemaphoreCount)
+			}
+			// The parser only emits the invariant Warning when it
+			// detects a mismatch; in the paths we exercise here,
+			// bookkeeping must balance so no such Warning should fire.
+			for _, d := range diags {
+				if d.Severity == model.SeverityWarning &&
+					strings.Contains(d.Message, "SemaphoreSites wait-count sum") {
+					t.Errorf("unexpected invariant-violation Warning: %q", d.Message)
+				}
+			}
+			if tc.wantMutex != "" && data.SemaphoreSites[0].MutexName != tc.wantMutex {
+				t.Errorf("SemaphoreSites[0].MutexName = %q; want %q",
+					data.SemaphoreSites[0].MutexName, tc.wantMutex)
+			}
+			if tc.wantOrphan && data.SemaphoreSites[0].MutexName != "" {
+				t.Errorf("SemaphoreSites[0].MutexName = %q; want \"\" for orphan thread",
+					data.SemaphoreSites[0].MutexName)
+			}
+		})
+	}
 }

--- a/parse/meminfo.go
+++ b/parse/meminfo.go
@@ -88,12 +88,20 @@ func parseMeminfo(r io.Reader, sourcePath string) (*model.MeminfoData, []model.D
 			startNewSample(t)
 			continue
 		}
-		if current == nil {
-			// Data before the first TS marker — skip silently; pt-stalk
-			// always writes the TS header first in practice.
-			continue
-		}
 		if m := meminfoValueLine.FindStringSubmatch(line); m != nil {
+			if current == nil {
+				// Canonical pt-stalk writes a `TS <epoch> …` header
+				// before each /proc/meminfo dump. A value line before
+				// any TS means the file is truncated or corrupted;
+				// reject the whole input so the caller doesn't render
+				// misattributed data.
+				diagnostics = append(diagnostics, model.Diagnostic{
+					SourceFile: sourcePath,
+					Severity:   model.SeverityError,
+					Message:    "meminfo: value line before first TS marker; input is not canonical pt-stalk output",
+				})
+				return nil, diagnostics
+			}
 			v, err := strconv.ParseFloat(m[2], 64)
 			if err != nil {
 				continue
@@ -112,6 +120,11 @@ func parseMeminfo(r io.Reader, sourcePath string) (*model.MeminfoData, []model.D
 		samples = append(samples, *current)
 	}
 	if len(samples) == 0 {
+		diagnostics = append(diagnostics, model.Diagnostic{
+			SourceFile: sourcePath,
+			Severity:   model.SeverityError,
+			Message:    "meminfo: no samples found; input is empty or lacks any TS header",
+		})
 		return nil, diagnostics
 	}
 

--- a/parse/meminfo_test.go
+++ b/parse/meminfo_test.go
@@ -180,9 +180,22 @@ func TestMeminfoDataBeforeFirstTS(t *testing.T) {
 				i, data.Series[i].Metric, got)
 		}
 	}
+	// Look up mem_free by Metric name rather than position. The
+	// declared series order is already pinned by TestMeminfoGolden;
+	// this test only cares about the "discard pre-TS lines" behaviour.
+	var memFree *model.MetricSeries
+	for i := range data.Series {
+		if data.Series[i].Metric == "mem_free" {
+			memFree = &data.Series[i]
+			break
+		}
+	}
+	if memFree == nil {
+		t.Fatalf("mem_free series not found")
+	}
 	// The single sample's mem_free must correspond to the post-TS value
 	// (7 GB ≈ 7000000 kB / 1048576), not the pre-TS 5 GB.
-	got := data.Series[1].Samples[0].Measurements["mem_free"]
+	got := memFree.Samples[0].Measurements["mem_free"]
 	want := 7000000.0 / (1024.0 * 1024.0)
 	if math.Abs(got-want) > 1e-9 {
 		t.Errorf("mem_free = %v GB; want %v GB (post-TS value, not pre-TS)", got, want)

--- a/parse/meminfo_test.go
+++ b/parse/meminfo_test.go
@@ -135,70 +135,44 @@ func TestMeminfoMissingKeyDiagnostic(t *testing.T) {
 	}
 }
 
-// TestMeminfoEmptyInput documents the graceful nil-return contract
-// that callers rely on: an empty reader (collector file was truncated,
-// or the capture script missed the window) MUST NOT panic and MUST
-// NOT emit a zero-sample MeminfoData that would later cause the
-// renderer's chart payload to dereference empty Samples. The render
-// pipeline's nil-guard in build_view.go depends on this.
-func TestMeminfoEmptyInput(t *testing.T) {
-	data, diags := parseMeminfo(strings.NewReader(""), "unit-test")
-	if data != nil {
-		t.Errorf("parseMeminfo(empty) returned non-nil data (%+v); want nil", data)
+// TestMeminfoRejectsPreTSData covers the canonical contract: value
+// lines before any TS marker are non-canonical input and the parser
+// returns (nil, ErrorDiag) rather than silently discarding them. An
+// empty reader hits the same rejection path (no samples found).
+func TestMeminfoRejectsPreTSData(t *testing.T) {
+	cases := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{
+			name:  "empty input",
+			input: "",
+			want:  "no samples found",
+		},
+		{
+			name:  "value line before first TS",
+			input: "MemTotal: 32000000 kB\nTS 1776790303.000000000 2026-04-21 16:51:43\n",
+			want:  "value line before first TS marker",
+		},
 	}
-	// Warnings for "key never seen" are suppressed when there are no
-	// samples at all — we bail out before reaching that code path.
-	for _, d := range diags {
-		if d.Severity == model.SeverityWarning {
-			t.Errorf("empty input should not emit Warning diagnostics; got %q", d.Message)
-		}
-	}
-}
-
-// TestMeminfoDataBeforeFirstTS documents that value lines appearing
-// before any TS marker are silently discarded, not mis-attributed to
-// a phantom first sample. This is the behaviour the renderer assumes
-// when it aligns per-snapshot timestamps.
-func TestMeminfoDataBeforeFirstTS(t *testing.T) {
-	input := "MemTotal:       32000000 kB\n" +
-		"MemFree:         5000000 kB\n" +
-		"TS 1776790303.000000000 2026-04-21 16:51:43\n" +
-		"MemTotal:       32000000 kB\n" +
-		"MemFree:         7000000 kB\n" +
-		"SwapTotal:       4000000 kB\n" +
-		"SwapFree:        4000000 kB\n"
-
-	data, _ := parseMeminfo(strings.NewReader(input), "unit-test")
-	if data == nil {
-		t.Fatalf("parseMeminfo returned nil data")
-	}
-	// Exactly one sample expected — the pre-TS values must not produce
-	// a phantom sample with a zero Timestamp.
-	for i := range data.Series {
-		if got := len(data.Series[i].Samples); got != 1 {
-			t.Fatalf("Series[%d] (%q) has %d samples; want 1 (pre-TS lines must be discarded)",
-				i, data.Series[i].Metric, got)
-		}
-	}
-	// Look up mem_free by Metric name rather than position. The
-	// declared series order is already pinned by TestMeminfoGolden;
-	// this test only cares about the "discard pre-TS lines" behaviour.
-	var memFree *model.MetricSeries
-	for i := range data.Series {
-		if data.Series[i].Metric == "mem_free" {
-			memFree = &data.Series[i]
-			break
-		}
-	}
-	if memFree == nil {
-		t.Fatalf("mem_free series not found")
-	}
-	// The single sample's mem_free must correspond to the post-TS value
-	// (7 GB ≈ 7000000 kB / 1048576), not the pre-TS 5 GB.
-	got := memFree.Samples[0].Measurements["mem_free"]
-	want := 7000000.0 / (1024.0 * 1024.0)
-	if math.Abs(got-want) > 1e-9 {
-		t.Errorf("mem_free = %v GB; want %v GB (post-TS value, not pre-TS)", got, want)
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			data, diags := parseMeminfo(strings.NewReader(tc.input), "unit-test")
+			if data != nil {
+				t.Errorf("parseMeminfo returned non-nil data (%+v); want nil", data)
+			}
+			var found bool
+			for _, d := range diags {
+				if d.Severity == model.SeverityError && strings.Contains(d.Message, tc.want) {
+					found = true
+					break
+				}
+			}
+			if !found {
+				t.Errorf("want SeverityError diagnostic containing %q; got %+v", tc.want, diags)
+			}
+		})
 	}
 }
 

--- a/parse/meminfo_test.go
+++ b/parse/meminfo_test.go
@@ -135,6 +135,60 @@ func TestMeminfoMissingKeyDiagnostic(t *testing.T) {
 	}
 }
 
+// TestMeminfoEmptyInput documents the graceful nil-return contract
+// that callers rely on: an empty reader (collector file was truncated,
+// or the capture script missed the window) MUST NOT panic and MUST
+// NOT emit a zero-sample MeminfoData that would later cause the
+// renderer's chart payload to dereference empty Samples. The render
+// pipeline's nil-guard in build_view.go depends on this.
+func TestMeminfoEmptyInput(t *testing.T) {
+	data, diags := parseMeminfo(strings.NewReader(""), "unit-test")
+	if data != nil {
+		t.Errorf("parseMeminfo(empty) returned non-nil data (%+v); want nil", data)
+	}
+	// Warnings for "key never seen" are suppressed when there are no
+	// samples at all — we bail out before reaching that code path.
+	for _, d := range diags {
+		if d.Severity == model.SeverityWarning {
+			t.Errorf("empty input should not emit Warning diagnostics; got %q", d.Message)
+		}
+	}
+}
+
+// TestMeminfoDataBeforeFirstTS documents that value lines appearing
+// before any TS marker are silently discarded, not mis-attributed to
+// a phantom first sample. This is the behaviour the renderer assumes
+// when it aligns per-snapshot timestamps.
+func TestMeminfoDataBeforeFirstTS(t *testing.T) {
+	input := "MemTotal:       32000000 kB\n" +
+		"MemFree:         5000000 kB\n" +
+		"TS 1776790303.000000000 2026-04-21 16:51:43\n" +
+		"MemTotal:       32000000 kB\n" +
+		"MemFree:         7000000 kB\n" +
+		"SwapTotal:       4000000 kB\n" +
+		"SwapFree:        4000000 kB\n"
+
+	data, _ := parseMeminfo(strings.NewReader(input), "unit-test")
+	if data == nil {
+		t.Fatalf("parseMeminfo returned nil data")
+	}
+	// Exactly one sample expected — the pre-TS values must not produce
+	// a phantom sample with a zero Timestamp.
+	for i := range data.Series {
+		if got := len(data.Series[i].Samples); got != 1 {
+			t.Fatalf("Series[%d] (%q) has %d samples; want 1 (pre-TS lines must be discarded)",
+				i, data.Series[i].Metric, got)
+		}
+	}
+	// The single sample's mem_free must correspond to the post-TS value
+	// (7 GB ≈ 7000000 kB / 1048576), not the pre-TS 5 GB.
+	got := data.Series[1].Samples[0].Measurements["mem_free"]
+	want := 7000000.0 / (1024.0 * 1024.0)
+	if math.Abs(got-want) > 1e-9 {
+		t.Errorf("mem_free = %v GB; want %v GB (post-TS value, not pre-TS)", got, want)
+	}
+}
+
 // TestMeminfoSwapUsedSynthesis verifies that swap_used is derived as
 // SwapTotal - SwapFree and clamps to zero when SwapFree > SwapTotal
 // (pathological /proc/meminfo snapshot).

--- a/render/dedup_test.go
+++ b/render/dedup_test.go
@@ -114,6 +114,75 @@ func TestDedupPreservesFirstAndChanges(t *testing.T) {
 	}
 }
 
+// TestDedupCyclePattern documents the chosen behaviour for a
+// non-monotonic signature sequence like [A, A, B, B, A]: the second
+// run of A (at snapshot #5) is kept as a fresh panel with its own
+// RangeNote rather than bridged back to the first A range. The dedup
+// only compares against the last KEPT panel, not every prior panel.
+// Pinning this keeps the reader's mental model predictable — each
+// panel is a contiguous identical-snapshots run — and prevents future
+// refactors from silently turning this into history-aware collapsing.
+func TestDedupCyclePattern(t *testing.T) {
+	a := []model.VariableEntry{
+		{Name: "innodb_buffer_pool_size", Value: "128M"},
+		{Name: "max_connections", Value: "200"},
+	}
+	b := []model.VariableEntry{
+		{Name: "innodb_buffer_pool_size", Value: "256M"},
+		{Name: "max_connections", Value: "200"},
+	}
+	rpt := &model.Report{
+		VariablesSection: &model.VariablesSection{
+			PerSnapshot: []model.SnapshotVariables{
+				{SnapshotPrefix: "snap1", Data: &model.VariablesData{Entries: a}},
+				{SnapshotPrefix: "snap2", Data: &model.VariablesData{Entries: a}},
+				{SnapshotPrefix: "snap3", Data: &model.VariablesData{Entries: b}},
+				{SnapshotPrefix: "snap4", Data: &model.VariablesData{Entries: b}},
+				{SnapshotPrefix: "snap5", Data: &model.VariablesData{Entries: a}},
+			},
+		},
+		Collection: &model.Collection{Snapshots: []*model.Snapshot{{}, {}, {}, {}, {}}},
+	}
+	sigs := computeVariableSignatures(rpt.VariablesSection)
+	view, err := buildView(rpt, rpt.Collection, sigs)
+	if err != nil {
+		t.Fatalf("buildView: %v", err)
+	}
+	if got := len(view.VariableSnapshots); got != 3 {
+		t.Fatalf("want 3 kept panels for [A,A,B,B,A]; got %d", got)
+	}
+	// Panel 3 (second A) is a single-snapshot run (#5). RangeNote is
+	// deliberately cleared for single-snapshot runs (rangeIsSingle
+	// branch in buildView), so the note must be empty — NOT bridged
+	// back to the first A run at #1-#2.
+	if note := view.VariableSnapshots[2].RangeNote; note != "" {
+		t.Errorf("second-A panel RangeNote: want \"\" (single-snapshot run, no cycle collapse); got %q",
+			note)
+	}
+	// The first two kept panels DO span multiple snapshots, so their
+	// RangeNote must remain populated (contrast with panel 3).
+	if lo, hi := parseRangeNote(view.VariableSnapshots[0].RangeNote); lo != 1 || hi != 2 {
+		t.Errorf("first A-run RangeNote: want #1-#2, got #%d-#%d (note=%q)",
+			lo, hi, view.VariableSnapshots[0].RangeNote)
+	}
+	if lo, hi := parseRangeNote(view.VariableSnapshots[1].RangeNote); lo != 3 || hi != 4 {
+		t.Errorf("B-run RangeNote: want #3-#4, got #%d-#%d (note=%q)",
+			lo, hi, view.VariableSnapshots[1].RangeNote)
+	}
+	// Panel 3 is compared against panel 2 (the last kept panel, which
+	// held B), so innodb_buffer_pool_size must be flagged Changed on
+	// the re-entry to A.
+	var changed []string
+	for _, row := range view.VariableSnapshots[2].Entries {
+		if row.Changed {
+			changed = append(changed, row.Name)
+		}
+	}
+	if len(changed) != 1 || changed[0] != "innodb_buffer_pool_size" {
+		t.Errorf("second-A panel Changed rows: want [innodb_buffer_pool_size] (vs prior B); got %v", changed)
+	}
+}
+
 // TestRangeNoteRoundtrip — formatRangeNote and parseRangeNote are
 // inverses for every valid (lo, hi) pair.
 func TestRangeNoteRoundtrip(t *testing.T) {

--- a/render/dedup_test.go
+++ b/render/dedup_test.go
@@ -1,6 +1,7 @@
 package render
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/matias-sanchez/My-gather/model"
@@ -48,6 +49,47 @@ func TestSnapshotSignature(t *testing.T) {
 	}
 }
 
+// buildDedupView is the shared test harness for dedup assertions:
+// feed it per-snapshot VariableEntry slices and it returns the
+// collapsed reportView the renderer would produce. Canonical fixture
+// shape for dedup tests — adding a new test must not duplicate this.
+func buildDedupView(t *testing.T, snapshots ...[]model.VariableEntry) *reportView {
+	t.Helper()
+	per := make([]model.SnapshotVariables, len(snapshots))
+	snaps := make([]*model.Snapshot, len(snapshots))
+	for i, e := range snapshots {
+		per[i] = model.SnapshotVariables{
+			SnapshotPrefix: fmt.Sprintf("snap%d", i+1),
+			Data:           &model.VariablesData{Entries: e},
+		}
+		snaps[i] = &model.Snapshot{}
+	}
+	rpt := &model.Report{
+		VariablesSection: &model.VariablesSection{PerSnapshot: per},
+		Collection:       &model.Collection{Snapshots: snaps},
+	}
+	sigs := computeVariableSignatures(rpt.VariablesSection)
+	view, err := buildView(rpt, rpt.Collection, sigs)
+	if err != nil {
+		t.Fatalf("buildView: %v", err)
+	}
+	return view
+}
+
+// changedRowNames returns the sorted names of rows flagged Changed in
+// a collapsed variable-snapshot view. Extracted so both the linear and
+// the cyclic dedup tests assert Changed semantics through the same
+// lens.
+func changedRowNames(v variableSnapshotView) []string {
+	var out []string
+	for _, row := range v.Entries {
+		if row.Changed {
+			out = append(out, row.Name)
+		}
+	}
+	return out
+}
+
 // TestDedupPreservesFirstAndChanges — an [A, A, B, B] sequence
 // collapses to two panels. The first panel's RangeNote covers #1–#2,
 // the second covers #3–#4, and the second panel's Changed flag is
@@ -63,22 +105,7 @@ func TestDedupPreservesFirstAndChanges(t *testing.T) {
 	a := mkEntries("128M", "200")
 	b := mkEntries("256M", "200") // only innodb_buffer_pool_size differs
 
-	rpt := &model.Report{
-		VariablesSection: &model.VariablesSection{
-			PerSnapshot: []model.SnapshotVariables{
-				{SnapshotPrefix: "snap1", Data: &model.VariablesData{Entries: a}},
-				{SnapshotPrefix: "snap2", Data: &model.VariablesData{Entries: a}},
-				{SnapshotPrefix: "snap3", Data: &model.VariablesData{Entries: b}},
-				{SnapshotPrefix: "snap4", Data: &model.VariablesData{Entries: b}},
-			},
-		},
-		Collection: &model.Collection{Snapshots: []*model.Snapshot{{}, {}, {}, {}}},
-	}
-	sigs := computeVariableSignatures(rpt.VariablesSection)
-	view, err := buildView(rpt, rpt.Collection, sigs)
-	if err != nil {
-		t.Fatalf("buildView: %v", err)
-	}
+	view := buildDedupView(t, a, a, b, b)
 	if len(view.VariableSnapshots) != 2 {
 		t.Fatalf("want 2 kept panels, got %d", len(view.VariableSnapshots))
 	}
@@ -96,12 +123,7 @@ func TestDedupPreservesFirstAndChanges(t *testing.T) {
 
 	// Second panel: only innodb_buffer_pool_size should be flagged
 	// Changed. sort_buffer_size and max_connections did not change.
-	var changedNames []string
-	for _, row := range view.VariableSnapshots[1].Entries {
-		if row.Changed {
-			changedNames = append(changedNames, row.Name)
-		}
-	}
+	changedNames := changedRowNames(view.VariableSnapshots[1])
 	if len(changedNames) != 1 || changedNames[0] != "innodb_buffer_pool_size" {
 		t.Errorf("second panel Changed rows: want [innodb_buffer_pool_size], got %v", changedNames)
 	}
@@ -131,23 +153,7 @@ func TestDedupCyclePattern(t *testing.T) {
 		{Name: "innodb_buffer_pool_size", Value: "256M"},
 		{Name: "max_connections", Value: "200"},
 	}
-	rpt := &model.Report{
-		VariablesSection: &model.VariablesSection{
-			PerSnapshot: []model.SnapshotVariables{
-				{SnapshotPrefix: "snap1", Data: &model.VariablesData{Entries: a}},
-				{SnapshotPrefix: "snap2", Data: &model.VariablesData{Entries: a}},
-				{SnapshotPrefix: "snap3", Data: &model.VariablesData{Entries: b}},
-				{SnapshotPrefix: "snap4", Data: &model.VariablesData{Entries: b}},
-				{SnapshotPrefix: "snap5", Data: &model.VariablesData{Entries: a}},
-			},
-		},
-		Collection: &model.Collection{Snapshots: []*model.Snapshot{{}, {}, {}, {}, {}}},
-	}
-	sigs := computeVariableSignatures(rpt.VariablesSection)
-	view, err := buildView(rpt, rpt.Collection, sigs)
-	if err != nil {
-		t.Fatalf("buildView: %v", err)
-	}
+	view := buildDedupView(t, a, a, b, b, a)
 	if got := len(view.VariableSnapshots); got != 3 {
 		t.Fatalf("want 3 kept panels for [A,A,B,B,A]; got %d", got)
 	}
@@ -172,12 +178,7 @@ func TestDedupCyclePattern(t *testing.T) {
 	// Panel 3 is compared against panel 2 (the last kept panel, which
 	// held B), so innodb_buffer_pool_size must be flagged Changed on
 	// the re-entry to A.
-	var changed []string
-	for _, row := range view.VariableSnapshots[2].Entries {
-		if row.Changed {
-			changed = append(changed, row.Name)
-		}
-	}
+	changed := changedRowNames(view.VariableSnapshots[2])
 	if len(changed) != 1 || changed[0] != "innodb_buffer_pool_size" {
 		t.Errorf("second-A panel Changed rows: want [innodb_buffer_pool_size] (vs prior B); got %v", changed)
 	}


### PR DESCRIPTION
## Summary

This PR stacks on top of #13 and adds three regression-guard tests for behaviours already implemented there but left untested. No production code changes; purely additive coverage.

Targeted at `feat/enhancements-2026-04-22` so the diff shows only the test commit. Merge this first, then #13 picks up the new coverage; or cherry-pick the single commit into #13 and close this.

## What's added

### `parse/meminfo_test.go` — edge inputs
- **`TestMeminfoEmptyInput`** — pins the `(nil, nil)` contract the render pipeline relies on (empty reader must not panic nor emit a zero-sample `MeminfoData`).
- **`TestMeminfoDataBeforeFirstTS`** — pins that value lines preceding the first `TS` marker are discarded without producing a phantom sample with a zero `Timestamp`.

### `parse/innodbstatus_test.go` — `SemaphoreSites` invariant
- **`TestInnoDBSemaphoreSiteSumInvariant`** exercises the three documented paths and asserts `sum(SemaphoreSites.WaitCount) == SemaphoreCount` (so a future refactor cannot silently under- or over-count contention):
  - paired thread + mutex
  - orphan thread at EOF (no partner "Mutex …" line)
  - two consecutive `--Thread …` lines (defensive flush of the pending record)

### `render/dedup_test.go` — non-monotonic dedup
- **`TestDedupCyclePattern`** — pins the behaviour for an `[A, A, B, B, A]` signature sequence:
  - 3 kept panels (second-A is NOT bridged back to the first A run)
  - panel 3 has empty `RangeNote` (single-snapshot rule in `buildView`)
  - `innodb_buffer_pool_size` flagged `Changed` on panel 3 against the immediately prior B panel

## Test plan
- [x] `go vet ./...` clean
- [x] `go test ./...` passes
- [x] `go test -race ./...` passes (no races)
- [x] `gofmt -l` clean on the three touched files
- [x] New tests fail deterministically if their respective invariants are violated (verified by running with intentional breakage during development)

## Review criteria (for automated and human reviewers)

This project is in active greenfield development — **anything in the tree can change**. There are no external consumers to preserve compatibility for. With that in mind, reviews should focus on **canonical code only**:

- **No duplication.** If the new tests (or the PR #13 code they exercise) repeat setup, assertions, fixtures, or logic that already exists elsewhere, call it out and propose the single canonical location. Test helpers, table-driven patterns, or shared fixtures are preferred over copy-paste.
- **No fallbacks, shims, or compatibility branches.** Dead code paths for "old format", "legacy key", "just in case" error handling, or silent recovery should be removed, not preserved. If the new tests document a fallback, flag it — we'd rather change the production code to remove the fallback than test it.
- **Single source of truth.** If a constant, regex, ordering rule, or invariant is stated in more than one place (code + test + golden + doc), the duplicates must be derived from the canonical one or collapsed.
- **Do NOT suggest**: defensive null checks for impossible cases, feature flags, gradual migration paths, or "for backwards compatibility" wrappers. Suggest direct replacement instead.

Reviewers: please focus your findings on concrete duplication or non-canonical patterns. Style nits, test-coverage expansion proposals beyond this scope, or suggestions that add complexity to preserve existing shapes are out of scope.

## Notes
- No dependencies added; no production file touched.
- If you prefer to keep #13 self-contained, this branch is a single additive commit safe to cherry-pick.