### PR TITLE
chore: issue templates + Discussions routing

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,42 @@
+name: Bug report
+description: Report something that doesn't work as expected.
+title: "bug: <short description>"
+labels: ["bug"]
+body:
+  - type: input
+    id: version
+    attributes:
+      label: my-gather version
+      description: Output of `my-gather --version`.
+      placeholder: v0.3.1
+    validations:
+      required: true
+  - type: input
+    id: platform
+    attributes:
+      label: Platform
+      description: OS + architecture.
+      placeholder: darwin/arm64, linux/amd64, ...
+    validations:
+      required: true
+  - type: textarea
+    id: what_happened
+    attributes:
+      label: What happened?
+      description: What did you do, what did you see, what did you expect?
+      placeholder: |
+        Steps:
+        1. ran `my-gather -o /tmp/r.html /path/to/pt-stalk/`
+        2. ...
+
+        Expected:
+        Observed:
+    validations:
+      required: true
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional context
+      description: pt-stalk directory layout (`ls`), redacted log excerpts, screenshots, any diagnostic output.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Idea or open-ended discussion
+    url: https://github.com/matias-sanchez/My-gather/discussions/categories/ideas
+    about: For feature ideas, design questions, or anything you want feedback on before it becomes a ticket.
+  - name: Question or help wanted
+    url: https://github.com/matias-sanchez/My-gather/discussions/categories/q-a
+    about: Ask a question instead of filing an issue.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,26 @@
+name: Feature request
+description: Suggest a new collector, rule, chart, or UX improvement.
+title: "feat: <short description>"
+labels: ["enhancement"]
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem you're solving
+      description: What's painful today? What's missing?
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed solution
+      description: Rough sketch is fine — screenshots/mockups welcome.
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Anything you ruled out and why?
+    validations:
+      required: false


### PR DESCRIPTION
## Summary
- Enables GitHub Discussions on the repo (Ideas + Q&A categories).
- Adds `.github/ISSUE_TEMPLATE/config.yml` so the "New issue" page surfaces Discussions for ideas/questions and disables blank issues.
- Adds structured templates for bug reports and feature requests.

## Test plan
- [ ] After merge: click "New issue" on the repo — two templates listed, plus two Discussion links at the top.
- [ ] "Discussions" tab visible in the repo nav.