### PR TITLE
release: raw per-arch binaries + install script

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -132,4 +132,8 @@ jobs:
         with:
           files: |
             dist/my-gather_*.tar.gz
+            dist/my-gather-darwin-amd64
+            dist/my-gather-darwin-arm64
+            dist/my-gather-linux-amd64
+            dist/my-gather-linux-arm64
             dist/SHA256SUMS

--- a/Makefile
+++ b/Makefile
@@ -59,10 +59,13 @@ lint:
 	$(GO) vet ./...
 
 # release: cross-compile for every target, bundle each into a tarball,
-# and emit a single SHA256SUMS file beside them. Does NOT depend on
-# `clean` so the local ./bin/ binary survives a release build.
+# also emit a raw `my-gather-<os>-<arch>` binary alongside each tarball
+# (so users can `curl | chmod | mv` in one step without the tarball
+# dance), and finish with a single SHA256SUMS covering every artifact.
+# Does NOT depend on `clean` so the local ./bin/ binary survives a
+# release build.
 release: $(DIST)
-	@rm -f $(DIST)/my-gather_*.tar.gz $(DIST)/SHA256SUMS
+	@rm -f $(DIST)/my-gather_*.tar.gz $(DIST)/my-gather-* $(DIST)/SHA256SUMS
 	@for target in $(TARGETS); do \
 	  os=$${target%%/*}; arch=$${target##*/}; \
 	  stage="$(DIST)/my-gather_$(VERSION)_$${os}_$${arch}"; \
@@ -73,11 +76,13 @@ release: $(DIST)
 	    || exit 1; \
 	  cp README.md CHANGELOG.md "$$stage/" 2>/dev/null || true; \
 	  ( cd $(DIST) && tar -czf "my-gather_$(VERSION)_$${os}_$${arch}.tar.gz" "my-gather_$(VERSION)_$${os}_$${arch}" ) || exit 1; \
+	  cp "$$stage/$(BIN_NAME)" "$(DIST)/$(BIN_NAME)-$${os}-$${arch}"; \
+	  chmod +x "$(DIST)/$(BIN_NAME)-$${os}-$${arch}"; \
 	  rm -rf "$$stage"; \
 	done
-	@( cd $(DIST) && $(SHA256) my-gather_*.tar.gz > SHA256SUMS )
+	@( cd $(DIST) && $(SHA256) my-gather_*.tar.gz my-gather-* > SHA256SUMS )
 	@echo "Release artifacts in $(DIST)/:"
-	@ls -lh $(DIST)/my-gather_*.tar.gz $(DIST)/SHA256SUMS
+	@ls -lh $(DIST)/my-gather_*.tar.gz $(DIST)/my-gather-* $(DIST)/SHA256SUMS
 
 $(DIST):
 	@mkdir -p $(DIST)

--- a/README.md
+++ b/README.md
@@ -8,14 +8,37 @@ Built for MySQL / Percona support engineers and DBAs triaging incidents under ti
 
 Active development. See `specs/001-ptstalk-report-mvp/` for the current feature spec, implementation plan, and task list.
 
+## Install
+
+One-liner (macOS + Linux, amd64 + arm64) — verifies the SHA-256 against the published `SHA256SUMS` and installs into `~/.local/bin`:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/matias-sanchez/My-gather/main/scripts/install.sh | sh
+```
+
+Pin to a specific tag or install somewhere else:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/matias-sanchez/My-gather/main/scripts/install.sh | VERSION=v0.3.0 sh
+curl -fsSL https://raw.githubusercontent.com/matias-sanchez/My-gather/main/scripts/install.sh | PREFIX=/usr/local/bin sudo sh
+```
+
+Or grab a raw binary from the [latest release](https://github.com/matias-sanchez/My-gather/releases/latest) directly — `my-gather-darwin-arm64`, `my-gather-darwin-amd64`, `my-gather-linux-arm64`, `my-gather-linux-amd64`. Each tag also ships a `.tar.gz` that bundles the binary + README + CHANGELOG, plus a single `SHA256SUMS` covering every artifact.
+
 ## Quickstart
+
+```bash
+my-gather testdata/example2 -o /tmp/report.html
+open /tmp/report.html   # macOS; xdg-open on Linux
+```
+
+Or build from source:
 
 ```bash
 git clone git@github.com:matias-sanchez/My-gather.git
 cd My-gather
 make build
 ./bin/my-gather testdata/example2 -o /tmp/report.html
-open /tmp/report.html   # macOS; xdg-open on Linux
 ```
 
 The report is one self-contained HTML file — CSS, JS, fonts, and data are inlined. Open it on an air-gapped laptop and everything renders.

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env sh
+# my-gather installer. Detects OS+arch, downloads the matching raw
+# binary from the latest GitHub Release, verifies its SHA-256
+# against the published SHA256SUMS, installs to $PREFIX (default
+# $HOME/.local/bin) and prints the installed version.
+#
+# Usage:
+#   curl -fsSL https://raw.githubusercontent.com/matias-sanchez/My-gather/main/scripts/install.sh | sh
+#   curl -fsSL ... | VERSION=v0.3.0 sh          # pin to a specific tag
+#   curl -fsSL ... | PREFIX=/usr/local/bin sh   # install to /usr/local/bin (sudo may be needed)
+#
+# No telemetry, no background work, no automatic updates.
+
+set -eu
+
+REPO="matias-sanchez/My-gather"
+BIN="my-gather"
+
+# Resolve OS.
+case "$(uname -s)" in
+  Darwin) os="darwin" ;;
+  Linux)  os="linux" ;;
+  *) echo "my-gather: unsupported OS '$(uname -s)'. Supported: darwin, linux." >&2; exit 1 ;;
+esac
+
+# Resolve arch.
+case "$(uname -m)" in
+  arm64|aarch64) arch="arm64" ;;
+  x86_64|amd64)  arch="amd64" ;;
+  *) echo "my-gather: unsupported arch '$(uname -m)'. Supported: arm64, amd64." >&2; exit 1 ;;
+esac
+
+asset="${BIN}-${os}-${arch}"
+
+# Resolve version: default to latest release, honour $VERSION override.
+version="${VERSION:-}"
+if [ -z "$version" ]; then
+  version=$(curl -fsSL "https://api.github.com/repos/${REPO}/releases/latest" \
+    | sed -n 's/.*"tag_name": *"\([^"]*\)".*/\1/p' \
+    | head -n1)
+  if [ -z "$version" ]; then
+    echo "my-gather: could not resolve latest release tag from GitHub API." >&2
+    exit 1
+  fi
+fi
+
+prefix="${PREFIX:-$HOME/.local/bin}"
+mkdir -p "$prefix"
+
+url="https://github.com/${REPO}/releases/download/${version}/${asset}"
+sums_url="https://github.com/${REPO}/releases/download/${version}/SHA256SUMS"
+
+tmp=$(mktemp -d)
+trap 'rm -rf "$tmp"' EXIT
+
+echo "my-gather: downloading ${asset} (${version})"
+curl -fsSL "$url" -o "${tmp}/${asset}"
+
+# Verify SHA-256 against the published SHA256SUMS.
+if curl -fsSL "$sums_url" -o "${tmp}/SHA256SUMS" 2>/dev/null; then
+  expected=$(grep "  ${asset}\$" "${tmp}/SHA256SUMS" | awk '{print $1}')
+  if [ -n "$expected" ]; then
+    if command -v sha256sum >/dev/null 2>&1; then
+      actual=$(sha256sum "${tmp}/${asset}" | awk '{print $1}')
+    else
+      actual=$(shasum -a 256 "${tmp}/${asset}" | awk '{print $1}')
+    fi
+    if [ "$expected" != "$actual" ]; then
+      echo "my-gather: checksum mismatch for ${asset}" >&2
+      echo "  expected: ${expected}" >&2
+      echo "  actual:   ${actual}" >&2
+      exit 1
+    fi
+    echo "my-gather: checksum verified"
+  else
+    echo "my-gather: ${asset} not listed in SHA256SUMS; skipping verify" >&2
+  fi
+else
+  echo "my-gather: SHA256SUMS not found for ${version}; skipping verify" >&2
+fi
+
+chmod +x "${tmp}/${asset}"
+mv "${tmp}/${asset}" "${prefix}/${BIN}"
+
+echo "my-gather: installed to ${prefix}/${BIN}"
+"${prefix}/${BIN}" --version || true
+
+case ":${PATH}:" in
+  *":${prefix}:"*) ;;
+  *) echo "my-gather: note — ${prefix} is not on your \$PATH. Add it with:" >&2
+     echo "    export PATH=\"${prefix}:\$PATH\"" >&2 ;;
+esac


### PR DESCRIPTION
## Summary
- Makefile `release` now outputs raw `my-gather-<os>-<arch>` binaries alongside the existing `.tar.gz` bundles; `SHA256SUMS` covers both.
- CI attaches the four raw binaries to every `v*` tag release automatically.
- `scripts/install.sh`: one-line curl-installable; auto-detects OS+arch, pins to latest tag (override with `VERSION=` / `PREFIX=`), verifies SHA-256.
- `README.md` install section with the curl one-liner + direct-download links.

## Test plan
- [x] `make vet` green
- [x] `make release` locally produces 4 tarballs + 4 raw binaries + `SHA256SUMS` (788 B)
- [ ] After merge + tag `v0.3.1`, verify GitHub Release has the 9 expected assets
- [ ] Run `curl -fsSL .../install.sh | sh` on a clean Mac → `my-gather --version` prints `v0.3.1`