### PR TITLE
feat(findings): rule DSL v2 + 2 config rules + 1 time-series rule + Advisor goldens

### DIFF
--- a/findings/findings.go
+++ b/findings/findings.go
@@ -11,6 +11,7 @@ package findings
 
 import (
 	"sort"
+	"sync"
 
 	"github.com/matias-sanchez/My-gather/model"
 )
@@ -93,24 +94,22 @@ type Finding struct {
 	Source string
 }
 
-// init seals the registry by sorting it by ID immediately after every
-// per-file init() has appended its RuleDefinition entries. Go
-// guarantees per-file init() functions run before any other call into
-// the package, and the file-init ordering within a package is
-// dependency-respecting (and ultimately stable for a given source
-// tree); sorting here removes that dependency entirely so the
-// registry's iteration order is purely alphabetical by RuleDefinition.ID.
-func init() {
-	sortRegistry()
-}
+// registrySortOnce ensures the registry is sorted exactly once,
+// after every per-file init() has populated it. Go runs in-package
+// init()s in source-file alphabetical order, so any sort placed in a
+// findings.go-level init() would execute before files like
+// register.go and rules_*.go contribute their entries. Doing the
+// sort lazily on first Analyze() call sidesteps that ordering trap.
+var registrySortOnce sync.Once
 
 // Analyze runs every registered rule against the given Report and
 // returns the non-Skip findings in a deterministic order: by
 // Subsystem, then by descending Severity (Crit first), then by ID
 // alphabetically. Internally it iterates the package-level registry,
-// which is sorted by RuleDefinition.ID at init time so the dispatch
-// order is stable independent of source file or build order.
+// which is sorted by RuleDefinition.ID on first call so the dispatch
+// order is stable independent of source-file or build order.
 func Analyze(r *model.Report) []Finding {
+	registrySortOnce.Do(sortRegistry)
 	if r == nil {
 		return nil
 	}

--- a/findings/findings.go
+++ b/findings/findings.go
@@ -93,72 +93,30 @@ type Finding struct {
 	Source string
 }
 
-// rule is the unit of composition: a function that takes a Report and
-// returns one Finding (or Severity=Skip to opt out).
-type rule func(r *model.Report) Finding
-
-// allRules is the deterministically-ordered registry of analytical
-// rules. Ordering is by subsystem-group then by rule ID; the exact
-// order in this slice does not matter because Analyze sorts the
-// results. New rules just append here.
-var allRules = []rule{
-	// Buffer Pool
-	ruleBPHitRatio,
-	ruleBPUndersized,
-	ruleBPFreePagesLow,
-	ruleBPLRUFlushing,
-	ruleBPWaitFree,
-	ruleBPDirtyPct,
-	ruleInnoDBFlushing,
-
-	// Redo Log
-	ruleRedoCheckpointAge,
-	ruleRedoPendingWrites,
-	ruleRedoPendingFsyncs,
-	ruleRedoLogWaits,
-
-	// InnoDB Semaphores (contention detection)
-	ruleSemaphoreWaits,
-
-	// Binlog Cache
-	ruleBinlogCacheDiskUse,
-	ruleBinlogStmtCacheDiskUse,
-
-	// Thread Cache
-	ruleThreadCacheHitRatio,
-
-	// Table Open Cache
-	ruleTableCacheUsage,
-	ruleTableCacheOverflows,
-	ruleTableCacheMissRatio,
-
-	// Temp Tables
-	ruleTmpDiskRatio,
-
-	// Query shape
-	ruleFullScanSelectScan,
-	ruleFullScanSelectFullJoin,
-	ruleFullScanHandlerRndNext,
-	ruleProcesslistAbuse,
-
-	// Connections
-	ruleAbortedConnectsRate,
-	ruleConnectionsSaturation,
-
-	// Configuration
-	ruleSlowLogDisabled,
+// init seals the registry by sorting it by ID immediately after every
+// per-file init() has appended its RuleDefinition entries. Go
+// guarantees per-file init() functions run before any other call into
+// the package, and the file-init ordering within a package is
+// dependency-respecting (and ultimately stable for a given source
+// tree); sorting here removes that dependency entirely so the
+// registry's iteration order is purely alphabetical by RuleDefinition.ID.
+func init() {
+	sortRegistry()
 }
 
-// Analyze runs every rule against the given Report and returns the
-// non-Skip findings in a deterministic order: by Subsystem, then by
-// descending Severity (Crit first), then by ID alphabetically.
+// Analyze runs every registered rule against the given Report and
+// returns the non-Skip findings in a deterministic order: by
+// Subsystem, then by descending Severity (Crit first), then by ID
+// alphabetically. Internally it iterates the package-level registry,
+// which is sorted by RuleDefinition.ID at init time so the dispatch
+// order is stable independent of source file or build order.
 func Analyze(r *model.Report) []Finding {
 	if r == nil {
 		return nil
 	}
-	out := make([]Finding, 0, len(allRules))
-	for _, fn := range allRules {
-		f := fn(r)
+	out := make([]Finding, 0, len(registry))
+	for _, def := range registry {
+		f := def.Run(r)
 		if f.Severity == SeveritySkip {
 			continue
 		}

--- a/findings/findings_golden_test.go
+++ b/findings/findings_golden_test.go
@@ -1,0 +1,248 @@
+package findings_test
+
+import (
+	"context"
+	"encoding/json"
+	"math"
+	"path/filepath"
+	"sort"
+	"testing"
+	"time"
+
+	"github.com/matias-sanchez/My-gather/findings"
+	"github.com/matias-sanchez/My-gather/model"
+	"github.com/matias-sanchez/My-gather/parse"
+	"github.com/matias-sanchez/My-gather/tests/goldens"
+)
+
+// TestGoldenAdvisor is the Advisor-output golden: it runs the full
+// pipeline (parse.Discover -> findings.Analyze) against
+// testdata/example2/ and snapshot-compares the rendered Findings
+// against testdata/golden/findings.example2.json.
+//
+// The golden is a compact, sorted-by-ID JSON projection of the
+// Findings slice — only the metadata fields that matter for review
+// (ID, Subsystem, Title, Severity, FormulaText, recommendation count)
+// so the file stays small enough to read in code review and is
+// resilient to incidental wording changes inside Summary /
+// Explanation.
+func TestGoldenAdvisor(t *testing.T) {
+	root := goldens.RepoRoot(t)
+	fixtureDir := filepath.Join(root, "testdata", "example2")
+
+	c, err := parse.Discover(context.Background(), fixtureDir, parse.DiscoverOptions{})
+	if err != nil {
+		t.Fatalf("parse.Discover(%s): %v", fixtureDir, err)
+	}
+	if c == nil {
+		t.Fatalf("parse.Discover returned nil Collection")
+	}
+
+	report := buildReportForFindings(c)
+	got := findings.Analyze(report)
+
+	type goldenRow struct {
+		ID                 string `json:"id"`
+		Subsystem          string `json:"subsystem"`
+		Title              string `json:"title"`
+		Severity           string `json:"severity"`
+		FormulaText        string `json:"formula_text"`
+		RecommendationsLen int    `json:"recommendations_len"`
+	}
+	rows := make([]goldenRow, 0, len(got))
+	for _, f := range got {
+		rows = append(rows, goldenRow{
+			ID:                 f.ID,
+			Subsystem:          f.Subsystem,
+			Title:              f.Title,
+			Severity:           severityName(f.Severity),
+			FormulaText:        f.FormulaText,
+			RecommendationsLen: len(f.Recommendations),
+		})
+	}
+	sort.Slice(rows, func(i, j int) bool { return rows[i].ID < rows[j].ID })
+
+	body, err := json.MarshalIndent(rows, "", "  ")
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	body = append(body, '\n')
+
+	goldenPath := filepath.Join(root, "testdata", "golden", "findings.example2.json")
+	goldens.Compare(t, goldenPath, body)
+}
+
+// severityName maps findings.Severity to a stable lowercase string
+// for the golden JSON. The Severity int values are private-ish (an
+// enum with iota), so the textual mapping insulates the golden from
+// any future renumbering.
+func severityName(s findings.Severity) string {
+	switch s {
+	case findings.SeverityCrit:
+		return "crit"
+	case findings.SeverityWarn:
+		return "warn"
+	case findings.SeverityInfo:
+		return "info"
+	case findings.SeverityOK:
+		return "ok"
+	default:
+		return "unknown"
+	}
+}
+
+// buildReportForFindings constructs the slim *model.Report that
+// findings.Analyze actually reads (DBSection.Mysqladmin,
+// DBSection.InnoDBPerSnapshot, VariablesSection.PerSnapshot). It
+// mirrors the relevant pieces of render.buildReport without taking a
+// dependency on the unexported render internals: render's full
+// builder also computes Navigation, Environment, OSSection, and a
+// ReportID, none of which findings.Analyze touches.
+func buildReportForFindings(c *model.Collection) *model.Report {
+	rpt := &model.Report{Collection: c}
+
+	// VariablesSection: one entry per snapshot in capture order.
+	var vs model.VariablesSection
+	for _, s := range c.Snapshots {
+		entry := model.SnapshotVariables{
+			SnapshotPrefix: s.Prefix,
+			Timestamp:      s.Timestamp,
+		}
+		if sf := s.SourceFiles[model.SuffixVariables]; sf != nil {
+			if data, ok := sf.Parsed.(*model.VariablesData); ok {
+				entry.Data = data
+			}
+		}
+		vs.PerSnapshot = append(vs.PerSnapshot, entry)
+	}
+	rpt.VariablesSection = &vs
+
+	// DBSection: per-snapshot InnoDB scalars + concatenated mysqladmin.
+	dbs := &model.DBSection{}
+	for _, s := range c.Snapshots {
+		entry := model.SnapshotInnoDB{
+			SnapshotPrefix: s.Prefix,
+			Timestamp:      s.Timestamp,
+		}
+		if sf := s.SourceFiles[model.SuffixInnodbStatus]; sf != nil {
+			if data, ok := sf.Parsed.(*model.InnodbStatusData); ok {
+				entry.Data = data
+			}
+		}
+		dbs.InnoDBPerSnapshot = append(dbs.InnoDBPerSnapshot, entry)
+	}
+	dbs.Mysqladmin = mergeMysqladmin(c)
+	rpt.DBSection = dbs
+	return rpt
+}
+
+// mergeMysqladmin concatenates every parsed *MysqladminData from c
+// onto a single time axis with NaN padding at snapshot boundaries.
+// Mirrors render.concatMysqladmin's contract (FR-030):
+//
+//   - VariableNames is the union, sorted alphabetically.
+//   - IsCounter[v] is true if any input declared v as a counter.
+//   - Counter slots at each non-first boundary are NaN — cross-
+//     snapshot counter deltas are not meaningful.
+//   - SnapshotBoundaries records each input's starting index in the
+//     merged Timestamps slice.
+//
+// Returns nil when no mysqladmin data is present (matches render's
+// behaviour: no charts to render, but findings.Analyze must skip
+// rules that depend on mysqladmin gracefully).
+func mergeMysqladmin(c *model.Collection) *model.MysqladminData {
+	var inputs []*model.MysqladminData
+	for _, s := range c.Snapshots {
+		sf := s.SourceFiles[model.SuffixMysqladmin]
+		if sf == nil || sf.Parsed == nil {
+			continue
+		}
+		data, ok := sf.Parsed.(*model.MysqladminData)
+		if !ok || data == nil || data.SampleCount == 0 {
+			continue
+		}
+		inputs = append(inputs, data)
+	}
+	if len(inputs) == 0 {
+		return nil
+	}
+	if len(inputs) == 1 {
+		return inputs[0]
+	}
+
+	// Union of variable names, sorted.
+	nameSet := map[string]bool{}
+	for _, d := range inputs {
+		for _, n := range d.VariableNames {
+			nameSet[n] = true
+		}
+	}
+	names := make([]string, 0, len(nameSet))
+	for n := range nameSet {
+		names = append(names, n)
+	}
+	sort.Strings(names)
+
+	isCounter := make(map[string]bool, len(names))
+	for _, n := range names {
+		for _, d := range inputs {
+			if d.IsCounter[n] {
+				isCounter[n] = true
+				break
+			}
+		}
+	}
+
+	var (
+		timestamps []time.Time
+		boundaries = make([]int, 0, len(inputs))
+		cumulative int
+		deltas     = make(map[string][]float64, len(names))
+	)
+	for _, n := range names {
+		deltas[n] = make([]float64, 0)
+	}
+
+	for inputIdx, d := range inputs {
+		boundaries = append(boundaries, cumulative)
+		timestamps = append(timestamps, d.Timestamps...)
+		// First pass: copy only variables this input declares.
+		written := map[string]bool{}
+		for _, n := range d.VariableNames {
+			src, present := d.Deltas[n]
+			if !present {
+				continue
+			}
+			if inputIdx > 0 && isCounter[n] && len(src) > 0 {
+				deltas[n] = append(deltas[n], math.NaN())
+				deltas[n] = append(deltas[n], src[1:]...)
+			} else {
+				deltas[n] = append(deltas[n], src...)
+			}
+			written[n] = true
+		}
+		// Second pass: NaN-pad any variable in the union that this
+		// input did not carry, so every per-name slice stays length-
+		// aligned with the merged timestamp axis.
+		for _, n := range names {
+			if written[n] {
+				continue
+			}
+			pad := make([]float64, d.SampleCount)
+			for i := range pad {
+				pad[i] = math.NaN()
+			}
+			deltas[n] = append(deltas[n], pad...)
+		}
+		cumulative = len(timestamps)
+	}
+
+	return &model.MysqladminData{
+		VariableNames:      names,
+		SampleCount:        len(timestamps),
+		Timestamps:         timestamps,
+		Deltas:             deltas,
+		IsCounter:          isCounter,
+		SnapshotBoundaries: boundaries,
+	}
+}

--- a/findings/register.go
+++ b/findings/register.go
@@ -56,17 +56,18 @@ type RuleDefinition struct {
 	// registry metadata. It is the canonical title used by static
 	// rule listings (the rules catalogue), and it is also the value
 	// the registered Run function SHOULD return as Finding.Title.
-	// The quality harness enforces the match for native registrations
-	// (TestRuleQuality_RegistryMatchesEmittedFinding); legacy-adapter
-	// entries can diverge until they are migrated.
+	// Drift between this field and the rendered Finding.Title is
+	// not yet enforced by the quality harness; a future cross-check
+	// (driven by Registry()) will pin native registrations.
 	Title string
 
 	// FormulaText is the symbolic formula or threshold the rule
-	// applies. Must be non-empty (enforced by the quality test). It
-	// is the canonical text used by the rules catalogue and is the
-	// value the registered Run function SHOULD return as
-	// Finding.FormulaText; the quality harness enforces the match
-	// for native registrations.
+	// applies. Must be non-empty (enforced by TestRuleQuality_-
+	// MetadataIsComplete). It is the canonical text used by the
+	// rules catalogue and is the value the registered Run function
+	// SHOULD return as Finding.FormulaText; like Title, the
+	// per-Finding match is left to a future cross-check rather
+	// than enforced today.
 	FormulaText string
 
 	// MinRecommendations is the minimum number of remediation steps

--- a/findings/register.go
+++ b/findings/register.go
@@ -52,12 +52,21 @@ type RuleDefinition struct {
 	// strings handled by subsystemOrder for deterministic rendering.
 	Subsystem string
 
-	// Title is the short human-readable rule name; mirrors
-	// Finding.Title produced by Run.
+	// Title is the short human-readable rule name recorded in the
+	// registry metadata. It is the canonical title used by static
+	// rule listings (the rules catalogue), and it is also the value
+	// the registered Run function SHOULD return as Finding.Title.
+	// The quality harness enforces the match for native registrations
+	// (TestRuleQuality_RegistryMatchesEmittedFinding); legacy-adapter
+	// entries can diverge until they are migrated.
 	Title string
 
 	// FormulaText is the symbolic formula or threshold the rule
-	// applies. Must be non-empty (enforced by the quality test).
+	// applies. Must be non-empty (enforced by the quality test). It
+	// is the canonical text used by the rules catalogue and is the
+	// value the registered Run function SHOULD return as
+	// Finding.FormulaText; the quality harness enforces the match
+	// for native registrations.
 	FormulaText string
 
 	// MinRecommendations is the minimum number of remediation steps
@@ -79,8 +88,12 @@ type RuleDefinition struct {
 // registry is the deterministically-ordered registry of RuleDefinition
 // entries. Populated at package init by register() helpers in this
 // file and the per-subsystem files that register native rules. The
-// registry is sorted by ID immediately after init so iteration order
-// is stable across runs (Constitution Principle IV).
+// registry is sorted by ID lazily on the first Analyze() call via a
+// sync.Once in findings.go (registrySortOnce). Sorting at init time
+// would race per-file init order — the sort would run before all
+// registrations completed — so we defer to first-use; iteration
+// order is still stable across runs (Constitution Principle IV)
+// because every Analyze call sees the registry post-sort.
 //
 // Migration plan: as of this PR 5 of the 26 shipped rules are native
 // RuleDefinition entries; the remaining 21 are wrapped with
@@ -95,19 +108,33 @@ func register(d RuleDefinition) {
 	registry = append(registry, d)
 }
 
-// legacyAdapter wraps a free-floating rule function in a synthetic
-// RuleDefinition. The metadata (ID, Subsystem, Title, FormulaText,
-// MinRecommendations) is reconstructed by invoking the function on a
-// nil *model.Report and re-introspecting its first non-skip output —
-// since rule functions return SeveritySkip for nil reports, we instead
-// declare the metadata explicitly at the call site. The adapter is a
-// transitional bridge: every call site is removed in a subsequent PR
-// when the underlying rule is converted to a native RuleDefinition.
+// Registry returns a sorted-by-ID copy of the rule registry. Intended
+// for external observers (test harnesses, documentation generators)
+// that need to inspect rule metadata without mutating dispatch state.
+// Calling Registry primes the same lazy sort Analyze uses, so the
+// returned slice is in canonical order even on first call.
+func Registry() []RuleDefinition {
+	registrySortOnce.Do(sortRegistry)
+	out := make([]RuleDefinition, len(registry))
+	copy(out, registry)
+	return out
+}
+
+// legacyAdapter wraps a free-floating rule function in a
+// RuleDefinition using metadata supplied explicitly at the call
+// site. It does not invoke or introspect the wrapped function;
+// callers must provide the ID, Subsystem, Title, FormulaText,
+// Severity, and MinRecommendations for the resulting definition.
+// The adapter is a transitional bridge: each call site is removed
+// once the underlying rule is converted to a native RuleDefinition
+// in the per-subsystem file.
 //
-// The adapter is intentionally minimal: it does not provide
-// FormulaText (callers must supply it) — both because the quality
-// harness rejects empty FormulaText and because the symbolic formula
-// is already encoded inside each rule function's returned Finding.
+// The adapter is intentionally minimal: callers must supply
+// FormulaText, both because the quality harness rejects empty
+// FormulaText and because the symbolic formula is already encoded
+// in the Finding returned by each legacy rule function — declaring
+// it at the call site keeps the registry's rules catalogue aligned
+// with the per-Finding output even for not-yet-migrated rules.
 func legacyAdapter(id, subsystem, title, formulaText string, severity SeverityHint, minRecs int, fn func(*model.Report) Finding) RuleDefinition {
 	return RuleDefinition{
 		ID:                 id,

--- a/findings/register.go
+++ b/findings/register.go
@@ -1,0 +1,228 @@
+package findings
+
+import (
+	"sort"
+
+	"github.com/matias-sanchez/My-gather/model"
+)
+
+// SeverityHint classifies the expected severity bucket of a rule for
+// the rule-quality test harness. It is intentionally separate from the
+// dynamic Severity field of Finding: a single rule may evaluate to
+// SeverityCrit on one fixture and SeverityOK on another, but it has a
+// fixed worst-case severity that the harness can sanity-check against
+// (e.g. a CRITICAL-class rule must offer at least three remediation
+// recommendations).
+type SeverityHint int
+
+const (
+	// SeverityHintInfo: rule's worst case is informational.
+	SeverityHintInfo SeverityHint = iota
+
+	// SeverityHintWarning: rule's worst case is a warning.
+	SeverityHintWarning
+
+	// SeverityHintCritical: rule's worst case is critical.
+	SeverityHintCritical
+
+	// SeverityHintVariable: rule may produce CRIT, WARN or INFO
+	// depending on inputs. Treated as "could be critical" by the
+	// quality harness.
+	SeverityHintVariable
+)
+
+// RuleDefinition is the structured registration entry for one Advisor
+// rule. Each rule publishes its metadata (ID, Subsystem, Title,
+// FormulaText, severity hint, minimum remediation count) alongside a
+// Run function that produces the actual Finding from a *model.Report.
+//
+// The registry is the single source of dispatch: Analyze iterates the
+// sorted registry and never knows about individual rule functions.
+// New rules append a RuleDefinition entry; the legacy free-floating
+// rule functions are wrapped via legacyAdapter while their migration
+// to native RuleDefinition entries is in flight.
+type RuleDefinition struct {
+	// ID is a stable, dotted slug used for ordering, deduplication,
+	// and as the rendered Finding.ID. Example:
+	// "buffer_pool.dirty_pages_high".
+	ID string
+
+	// Subsystem is the human-readable group label rendered in the
+	// Advisor section (matches Finding.Subsystem). Must be one of the
+	// strings handled by subsystemOrder for deterministic rendering.
+	Subsystem string
+
+	// Title is the short human-readable rule name; mirrors
+	// Finding.Title produced by Run.
+	Title string
+
+	// FormulaText is the symbolic formula or threshold the rule
+	// applies. Must be non-empty (enforced by the quality test).
+	FormulaText string
+
+	// MinRecommendations is the minimum number of remediation steps
+	// the rule must produce when it fires non-OK. The quality harness
+	// requires CRITICAL-bucket rules to have at least 3 and INFO-only
+	// rules to have at least 1.
+	MinRecommendations int
+
+	// Severity is the expected worst-case severity bucket. See
+	// SeverityHint constants.
+	Severity SeverityHint
+
+	// Run computes the Finding for the supplied Report. It must
+	// return a Finding with Severity == SeveritySkip when the rule's
+	// inputs are missing or it has no signal to emit.
+	Run func(*model.Report) Finding
+}
+
+// registry is the deterministically-ordered registry of RuleDefinition
+// entries. Populated at package init by register() helpers in this
+// file and the per-subsystem files that register native rules. The
+// registry is sorted by ID immediately after init so iteration order
+// is stable across runs (Constitution Principle IV).
+//
+// Migration plan: as of this PR 5 of the 26 shipped rules are native
+// RuleDefinition entries; the remaining 21 are wrapped with
+// legacyAdapter so the registry is the only dispatch path while their
+// per-rule conversions ship one-by-one in follow-up PRs. Adapter is
+// deleted when the legacy count reaches 0.
+var registry []RuleDefinition
+
+// register appends a RuleDefinition to the package-level registry. It
+// is intended to be called from init() in the per-subsystem files.
+func register(d RuleDefinition) {
+	registry = append(registry, d)
+}
+
+// legacyAdapter wraps a free-floating rule function in a synthetic
+// RuleDefinition. The metadata (ID, Subsystem, Title, FormulaText,
+// MinRecommendations) is reconstructed by invoking the function on a
+// nil *model.Report and re-introspecting its first non-skip output —
+// since rule functions return SeveritySkip for nil reports, we instead
+// declare the metadata explicitly at the call site. The adapter is a
+// transitional bridge: every call site is removed in a subsequent PR
+// when the underlying rule is converted to a native RuleDefinition.
+//
+// The adapter is intentionally minimal: it does not provide
+// FormulaText (callers must supply it) — both because the quality
+// harness rejects empty FormulaText and because the symbolic formula
+// is already encoded inside each rule function's returned Finding.
+func legacyAdapter(id, subsystem, title, formulaText string, severity SeverityHint, minRecs int, fn func(*model.Report) Finding) RuleDefinition {
+	return RuleDefinition{
+		ID:                 id,
+		Subsystem:          subsystem,
+		Title:              title,
+		FormulaText:        formulaText,
+		MinRecommendations: minRecs,
+		Severity:           severity,
+		Run:                fn,
+	}
+}
+
+// init seeds the registry with the legacy rules that have not yet
+// been migrated to native RuleDefinition. Native registrations live in
+// the per-subsystem files (init() in each), so every rule has exactly
+// one declaration site.
+//
+// After every package init has run, sortRegistry() is called from
+// findings.go to enforce by-ID ordering once the registry is fully
+// populated.
+func init() {
+	// 21 of 26 rules ride through legacyAdapter while their native
+	// migrations are in flight — see the migration plan in the
+	// package-level registry comment above.
+	register(legacyAdapter(
+		"bp.undersized", "Buffer Pool", "Buffer pool size vs workload",
+		"innodb_buffer_pool_size  vs  {>=1 GiB warn floor, >=256 MiB crit floor}  (gated on Threads_connected >= 50 and Uptime >= 1h)",
+		SeverityHintVariable, 3, ruleBPUndersized))
+	register(legacyAdapter(
+		"bp.free_pages_low", "Buffer Pool", "Buffer pool free-page headroom",
+		"Innodb_buffer_pool_pages_free  vs  innodb_lru_scan_depth * innodb_buffer_pool_instances",
+		SeverityHintVariable, 3, ruleBPFreePagesLow))
+	register(legacyAdapter(
+		"bp.lru_flushing", "Buffer Pool", "LRU-list page flushing rate",
+		"Innodb_buffer_pool_pages_LRU_flushed/s",
+		SeverityHintVariable, 2, ruleBPLRUFlushing))
+	register(legacyAdapter(
+		"bp.wait_free", "Buffer Pool", "Buffer pool wait_free events",
+		"Innodb_buffer_pool_wait_free/s > 0",
+		SeverityHintCritical, 3, ruleBPWaitFree))
+	register(legacyAdapter(
+		"bp.dirty_pct", "Buffer Pool", "Buffer pool dirty-page percentage",
+		"Innodb_buffer_pool_pages_dirty / Innodb_buffer_pool_pages_total  vs  innodb_max_dirty_pages_pct",
+		SeverityHintVariable, 3, ruleBPDirtyPct))
+	register(legacyAdapter(
+		"redo.checkpoint_age", "Redo Log", "Redo checkpoint age",
+		"max(Innodb_checkpoint_age) / Innodb_checkpoint_max_age",
+		SeverityHintVariable, 3, ruleRedoCheckpointAge))
+	register(legacyAdapter(
+		"redo.pending_writes", "Redo Log", "Redo log pending writes",
+		"max(Innodb_os_log_pending_writes) > 0",
+		SeverityHintCritical, 3, ruleRedoPendingWrites))
+	register(legacyAdapter(
+		"redo.pending_fsyncs", "Redo Log", "Redo log pending fsyncs",
+		"max(Innodb_os_log_pending_fsyncs) > 0",
+		SeverityHintCritical, 3, ruleRedoPendingFsyncs))
+	register(legacyAdapter(
+		"redo.log_waits", "Redo Log", "Redo log buffer waits",
+		"Innodb_log_waits/s > 0",
+		SeverityHintVariable, 3, ruleRedoLogWaits))
+	register(legacyAdapter(
+		"binlog.cache_disk_use", "Binlog Cache", "Binlog cache spilled to disk",
+		"Binlog_cache_disk_use/s > 0",
+		SeverityHintVariable, 1, ruleBinlogCacheDiskUse))
+	register(legacyAdapter(
+		"binlog.stmt_cache_disk_use", "Binlog Cache", "Statement-binlog cache spilled to disk",
+		"Binlog_stmt_cache_disk_use/s > 0",
+		SeverityHintVariable, 1, ruleBinlogStmtCacheDiskUse))
+	register(legacyAdapter(
+		"threadcache.hit_ratio", "Thread Cache", "Thread cache hit ratio",
+		"1 - Threads_created / Connections",
+		SeverityHintVariable, 1, ruleThreadCacheHitRatio))
+	register(legacyAdapter(
+		"tablecache.usage", "Table Open Cache", "Open-tables vs table_open_cache",
+		"Open_tables / table_open_cache",
+		SeverityHintVariable, 2, ruleTableCacheUsage))
+	register(legacyAdapter(
+		"tablecache.overflows", "Table Open Cache", "Table cache overflows rate",
+		"Table_open_cache_overflows/s",
+		SeverityHintVariable, 1, ruleTableCacheOverflows))
+	register(legacyAdapter(
+		"tablecache.miss_ratio", "Table Open Cache", "Table cache miss ratio",
+		"misses / (hits + misses)",
+		SeverityHintVariable, 1, ruleTableCacheMissRatio))
+	register(legacyAdapter(
+		"tmp.disk_ratio", "Temp Tables", "Temp tables spilling to disk",
+		"Created_tmp_disk_tables / Created_tmp_tables",
+		SeverityHintVariable, 1, ruleTmpDiskRatio))
+	register(legacyAdapter(
+		"queryshape.select_full_join", "Query Shape", "Joins without usable indexes",
+		"Select_full_join/s > 0",
+		SeverityHintVariable, 1, ruleFullScanSelectFullJoin))
+	register(legacyAdapter(
+		"queryshape.handler_read_rnd_next", "Query Shape", "Sequential row reads (Handler_read_rnd_next)",
+		"Handler_read_rnd_next/s  AND  Handler_read_rnd_next / Com_select",
+		SeverityHintVariable, 1, ruleFullScanHandlerRndNext))
+	register(legacyAdapter(
+		"queryshape.is_processlist", "Query Shape", "information_schema.processlist abuse",
+		"Deprecated_use_i_s_processlist_count/s > 0",
+		SeverityHintVariable, 1, ruleProcesslistAbuse))
+	register(legacyAdapter(
+		"connections.aborted_rate", "Connections", "Aborted connections rate",
+		"Aborted_connects/s",
+		SeverityHintVariable, 1, ruleAbortedConnectsRate))
+	register(legacyAdapter(
+		"connections.saturation", "Connections", "Connection slot saturation",
+		"Threads_connected / max_connections",
+		SeverityHintVariable, 3, ruleConnectionsSaturation))
+}
+
+// sortRegistry sorts the registry by RuleDefinition.ID. Called from
+// the package-level init in findings.go after every per-file init has
+// populated the registry.
+func sortRegistry() {
+	sort.SliceStable(registry, func(i, j int) bool {
+		return registry[i].ID < registry[j].ID
+	})
+}

--- a/findings/rules_bufferpool.go
+++ b/findings/rules_bufferpool.go
@@ -334,3 +334,18 @@ func ruleBPDirtyPct(r *model.Report) Finding {
 		Source: "Rosetta Stone — Buffer Pool §Saturation (capacity), Part B Innodb_buffer_pool_pages_dirty",
 	}
 }
+
+// init registers the native RuleDefinition for ruleBPHitRatio. The
+// other Buffer Pool rules in this file remain wrapped via
+// legacyAdapter in register.go until their per-rule conversions land.
+func init() {
+	register(RuleDefinition{
+		ID:                 "bp.hit_ratio",
+		Subsystem:          "Buffer Pool",
+		Title:              "Buffer pool hit ratio",
+		FormulaText:        "hit_ratio = 1 − Innodb_buffer_pool_reads / Innodb_buffer_pool_read_requests",
+		MinRecommendations: 3,
+		Severity:           SeverityHintVariable,
+		Run:                ruleBPHitRatio,
+	})
+}

--- a/findings/rules_config.go
+++ b/findings/rules_config.go
@@ -51,3 +51,16 @@ func ruleSlowLogDisabled(r *model.Report) Finding {
 		Source: "Rosetta Stone — Part B slow_query_log",
 	}
 }
+
+// init registers ruleSlowLogDisabled as a native RuleDefinition.
+func init() {
+	register(RuleDefinition{
+		ID:                 "config.slow_log_disabled",
+		Subsystem:          "Configuration",
+		Title:              "Slow query log is disabled",
+		FormulaText:        "slow_query_log = OFF  AND  Questions/s > 0",
+		MinRecommendations: 3,
+		Severity:           SeverityHintWarning,
+		Run:                ruleSlowLogDisabled,
+	})
+}

--- a/findings/rules_config_max_connections.go
+++ b/findings/rules_config_max_connections.go
@@ -232,9 +232,10 @@ func ruleConfigSyncBinlogNotOne(r *model.Report) Finding {
 // If gtid_mode is absent or OFF, the rule conservatively returns
 // false even when binlog_format is set; the worst-case is missing a
 // CRIT escalation on a classic file-position replica, which the WARN
-// branch still surfaces. The previous looser implementation
-// (binlog_format != "" was sufficient) misclassified standalone 8.0
-// servers as replicas — flagged by Codex on PR #32 round 1.
+// branch still surfaces. A looser earlier draft treated any non-empty
+// binlog_format as evidence of replication, which misclassified every
+// standalone 8.0 instance (binlog_format=ROW is the default) as a
+// replica.
 func isReplicationConfigured(r *model.Report) bool {
 	serverID, ok := variableFloat(r, "server_id")
 	if !ok || serverID == 0 {

--- a/findings/rules_config_max_connections.go
+++ b/findings/rules_config_max_connections.go
@@ -1,0 +1,256 @@
+package findings
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/matias-sanchez/My-gather/model"
+)
+
+// ruleConfigMaxConnectionsHigh flags `max_connections` settings that
+// are large enough to be a foot-gun on under-sized hosts. A high
+// max_connections is not a problem on its own — it only becomes one
+// when the buffer pool is small (per-thread overhead can outweigh
+// pool memory) or when concurrent runners spike.
+//
+// Trip conditions:
+//
+//	max_connections > 5000
+//	  AND innodb_buffer_pool_size < 1 GiB per 1000 max_connections
+//	  → WARN
+//
+//	max_connections > 5000
+//	  AND innodb_buffer_pool_size < 256 MiB per 1000 max_connections
+//	  → CRIT
+//
+// Per-thread overhead (sort_buffer, join_buffer, thread stack) is the
+// usual 4-12 MiB ballpark, so a 1 GiB-per-1000 floor keeps the host
+// from running out of memory under any plausible concurrency surge.
+func ruleConfigMaxConnectionsHigh(r *model.Report) Finding {
+	const (
+		threshold     = 5000.0
+		bytesPer1000W = 1024.0 * 1024.0 * 1024.0 // 1 GiB / 1k connections
+		bytesPer1000C = 256.0 * 1024.0 * 1024.0  // 256 MiB / 1k connections
+	)
+	maxConns, ok := variableFloat(r, "max_connections")
+	if !ok || maxConns <= threshold {
+		return Finding{Severity: SeveritySkip}
+	}
+	bpSize, ok := variableFloat(r, "innodb_buffer_pool_size")
+	if !ok || bpSize <= 0 {
+		return Finding{Severity: SeveritySkip}
+	}
+	perThousand := bpSize / (maxConns / 1000)
+
+	sev := SeverityOK
+	summary := fmt.Sprintf("max_connections = %s with %s per 1k slots — within the 1 GiB-per-1k headroom band.",
+		formatNum(maxConns), humanBytes(perThousand))
+	switch {
+	case perThousand < bytesPer1000C:
+		sev = SeverityCrit
+		summary = fmt.Sprintf("max_connections = %s but innodb_buffer_pool_size is only %s (%s per 1k slots) — concurrent thread overhead will starve the pool under load.",
+			formatNum(maxConns), humanBytes(bpSize), humanBytes(perThousand))
+	case perThousand < bytesPer1000W:
+		sev = SeverityWarn
+		summary = fmt.Sprintf("max_connections = %s with %s buffer pool — that's only %s per 1k slots, well below the 1 GiB headroom guideline.",
+			formatNum(maxConns), humanBytes(bpSize), humanBytes(perThousand))
+	}
+	threadsRunning, hasRun := gaugeMax(r, "Threads_running")
+	metrics := []MetricRef{
+		{Name: "max_connections", Value: maxConns, Unit: "count"},
+		{Name: "innodb_buffer_pool_size", Value: bpSize, Unit: "bytes"},
+		{Name: "buffer pool / 1k slots", Value: perThousand, Unit: "bytes"},
+	}
+	if hasRun {
+		metrics = append(metrics, MetricRef{Name: "Threads_running (max)", Value: threadsRunning, Unit: "count"})
+	}
+	return Finding{
+		ID:        "config.max_connections_high",
+		Subsystem: "Configuration",
+		Title:     "max_connections vs buffer pool sizing",
+		Severity:  sev,
+		Summary:   summary,
+		Explanation: "max_connections caps the number of concurrent threads MySQL will accept. Each open thread reserves stack, " +
+			"sort_buffer, join_buffer and other per-session memory before it ever runs a query. When max_connections is large " +
+			"and the buffer pool is small, a connection burst can either OOM the host or starve the pool of headroom for hot " +
+			"data. The 1 GiB-per-1000-slots heuristic leaves room for ~4-12 MiB per thread plus stable buffer-pool capacity.",
+		FormulaText: "max_connections > 5000  AND  innodb_buffer_pool_size / (max_connections / 1000) < {1 GiB warn, 256 MiB crit}",
+		FormulaComputed: fmt.Sprintf("max_connections=%s, innodb_buffer_pool_size=%s, ratio=%s/1k",
+			formatNum(maxConns), humanBytes(bpSize), humanBytes(perThousand)),
+		Metrics: metrics,
+		Recommendations: []string{
+			"Lower max_connections to a value that reflects real concurrency (typical OLTP fleets sit at 200-2000).",
+			"If the application genuinely needs thousands of pooled connections, place a proxy (ProxySQL, MySQL Router) in front so the server only sees actual runners.",
+			"Raise innodb_buffer_pool_size so the pool retains at least 1 GiB of headroom per 1000 max_connections after per-thread allocations.",
+		},
+		Source: "Rosetta Stone — Connections (capacity vs concurrency)",
+	}
+}
+
+// ruleConfigSyncBinlogNotOne flags durability-relevant settings of
+// `sync_binlog` that drift from the canonical safe value of 1.
+//
+// Trip conditions:
+//
+//	sync_binlog == 0  AND replication is configured  → CRIT
+//	sync_binlog == 0  (no replication / unknown)     → WARN
+//	sync_binlog > 1                                  → WARN (durability concern under crash)
+//	log_bin = OFF                                    → INFO (binlog disabled — different scenario)
+//
+// "Replication is configured" is detected via `server_id != 0` AND
+// (`gtid_mode != OFF` OR a non-empty `binlog_format`); both are
+// captured in pt-stalk's variables snapshot. False negatives are
+// safer than false positives: the WARN tier still flags a mis-set
+// sync_binlog independently.
+func ruleConfigSyncBinlogNotOne(r *model.Report) Finding {
+	logBinRaw, hasLogBin := variableRaw(r, "log_bin")
+	if hasLogBin {
+		logBin := strings.ToUpper(strings.TrimSpace(logBinRaw))
+		if logBin == "OFF" || logBin == "0" {
+			return Finding{
+				ID:        "config.sync_binlog_not_one",
+				Subsystem: "Configuration",
+				Title:     "Binary logging is disabled",
+				Severity:  SeverityInfo,
+				Summary:   "log_bin = OFF — binary logging is disabled; sync_binlog has no effect on this server.",
+				Explanation: "With log_bin = OFF the server does not record write events to a binary log, so neither replication " +
+					"nor point-in-time recovery is possible from this instance. This may be intentional for a read replica " +
+					"with semi-sync disabled or a development host, but is otherwise a serious recoverability gap.",
+				FormulaText:     "log_bin = OFF",
+				FormulaComputed: "log_bin = " + logBinRaw,
+				Metrics: []MetricRef{
+					{Name: "log_bin", Value: 0, Unit: "bool", Note: "raw: " + logBinRaw},
+				},
+				Recommendations: []string{
+					"If this is a primary or a server that may ever be promoted, enable log_bin and pick a sensible binlog retention.",
+				},
+				Source: "Rosetta Stone — Configuration §Binlog (durability)",
+			}
+		}
+	}
+
+	syncBL, ok := variableFloat(r, "sync_binlog")
+	if !ok {
+		return Finding{Severity: SeveritySkip}
+	}
+	if syncBL == 1 {
+		return Finding{Severity: SeveritySkip}
+	}
+
+	replicationLikely := isReplicationConfigured(r)
+
+	switch {
+	case syncBL == 0 && replicationLikely:
+		return Finding{
+			ID:        "config.sync_binlog_not_one",
+			Subsystem: "Configuration",
+			Title:     "sync_binlog disabled with replication configured",
+			Severity:  SeverityCrit,
+			Summary:   "sync_binlog = 0 on a replication-configured server — a crash can lose binlog events that have already been streamed to replicas.",
+			Explanation: "sync_binlog = 0 means the server never fsync()s the binary log; it is flushed only when the OS decides. " +
+				"On a primary serving replicas, a crash can leave replicas with events that no longer exist on the primary's disk, " +
+				"breaking replication and risking data loss. The canonical safe value on any replication-active primary is 1.",
+			FormulaText:     "sync_binlog = 0  AND  (server_id != 0  AND  binlog/gtid configured)",
+			FormulaComputed: fmt.Sprintf("sync_binlog = %s, replication_configured = true", formatNum(syncBL)),
+			Metrics: []MetricRef{
+				{Name: "sync_binlog", Value: syncBL, Unit: "count"},
+			},
+			Recommendations: []string{
+				"Set sync_binlog = 1 on the primary so every group commit fsyncs the binary log.",
+				"Pair with innodb_flush_log_at_trx_commit = 1 for full ACID durability.",
+				"If write throughput drops unacceptably, batch with binlog_group_commit_sync_delay before relaxing sync_binlog.",
+			},
+			Source: "Rosetta Stone — Configuration §Binlog (durability)",
+		}
+	case syncBL == 0:
+		return Finding{
+			ID:        "config.sync_binlog_not_one",
+			Subsystem: "Configuration",
+			Title:     "sync_binlog is 0",
+			Severity:  SeverityWarn,
+			Summary:   "sync_binlog = 0 — binary log is never fsync'd; a server crash can lose binlog events.",
+			Explanation: "Even without replication, sync_binlog = 0 makes the binary log unreliable for point-in-time recovery: " +
+				"after a crash, the on-disk binlog may not contain the last group of committed transactions.",
+			FormulaText:     "sync_binlog = 0",
+			FormulaComputed: fmt.Sprintf("sync_binlog = %s", formatNum(syncBL)),
+			Metrics: []MetricRef{
+				{Name: "sync_binlog", Value: syncBL, Unit: "count"},
+			},
+			Recommendations: []string{
+				"Set sync_binlog = 1 unless you have explicitly accepted the recoverability gap.",
+				"Verify your backup / PITR strategy does not depend on the binary log if you keep sync_binlog = 0.",
+				"Document the deviation in the server's runbook so the next operator knows the trade-off.",
+			},
+			Source: "Rosetta Stone — Configuration §Binlog (durability)",
+		}
+	default:
+		// sync_binlog > 1: writes fsync every Nth commit, durability gap of N transactions on crash.
+		return Finding{
+			ID:        "config.sync_binlog_not_one",
+			Subsystem: "Configuration",
+			Title:     "sync_binlog > 1",
+			Severity:  SeverityWarn,
+			Summary:   fmt.Sprintf("sync_binlog = %s — up to %s transactions can be lost on crash.", formatNum(syncBL), formatNum(syncBL-1)),
+			Explanation: "sync_binlog > 1 fsyncs the binary log only every Nth group commit. On a crash the most recent N-1 " +
+				"transactions may be missing from the binlog, breaking PITR and (on a primary) potentially making replicas " +
+				"diverge. The safe value is 1.",
+			FormulaText:     "sync_binlog > 1",
+			FormulaComputed: fmt.Sprintf("sync_binlog = %s", formatNum(syncBL)),
+			Metrics: []MetricRef{
+				{Name: "sync_binlog", Value: syncBL, Unit: "count"},
+			},
+			Recommendations: []string{
+				"Set sync_binlog = 1 for full durability.",
+				"If write throughput is the concern, use binlog_group_commit_sync_delay (microseconds) — it batches without losing fsync semantics.",
+				"Re-evaluate hardware: a healthy NVMe should sustain sync_binlog = 1 well past 10k commits/s.",
+			},
+			Source: "Rosetta Stone — Configuration §Binlog (durability)",
+		}
+	}
+}
+
+// isReplicationConfigured reports whether the captured variables
+// suggest the server is part of a replication topology. The detector
+// is intentionally conservative — both server_id != 0 AND a binlog/
+// GTID indicator must be present — so the CRIT escalation in
+// ruleConfigSyncBinlogNotOne does not fire on standalone servers.
+func isReplicationConfigured(r *model.Report) bool {
+	serverID, ok := variableFloat(r, "server_id")
+	if !ok || serverID == 0 {
+		return false
+	}
+	if g, ok := variableRaw(r, "gtid_mode"); ok {
+		if v := strings.ToUpper(strings.TrimSpace(g)); v != "" && v != "OFF" {
+			return true
+		}
+	}
+	if f, ok := variableRaw(r, "binlog_format"); ok {
+		if strings.TrimSpace(f) != "" {
+			return true
+		}
+	}
+	return false
+}
+
+// init registers the two new configuration rules added in this PR.
+func init() {
+	register(RuleDefinition{
+		ID:                 "config.max_connections_high",
+		Subsystem:          "Configuration",
+		Title:              "max_connections vs buffer pool sizing",
+		FormulaText:        "max_connections > 5000  AND  innodb_buffer_pool_size / (max_connections/1000) < {1 GiB warn, 256 MiB crit}",
+		MinRecommendations: 3,
+		Severity:           SeverityHintVariable,
+		Run:                ruleConfigMaxConnectionsHigh,
+	})
+	register(RuleDefinition{
+		ID:                 "config.sync_binlog_not_one",
+		Subsystem:          "Configuration",
+		Title:              "sync_binlog vs replication durability",
+		FormulaText:        "sync_binlog != 1  (CRIT if replication; INFO if log_bin=OFF; WARN otherwise)",
+		MinRecommendations: 3,
+		Severity:           SeverityHintVariable,
+		Run:                ruleConfigSyncBinlogNotOne,
+	})
+}
+

--- a/findings/rules_config_max_connections.go
+++ b/findings/rules_config_max_connections.go
@@ -98,10 +98,9 @@ func ruleConfigMaxConnectionsHigh(r *model.Report) Finding {
 //	log_bin = OFF                                    → INFO (binlog disabled — different scenario)
 //
 // "Replication is configured" is detected via `server_id != 0` AND
-// (`gtid_mode != OFF` OR a non-empty `binlog_format`); both are
-// captured in pt-stalk's variables snapshot. False negatives are
-// safer than false positives: the WARN tier still flags a mis-set
-// sync_binlog independently.
+// `gtid_mode != OFF`; see isReplicationConfigured for rationale.
+// False negatives are safer than false positives: the WARN tier
+// still flags a mis-set sync_binlog independently.
 func ruleConfigSyncBinlogNotOne(r *model.Report) Finding {
 	logBinRaw, hasLogBin := variableRaw(r, "log_bin")
 	if hasLogBin {

--- a/findings/rules_config_max_connections.go
+++ b/findings/rules_config_max_connections.go
@@ -122,7 +122,9 @@ func ruleConfigSyncBinlogNotOne(r *model.Report) Finding {
 					{Name: "log_bin", Value: 0, Unit: "bool", Note: "raw: " + logBinRaw},
 				},
 				Recommendations: []string{
-					"If this is a primary or a server that may ever be promoted, enable log_bin and pick a sensible binlog retention.",
+					"If this is a primary or a server that may ever be promoted, enable log_bin and pick a sensible binlog retention (binlog_expire_logs_seconds, typically 3-7 days).",
+					"Confirm an external mechanism exists for point-in-time recovery: physical backups + binlog replay is the canonical MySQL PITR path, so without log_bin you must have a substitute (e.g. xtrabackup with frequent incrementals, or a logical replica that does have binlog enabled).",
+					"Document log_bin = OFF in the runbook so future operators know that promoting this instance to primary without first enabling binlog would orphan replicas and prevent PITR for transactions issued before the change.",
 				},
 				Source: "Rosetta Stone — Configuration §Binlog (durability)",
 			}

--- a/findings/rules_config_max_connections.go
+++ b/findings/rules_config_max_connections.go
@@ -210,26 +210,42 @@ func ruleConfigSyncBinlogNotOne(r *model.Report) Finding {
 }
 
 // isReplicationConfigured reports whether the captured variables
-// suggest the server is part of a replication topology. The detector
-// is intentionally conservative — both server_id != 0 AND a binlog/
-// GTID indicator must be present — so the CRIT escalation in
-// ruleConfigSyncBinlogNotOne does not fire on standalone servers.
+// suggest the server is actively participating in a replication
+// topology, not merely capable of it. The detector is intentionally
+// conservative because the only consumer (ruleConfigSyncBinlogNotOne)
+// uses it to escalate sync_binlog=0 from WARN to CRIT — a false
+// positive there overstates risk on standalone servers.
+//
+// Signals (all must hold):
+//
+//  1. server_id != 0 — the legacy non-replica default is 0; any
+//     non-zero value means the operator has assigned an identity.
+//     Necessary but not sufficient: MySQL 8.0+ ships server_id=1 by
+//     default since 8.0.3, so this alone catches every fresh install.
+//
+//  2. gtid_mode is set and not "OFF" — strongest signal. MySQL only
+//     reports gtid_mode when binlog is on AND the operator opted into
+//     GTID, which is the modern source-of-truth for replication.
+//     binlog_format alone (which defaults to ROW since 8.0.22) is NOT
+//     enough — every standalone 8.0 instance has binlog_format=ROW.
+//
+// If gtid_mode is absent or OFF, the rule conservatively returns
+// false even when binlog_format is set; the worst-case is missing a
+// CRIT escalation on a classic file-position replica, which the WARN
+// branch still surfaces. The previous looser implementation
+// (binlog_format != "" was sufficient) misclassified standalone 8.0
+// servers as replicas — flagged by Codex on PR #32 round 1.
 func isReplicationConfigured(r *model.Report) bool {
 	serverID, ok := variableFloat(r, "server_id")
 	if !ok || serverID == 0 {
 		return false
 	}
-	if g, ok := variableRaw(r, "gtid_mode"); ok {
-		if v := strings.ToUpper(strings.TrimSpace(g)); v != "" && v != "OFF" {
-			return true
-		}
+	g, ok := variableRaw(r, "gtid_mode")
+	if !ok {
+		return false
 	}
-	if f, ok := variableRaw(r, "binlog_format"); ok {
-		if strings.TrimSpace(f) != "" {
-			return true
-		}
-	}
-	return false
+	v := strings.ToUpper(strings.TrimSpace(g))
+	return v != "" && v != "OFF"
 }
 
 // init registers the two new configuration rules added in this PR.

--- a/findings/rules_config_max_connections.go
+++ b/findings/rules_config_max_connections.go
@@ -253,4 +253,3 @@ func init() {
 		Run:                ruleConfigSyncBinlogNotOne,
 	})
 }
-

--- a/findings/rules_config_max_connections_test.go
+++ b/findings/rules_config_max_connections_test.go
@@ -1,0 +1,125 @@
+package findings
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestConfigMaxConnectionsHigh(t *testing.T) {
+	cases := []struct {
+		name     string
+		maxConns string
+		bpBytes  string
+		wantSev  Severity
+		wantSubs string
+	}{
+		// Below threshold: skipped.
+		{"below_threshold", "1000", "8589934592" /*8 GiB*/, SeveritySkip, ""},
+		// Big pool, big max_connections: OK.
+		{"ok_big_pool", "10000", "21474836480" /*20 GiB*/, SeverityOK, "within"},
+		// 6000 connections + 2 GiB pool: 333 MiB / 1k slots → WARN band (< 1 GiB but > 256 MiB).
+		{"warn_under_1gib_per_1k", "6000", "2147483648" /*2 GiB*/, SeverityWarn, "below the 1 GiB"},
+		// 10000 connections + 1 GiB pool: 100 MiB / 1k slots → CRIT band (< 256 MiB).
+		{"crit_under_256mib_per_1k", "10000", "1073741824" /*1 GiB*/, SeverityCrit, "starve the pool"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			b := newBuilder().
+				variable("max_connections", tc.maxConns).
+				variable("innodb_buffer_pool_size", tc.bpBytes)
+			got := Analyze(b.build())
+			f := findByID(got, "config.max_connections_high")
+			if tc.wantSev == SeveritySkip {
+				if f != nil {
+					t.Fatalf("expected skip, got %+v", f)
+				}
+				return
+			}
+			if f == nil {
+				t.Fatalf("config.max_connections_high not present")
+			}
+			if f.Severity != tc.wantSev {
+				t.Errorf("severity: got %v, want %v (summary: %q)", f.Severity, tc.wantSev, f.Summary)
+			}
+			if tc.wantSubs != "" && !strings.Contains(f.Summary, tc.wantSubs) {
+				t.Errorf("summary %q missing %q", f.Summary, tc.wantSubs)
+			}
+		})
+	}
+}
+
+func TestConfigMaxConnectionsHigh_SkipsWhenBPMissing(t *testing.T) {
+	// 6000 max_connections but no innodb_buffer_pool_size variable
+	// captured: rule should skip rather than fire on partial data.
+	b := newBuilder().variable("max_connections", "6000")
+	if findByID(Analyze(b.build()), "config.max_connections_high") != nil {
+		t.Fatal("expected skip when innodb_buffer_pool_size is absent")
+	}
+}
+
+func TestConfigSyncBinlogNotOne(t *testing.T) {
+	t.Run("skip_when_safe", func(t *testing.T) {
+		b := newBuilder().
+			variable("log_bin", "ON").
+			variable("sync_binlog", "1")
+		if findByID(Analyze(b.build()), "config.sync_binlog_not_one") != nil {
+			t.Fatal("expected skip when sync_binlog=1")
+		}
+	})
+
+	t.Run("info_when_log_bin_off", func(t *testing.T) {
+		b := newBuilder().
+			variable("log_bin", "OFF").
+			variable("sync_binlog", "0")
+		f := findByID(Analyze(b.build()), "config.sync_binlog_not_one")
+		if f == nil || f.Severity != SeverityInfo {
+			t.Fatalf("expected Info when log_bin=OFF, got %+v", f)
+		}
+		if !strings.Contains(f.Summary, "log_bin = OFF") {
+			t.Errorf("summary should mention log_bin: %q", f.Summary)
+		}
+	})
+
+	t.Run("warn_when_zero_no_replication", func(t *testing.T) {
+		b := newBuilder().
+			variable("log_bin", "ON").
+			variable("sync_binlog", "0").
+			variable("server_id", "0") // no replication
+		f := findByID(Analyze(b.build()), "config.sync_binlog_not_one")
+		if f == nil || f.Severity != SeverityWarn {
+			t.Fatalf("expected Warn for sync_binlog=0 standalone, got %+v", f)
+		}
+	})
+
+	t.Run("crit_when_zero_with_replication", func(t *testing.T) {
+		b := newBuilder().
+			variable("log_bin", "ON").
+			variable("sync_binlog", "0").
+			variable("server_id", "1").
+			variable("gtid_mode", "ON")
+		f := findByID(Analyze(b.build()), "config.sync_binlog_not_one")
+		if f == nil || f.Severity != SeverityCrit {
+			t.Fatalf("expected Crit when replication is configured, got %+v", f)
+		}
+	})
+
+	t.Run("warn_when_greater_than_one", func(t *testing.T) {
+		b := newBuilder().
+			variable("log_bin", "ON").
+			variable("sync_binlog", "100")
+		f := findByID(Analyze(b.build()), "config.sync_binlog_not_one")
+		if f == nil || f.Severity != SeverityWarn {
+			t.Fatalf("expected Warn for sync_binlog=100, got %+v", f)
+		}
+		if !strings.Contains(f.Summary, "100") {
+			t.Errorf("summary should mention the value: %q", f.Summary)
+		}
+	})
+
+	t.Run("skip_when_variable_absent", func(t *testing.T) {
+		b := newBuilder() // no variables at all
+		if findByID(Analyze(b.build()), "config.sync_binlog_not_one") != nil {
+			t.Fatal("expected skip when sync_binlog absent and log_bin absent")
+		}
+	})
+}

--- a/findings/rules_flushing.go
+++ b/findings/rules_flushing.go
@@ -193,8 +193,8 @@ func init() {
 	register(RuleDefinition{
 		ID:                 "innodb.flushing",
 		Subsystem:          "Buffer Pool",
-		Title:              "InnoDB page-flushing back-pressure",
-		FormulaText:        "any of (PendingWritesSinglePage>0, PendingFsyncLog>0, PendingWritesFlushList>0, PendingWritesLRU>0, PendingFsyncBufferPool>0)",
+		Title:              "InnoDB flushing pressure",
+		FormulaText:        "any of {singlePage, fsyncLog, LRU, flushList, fsyncBP} > 0",
 		MinRecommendations: 3,
 		Severity:           SeverityHintVariable,
 		Run:                ruleInnoDBFlushing,

--- a/findings/rules_flushing.go
+++ b/findings/rules_flushing.go
@@ -187,3 +187,16 @@ func ruleInnoDBFlushing(r *model.Report) Finding {
 		Source:          "Rosetta Stone — Buffer Pool §Saturation (flushing), Redo Log §Saturation (fsync)",
 	}
 }
+
+// init registers ruleInnoDBFlushing as a native RuleDefinition.
+func init() {
+	register(RuleDefinition{
+		ID:                 "innodb.flushing",
+		Subsystem:          "Buffer Pool",
+		Title:              "InnoDB page-flushing back-pressure",
+		FormulaText:        "any of (PendingWritesSinglePage>0, PendingFsyncLog>0, PendingWritesFlushList>0, PendingWritesLRU>0, PendingFsyncBufferPool>0)",
+		MinRecommendations: 3,
+		Severity:           SeverityHintVariable,
+		Run:                ruleInnoDBFlushing,
+	})
+}

--- a/findings/rules_quality_test.go
+++ b/findings/rules_quality_test.go
@@ -104,23 +104,21 @@ func TestRuleQuality_CritRulesHaveEnoughRecommendations(t *testing.T) {
 	}
 }
 
-// TestRuleQuality_FindingHonorsMinRecommendations asserts that when a
-// rule fires non-skip on a fixture, the rendered Finding actually
-// carries at least the declared MinRecommendations. Run() against a
-// nil report returns SeveritySkip for every rule, so this scan is a
-// best-effort sanity check on the declared metadata; per-rule fixture
-// tests in findings_test.go are still the authoritative coverage.
-func TestRuleQuality_FindingHonorsMinRecommendations(t *testing.T) {
+// TestRuleQuality_RunIsNonNilForNatives is a transitional sanity
+// check for native RuleDefinition entries: it confirms that each
+// declared native rule has a non-nil Run pointer (also covered by
+// MetadataIsComplete; this test scaffolds a future migration of the
+// per-Finding cross-check that lives in
+// findings_quality_runtime_test.go in the findings_test external
+// package, where it can use the same fixture-loading pattern as the
+// golden test).
+//
+// Migration plan: as native rules are added or moved to native
+// registration, append their ID to nativeRuleIDs there; the
+// runtime cross-check then exercises them on the example2 fixture
+// via Registry().
+func TestRuleQuality_RunIsNonNilForNatives(t *testing.T) {
 	for _, def := range registry {
-		if def.MinRecommendations <= 0 {
-			continue
-		}
-		// Per-rule fixture tests already exercise the Run path with
-		// realistic inputs; here we just validate that the declared
-		// floor is non-negative and the function pointer is non-nil
-		// (the latter is also checked by MetadataIsComplete; this
-		// test scaffolds the per-Finding check that PR-N+1 will
-		// extend with synthetic inputs that force a fire).
 		if def.Run == nil {
 			t.Errorf("rule %q has nil Run", def.ID)
 		}

--- a/findings/rules_quality_test.go
+++ b/findings/rules_quality_test.go
@@ -1,0 +1,143 @@
+package findings
+
+import (
+	"testing"
+)
+
+// knownSubsystems is the set of Subsystem string values rendered by
+// the Advisor. Mirrors the cases in subsystemOrder; new subsystems
+// must be added in both places (the test catches the omission here,
+// the renderer uses the order from subsystemOrder).
+var knownSubsystems = map[string]struct{}{
+	"Buffer Pool":       {},
+	"Redo Log":          {},
+	"InnoDB Semaphores": {},
+	"Binlog Cache":      {},
+	"Thread Cache":      {},
+	"Table Open Cache":  {},
+	"Temp Tables":       {},
+	"Query Shape":       {},
+	"Connections":       {},
+	"Configuration":     {},
+}
+
+// TestRuleQuality_RegistryNotEmpty fails when the registry is somehow
+// empty at test time — guards against package-init failures that
+// would silently drop every rule.
+func TestRuleQuality_RegistryNotEmpty(t *testing.T) {
+	if len(registry) == 0 {
+		t.Fatal("rule registry is empty: package init did not register any rules")
+	}
+}
+
+// TestRuleQuality_MetadataIsComplete asserts that every entry in the
+// registry has non-empty ID, Title, and FormulaText. These fields are
+// load-bearing for the Advisor render path and the rendered Finding
+// quality.
+func TestRuleQuality_MetadataIsComplete(t *testing.T) {
+	for _, def := range registry {
+		if def.ID == "" {
+			t.Errorf("rule with empty ID found (Title=%q)", def.Title)
+		}
+		if def.Title == "" {
+			t.Errorf("rule %q has empty Title", def.ID)
+		}
+		if def.FormulaText == "" {
+			t.Errorf("rule %q has empty FormulaText", def.ID)
+		}
+		if def.Run == nil {
+			t.Errorf("rule %q has nil Run function", def.ID)
+		}
+	}
+}
+
+// TestRuleQuality_IDsAreUnique guards against the failure mode where
+// two registrations claim the same ID. Two definitions with the same
+// ID would silently shadow each other in the rendered output (the
+// last one to evaluate wins, depending on iteration order).
+func TestRuleQuality_IDsAreUnique(t *testing.T) {
+	seen := make(map[string]int, len(registry))
+	for _, def := range registry {
+		seen[def.ID]++
+	}
+	for id, count := range seen {
+		if count > 1 {
+			t.Errorf("rule ID %q is registered %d times; IDs must be unique", id, count)
+		}
+	}
+}
+
+// TestRuleQuality_SubsystemIsKnown asserts every registered rule
+// declares a Subsystem value that the renderer's subsystemOrder
+// switch handles. New subsystems must be added to both subsystemOrder
+// and knownSubsystems above.
+func TestRuleQuality_SubsystemIsKnown(t *testing.T) {
+	for _, def := range registry {
+		if _, ok := knownSubsystems[def.Subsystem]; !ok {
+			t.Errorf("rule %q declares unknown Subsystem %q", def.ID, def.Subsystem)
+		}
+	}
+}
+
+// TestRuleQuality_CritRulesHaveEnoughRecommendations asserts that
+// rules whose declared worst case is SeverityHintCritical carry at
+// least three remediation recommendations: a Critical card with one
+// suggestion is a quality-of-output regression.
+//
+// Variable-severity rules are checked separately: they must declare
+// at least one recommendation, but the per-rule judgement of how many
+// suggestions they actually need is captured in MinRecommendations
+// itself (the rule author picks a value matching the rendered Finding).
+func TestRuleQuality_CritRulesHaveEnoughRecommendations(t *testing.T) {
+	for _, def := range registry {
+		switch def.Severity {
+		case SeverityHintCritical:
+			if def.MinRecommendations < 3 {
+				t.Errorf("rule %q is declared SeverityHintCritical but MinRecommendations=%d (need >=3)",
+					def.ID, def.MinRecommendations)
+			}
+		case SeverityHintVariable, SeverityHintWarning, SeverityHintInfo:
+			if def.MinRecommendations < 1 {
+				t.Errorf("rule %q declares 0 recommendations (need >=1)", def.ID)
+			}
+		}
+	}
+}
+
+// TestRuleQuality_FindingHonorsMinRecommendations asserts that when a
+// rule fires non-skip on a fixture, the rendered Finding actually
+// carries at least the declared MinRecommendations. Run() against a
+// nil report returns SeveritySkip for every rule, so this scan is a
+// best-effort sanity check on the declared metadata; per-rule fixture
+// tests in findings_test.go are still the authoritative coverage.
+func TestRuleQuality_FindingHonorsMinRecommendations(t *testing.T) {
+	for _, def := range registry {
+		if def.MinRecommendations <= 0 {
+			continue
+		}
+		// Per-rule fixture tests already exercise the Run path with
+		// realistic inputs; here we just validate that the declared
+		// floor is non-negative and the function pointer is non-nil
+		// (the latter is also checked by MetadataIsComplete; this
+		// test scaffolds the per-Finding check that PR-N+1 will
+		// extend with synthetic inputs that force a fire).
+		if def.Run == nil {
+			t.Errorf("rule %q has nil Run", def.ID)
+		}
+	}
+}
+
+// TestRuleQuality_RegistryIsSortedByID asserts the dispatch order is
+// stable and alphabetical, the property Analyze relies on for
+// deterministic output. Calls Analyze first to trigger the
+// registry-sort sync.Once (Analyze sorts on first call rather than at
+// init time, see findings.go for the rationale).
+func TestRuleQuality_RegistryIsSortedByID(t *testing.T) {
+	_ = Analyze(nil) // primes the sync.Once
+	for i := 1; i < len(registry); i++ {
+		if registry[i-1].ID > registry[i].ID {
+			t.Errorf("registry not sorted by ID: index %d (%q) > index %d (%q)",
+				i-1, registry[i-1].ID, i, registry[i].ID)
+		}
+	}
+}

--- a/findings/rules_queryshape.go
+++ b/findings/rules_queryshape.go
@@ -39,6 +39,22 @@ func ruleFullScanSelectScan(r *model.Report) Finding {
 	}
 }
 
+// init registers ruleFullScanSelectScan as a native RuleDefinition.
+// MinRecommendations is 1 because this rule's INFO/WARN/CRIT outputs
+// share the same two-step remediation list — the symptom is the same;
+// the severity scales with rate.
+func init() {
+	register(RuleDefinition{
+		ID:                 "queryshape.select_scan",
+		Subsystem:          "Query Shape",
+		Title:              "Full table scans on the first join input",
+		FormulaText:        "Select_scan/s > 0  (crit > 10/s)",
+		MinRecommendations: 1,
+		Severity:           SeverityHintVariable,
+		Run:                ruleFullScanSelectScan,
+	})
+}
+
 // ruleFullScanSelectFullJoin flags joins that performed table scans
 // because they do not use indexes.
 // See Rosetta Stone — Part B Select_full_join.

--- a/findings/rules_semaphores.go
+++ b/findings/rules_semaphores.go
@@ -124,3 +124,16 @@ func ruleSemaphoreWaits(r *model.Report) Finding {
 		Source:          "Rosetta Stone — InnoDB SEMAPHORES section (contention detection)",
 	}
 }
+
+// init registers ruleSemaphoreWaits as a native RuleDefinition.
+func init() {
+	register(RuleDefinition{
+		ID:                 "innodb.semaphores",
+		Subsystem:          "InnoDB Semaphores",
+		Title:              "InnoDB semaphore contention",
+		FormulaText:        "peak waiting threads > 0  (crit ≥ 500)",
+		MinRecommendations: 3,
+		Severity:           SeverityHintVariable,
+		Run:                ruleSemaphoreWaits,
+	})
+}

--- a/findings/rules_threadqueue.go
+++ b/findings/rules_threadqueue.go
@@ -25,8 +25,8 @@ import (
 // connections.saturation rule.
 //
 // This is the only currently-shipping rule that walks the whole
-// time-series with gaugeMax — a deliberate baseline that PR-33
-// introduces for future time-series rules to follow.
+// time-series with gaugeMax — a deliberate baseline (introduced
+// alongside the rule itself) for future time-series rules to follow.
 func ruleThreadMaxQueueDepth(r *model.Report) Finding {
 	peak, ok := gaugeMax(r, "Threads_running")
 	if !ok || peak <= 0 {
@@ -53,12 +53,22 @@ func ruleThreadMaxQueueDepth(r *model.Report) Finding {
 	switch {
 	case peak >= critAt:
 		sev = SeverityCrit
-		summary = fmt.Sprintf("Threads_running peaked at %s — concurrency saturated (>=%s of max_connections=%s).",
-			formatNum(peak), formatNum(critAt), formatNum(maxConns))
+		if hasMax && maxConns > 0 {
+			summary = fmt.Sprintf("Threads_running peaked at %s — concurrency saturated (>=%s of max_connections=%s).",
+				formatNum(peak), formatNum(critAt), formatNum(maxConns))
+		} else {
+			summary = fmt.Sprintf("Threads_running peaked at %s — concurrency saturated at or beyond the fixed CRIT threshold (%s; %s).",
+				formatNum(peak), formatNum(critAt), floorReason)
+		}
 	case peak >= warnAt:
 		sev = SeverityWarn
-		summary = fmt.Sprintf("Threads_running peaked at %s — at or beyond half of max_connections (%s); queries are starting to queue.",
-			formatNum(peak), formatNum(warnAt))
+		if hasMax && maxConns > 0 {
+			summary = fmt.Sprintf("Threads_running peaked at %s — at or beyond half of max_connections (%s); queries are starting to queue.",
+				formatNum(peak), formatNum(warnAt))
+		} else {
+			summary = fmt.Sprintf("Threads_running peaked at %s — at or beyond the fixed WARN threshold (%s; %s); queries are starting to queue.",
+				formatNum(peak), formatNum(warnAt), floorReason)
+		}
 	}
 	metrics := []MetricRef{
 		{Name: "Threads_running (peak)", Value: peak, Unit: "count", Note: "max across capture window"},
@@ -93,9 +103,9 @@ func ruleThreadMaxQueueDepth(r *model.Report) Finding {
 }
 
 // init registers ruleThreadMaxQueueDepth as a native RuleDefinition.
-// This is the time-series rule shipped in PR-33; it inspects the full
-// Threads_running gauge series across the capture (gaugeMax) rather
-// than just the last sample.
+// This is the first time-series rule shipped through the registry; it
+// inspects the full Threads_running gauge series across the capture
+// (gaugeMax) rather than just the last sample.
 func init() {
 	register(RuleDefinition{
 		ID:                 "thread.max_queue_depth",

--- a/findings/rules_threadqueue.go
+++ b/findings/rules_threadqueue.go
@@ -1,0 +1,110 @@
+package findings
+
+import (
+	"fmt"
+
+	"github.com/matias-sanchez/My-gather/model"
+)
+
+// ruleThreadMaxQueueDepth is a time-series rule: it scans every
+// observed Threads_running value across the capture and flags peaks
+// that imply concurrency saturation. Threads_running is the count of
+// query threads actively running on the CPU at the sample instant —
+// distinct from Threads_connected (which counts open sessions, most
+// of which are idle). When Threads_running peaks rise toward
+// max_connections, queries are queueing on row locks, mutexes, or CPU.
+//
+// Thresholds scale with max_connections so the rule works for both
+// small and large servers:
+//
+//	peak >= max_connections / 2      → WARN
+//	peak >= max_connections * 0.9    → CRIT
+//
+// When max_connections is unknown the rule falls back to fixed
+// thresholds (50 → WARN, 200 → CRIT) consistent with the
+// connections.saturation rule.
+//
+// This is the only currently-shipping rule that walks the whole
+// time-series with gaugeMax — a deliberate baseline that PR-33
+// introduces for future time-series rules to follow.
+func ruleThreadMaxQueueDepth(r *model.Report) Finding {
+	peak, ok := gaugeMax(r, "Threads_running")
+	if !ok || peak <= 0 {
+		return Finding{Severity: SeveritySkip}
+	}
+	maxConns, hasMax := variableFloat(r, "max_connections")
+	var (
+		warnAt, critAt float64
+		floorReason    string
+	)
+	if hasMax && maxConns > 0 {
+		warnAt = maxConns / 2
+		critAt = maxConns * 0.9
+		floorReason = fmt.Sprintf("vs max_connections=%s", formatNum(maxConns))
+	} else {
+		warnAt = 50
+		critAt = 200
+		floorReason = "fixed thresholds (max_connections unknown)"
+	}
+
+	sev := SeverityOK
+	summary := fmt.Sprintf("Threads_running peak was %s — concurrency well below the %s warn threshold (%s).",
+		formatNum(peak), floorReason, formatNum(warnAt))
+	switch {
+	case peak >= critAt:
+		sev = SeverityCrit
+		summary = fmt.Sprintf("Threads_running peaked at %s — concurrency saturated (>=%s of max_connections=%s).",
+			formatNum(peak), formatNum(critAt), formatNum(maxConns))
+	case peak >= warnAt:
+		sev = SeverityWarn
+		summary = fmt.Sprintf("Threads_running peaked at %s — at or beyond half of max_connections (%s); queries are starting to queue.",
+			formatNum(peak), formatNum(warnAt))
+	}
+	metrics := []MetricRef{
+		{Name: "Threads_running (peak)", Value: peak, Unit: "count", Note: "max across capture window"},
+		{Name: "warn threshold", Value: warnAt, Unit: "count"},
+		{Name: "crit threshold", Value: critAt, Unit: "count"},
+	}
+	if hasMax {
+		metrics = append(metrics, MetricRef{Name: "max_connections", Value: maxConns, Unit: "count"})
+	}
+	return Finding{
+		ID:        "thread.max_queue_depth",
+		Subsystem: "Connections",
+		Title:     "Threads_running peak across capture",
+		Severity:  sev,
+		Summary:   summary,
+		Explanation: "Threads_running is sampled per second by mysqladmin. Its peak across the capture is the most concrete view " +
+			"of how saturated the server got under the workload. A peak nearing max_connections means queries are queueing on " +
+			"locks, mutexes, or available CPU; sustained high values usually indicate a hot row, a table scan storm, or a " +
+			"missing index. Compare this rule's verdict against connections.saturation (which is gauge-last) to distinguish a " +
+			"steady-state load from a brief spike.",
+		FormulaText: "max(Threads_running) across capture  vs  {max_connections/2 warn, max_connections*0.9 crit}",
+		FormulaComputed: fmt.Sprintf("peak Threads_running = %s; warn=%s, crit=%s (%s)",
+			formatNum(peak), formatNum(warnAt), formatNum(critAt), floorReason),
+		Metrics: metrics,
+		Recommendations: []string{
+			"Cross-reference with the processlist capture to see which queries were running at the peak.",
+			"Check the InnoDB Semaphores card — sustained high Threads_running with semaphore waits points at a hot mutex.",
+			"If the workload genuinely needs the parallelism, validate max_connections sizing and per-thread memory budget.",
+		},
+		Source: "Rosetta Stone — Connections (saturation, time-series)",
+	}
+}
+
+// init registers ruleThreadMaxQueueDepth as a native RuleDefinition.
+// This is the time-series rule shipped in PR-33; it inspects the full
+// Threads_running gauge series across the capture (gaugeMax) rather
+// than just the last sample.
+func init() {
+	register(RuleDefinition{
+		ID:                 "thread.max_queue_depth",
+		Subsystem:          "Connections",
+		Title:              "Threads_running peak across capture",
+		FormulaText:        "max(Threads_running) across capture  vs  max_connections/2 (warn) and max_connections*0.9 (crit)",
+		MinRecommendations: 3,
+		Severity:           SeverityHintVariable,
+		Run:                ruleThreadMaxQueueDepth,
+	})
+}
+

--- a/findings/rules_threadqueue.go
+++ b/findings/rules_threadqueue.go
@@ -107,4 +107,3 @@ func init() {
 		Run:                ruleThreadMaxQueueDepth,
 	})
 }
-

--- a/findings/rules_threadqueue_test.go
+++ b/findings/rules_threadqueue_test.go
@@ -12,8 +12,8 @@ func TestThreadMaxQueueDepth(t *testing.T) {
 		wantSev  Severity
 	}{
 		{"skip_when_zero", 0, "500", SeveritySkip},
-		{"ok_low_peak", 50, "500", SeverityOK},   // peak < 250 (max/2)
-		{"warn_half", 260, "500", SeverityWarn},  // peak >= 250 (max/2) but < 450 (max*0.9)
+		{"ok_low_peak", 50, "500", SeverityOK},      // peak < 250 (max/2)
+		{"warn_half", 260, "500", SeverityWarn},     // peak >= 250 (max/2) but < 450 (max*0.9)
 		{"crit_near_max", 460, "500", SeverityCrit}, // peak >= 450
 		// Fallback path (max_connections absent): warn at 50, crit at 200.
 		{"fallback_warn", 75, "", SeverityWarn},

--- a/findings/rules_threadqueue_test.go
+++ b/findings/rules_threadqueue_test.go
@@ -1,0 +1,44 @@
+package findings
+
+import (
+	"testing"
+)
+
+func TestThreadMaxQueueDepth(t *testing.T) {
+	cases := []struct {
+		name     string
+		peak     float64
+		maxConns string
+		wantSev  Severity
+	}{
+		{"skip_when_zero", 0, "500", SeveritySkip},
+		{"ok_low_peak", 50, "500", SeverityOK},   // peak < 250 (max/2)
+		{"warn_half", 260, "500", SeverityWarn},  // peak >= 250 (max/2) but < 450 (max*0.9)
+		{"crit_near_max", 460, "500", SeverityCrit}, // peak >= 450
+		// Fallback path (max_connections absent): warn at 50, crit at 200.
+		{"fallback_warn", 75, "", SeverityWarn},
+		{"fallback_crit", 250, "", SeverityCrit},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			b := newBuilder().gaugeMax("Threads_running", tc.peak)
+			if tc.maxConns != "" {
+				b = b.variable("max_connections", tc.maxConns)
+			}
+			got := Analyze(b.build())
+			f := findByID(got, "thread.max_queue_depth")
+			if tc.wantSev == SeveritySkip {
+				if f != nil {
+					t.Fatalf("expected skip, got %+v", f)
+				}
+				return
+			}
+			if f == nil {
+				t.Fatalf("rule missing")
+			}
+			if f.Severity != tc.wantSev {
+				t.Errorf("severity: got %v, want %v (summary: %q)", f.Severity, tc.wantSev, f.Summary)
+			}
+		})
+	}
+}

--- a/testdata/golden/findings.example2.json
+++ b/testdata/golden/findings.example2.json
@@ -1,0 +1,162 @@
+[
+  {
+    "id": "bp.dirty_pct",
+    "subsystem": "Buffer Pool",
+    "title": "Dirty-page ratio",
+    "severity": "ok",
+    "formula_text": "dirty_pct = Innodb_buffer_pool_pages_dirty / Innodb_buffer_pool_pages_total × 100  vs  innodb_max_dirty_pages_pct",
+    "recommendations_len": 3
+  },
+  {
+    "id": "bp.free_pages_low",
+    "subsystem": "Buffer Pool",
+    "title": "Buffer pool free pages exhausted",
+    "severity": "warn",
+    "formula_text": "free_pages \u003c= innodb_lru_scan_depth × innodb_buffer_pool_instances  AND  Innodb_buffer_pool_reads/s \u003e 0",
+    "recommendations_len": 3
+  },
+  {
+    "id": "bp.hit_ratio",
+    "subsystem": "Buffer Pool",
+    "title": "Buffer pool hit ratio",
+    "severity": "crit",
+    "formula_text": "hit_ratio = 1 − Innodb_buffer_pool_reads / Innodb_buffer_pool_read_requests",
+    "recommendations_len": 3
+  },
+  {
+    "id": "bp.wait_free",
+    "subsystem": "Buffer Pool",
+    "title": "Query threads waiting for free buffer pool pages",
+    "severity": "crit",
+    "formula_text": "Innodb_buffer_pool_wait_free/s \u003e 0",
+    "recommendations_len": 3
+  },
+  {
+    "id": "config.slow_log_disabled",
+    "subsystem": "Configuration",
+    "title": "Slow query log is disabled",
+    "severity": "warn",
+    "formula_text": "slow_query_log = OFF  AND  Questions/s \u003e 0",
+    "recommendations_len": 3
+  },
+  {
+    "id": "connections.saturation",
+    "subsystem": "Connections",
+    "title": "Connection pool saturation",
+    "severity": "ok",
+    "formula_text": "Threads_connected / max_connections  and  Threads_running (max)",
+    "recommendations_len": 3
+  },
+  {
+    "id": "innodb.flushing",
+    "subsystem": "Buffer Pool",
+    "title": "InnoDB flushing pressure",
+    "severity": "warn",
+    "formula_text": "any of {singlePage, fsyncLog, LRU, flushList, fsyncBP} \u003e 0",
+    "recommendations_len": 4
+  },
+  {
+    "id": "innodb.semaphores",
+    "subsystem": "InnoDB Semaphores",
+    "title": "InnoDB semaphore contention",
+    "severity": "warn",
+    "formula_text": "peak waiting threads \u003e 0  (crit ≥ 500)",
+    "recommendations_len": 5
+  },
+  {
+    "id": "queryshape.handler_read_rnd_next",
+    "subsystem": "Query Shape",
+    "title": "Sequential row reads (table scans)",
+    "severity": "warn",
+    "formula_text": "Handler_read_rnd_next/s  and  Handler_read_rnd_next / Com_select",
+    "recommendations_len": 2
+  },
+  {
+    "id": "queryshape.is_processlist",
+    "subsystem": "Query Shape",
+    "title": "information_schema.PROCESSLIST usage",
+    "severity": "warn",
+    "formula_text": "Deprecated_use_i_s_processlist_count/s",
+    "recommendations_len": 2
+  },
+  {
+    "id": "queryshape.select_full_join",
+    "subsystem": "Query Shape",
+    "title": "Joins without usable indexes",
+    "severity": "crit",
+    "formula_text": "Select_full_join/s \u003e 0",
+    "recommendations_len": 2
+  },
+  {
+    "id": "queryshape.select_scan",
+    "subsystem": "Query Shape",
+    "title": "Full table scans on the first join input",
+    "severity": "crit",
+    "formula_text": "Select_scan/s \u003e 0",
+    "recommendations_len": 2
+  },
+  {
+    "id": "redo.checkpoint_age",
+    "subsystem": "Redo Log",
+    "title": "Redo log checkpoint age",
+    "severity": "ok",
+    "formula_text": "checkpoint_age / checkpoint_max_age",
+    "recommendations_len": 3
+  },
+  {
+    "id": "redo.pending_fsyncs",
+    "subsystem": "Redo Log",
+    "title": "Redo log pending fsyncs",
+    "severity": "crit",
+    "formula_text": "max(Innodb_os_log_pending_fsyncs) \u003e 0",
+    "recommendations_len": 3
+  },
+  {
+    "id": "redo.pending_writes",
+    "subsystem": "Redo Log",
+    "title": "Redo log pending writes",
+    "severity": "crit",
+    "formula_text": "max(Innodb_os_log_pending_writes) \u003e 0",
+    "recommendations_len": 3
+  },
+  {
+    "id": "tablecache.miss_ratio",
+    "subsystem": "Table Open Cache",
+    "title": "Table cache miss ratio",
+    "severity": "ok",
+    "formula_text": "miss_ratio = Table_open_cache_misses / (Table_open_cache_hits + Table_open_cache_misses)",
+    "recommendations_len": 2
+  },
+  {
+    "id": "tablecache.usage",
+    "subsystem": "Table Open Cache",
+    "title": "Table cache saturation",
+    "severity": "ok",
+    "formula_text": "usage = Open_tables / table_open_cache",
+    "recommendations_len": 3
+  },
+  {
+    "id": "thread.max_queue_depth",
+    "subsystem": "Connections",
+    "title": "Threads_running peak across capture",
+    "severity": "ok",
+    "formula_text": "max(Threads_running) across capture  vs  {max_connections/2 warn, max_connections*0.9 crit}",
+    "recommendations_len": 3
+  },
+  {
+    "id": "threadcache.hit_ratio",
+    "subsystem": "Thread Cache",
+    "title": "Thread cache hit ratio",
+    "severity": "ok",
+    "formula_text": "hit_ratio = 1 − Threads_created / Connections",
+    "recommendations_len": 2
+  },
+  {
+    "id": "tmp.disk_ratio",
+    "subsystem": "Temp Tables",
+    "title": "Internal temp tables spilling to disk",
+    "severity": "ok",
+    "formula_text": "disk_ratio = Created_tmp_disk_tables / Created_tmp_tables",
+    "recommendations_len": 3
+  }
+]


### PR DESCRIPTION
## Summary

Refactors the Advisor rule engine to a structured `RuleDefinition` registry, adds a rule-quality test harness, ships two new configuration rules and one time-series rule, and introduces a compact JSON golden for `findings.Analyze()`.

The public Advisor API is unchanged — `findings.Analyze(*model.Report) []Finding` — and every pre-existing rule's output is byte-identical to `main`.

## Migration plan (RuleDefinition vs legacyAdapter)

5 of the 26 shipped rules are native `RuleDefinition` entries in this PR (one per major code path so the registry exercise lights up every subsystem at once):

- `bp.hit_ratio` (Buffer Pool)
- `innodb.semaphores` (InnoDB Semaphores)
- `innodb.flushing` (Buffer Pool / flushing)
- `queryshape.select_scan` (Query Shape)
- `config.slow_log_disabled` (Configuration)

The remaining 21 rules ride through `legacyAdapter` so the registry is the only dispatch path while the per-rule conversions ship in follow-up PRs. A migration plan comment in `findings/register.go` records the 5/21 ratio and the deletion criterion for the adapter (it is removed when the legacy count reaches 0).

Counting after this PR:

- **Native** RuleDefinition: 5 (legacy) + 2 (new config) + 1 (new time-series) = **8**
- **Adapter-wrapped**: **21**
- **Total**: **29**

## Commits

1. **`102181c`** — `findings: introduce RuleDefinition + registry; migrate 5 existing rules`
   - Replaces the free-floating `allRules` slice with `RuleDefinition` + package-level `registry`.
   - Analyze sorts the registry once via `sync.Once` on first call (init-order safe) and iterates by `RuleDefinition.ID`.
   - 5 rules migrate to native registration; 21 use `legacyAdapter`.

2. **`b4c449b`** — `findings: rule quality test harness`
   - Adds `findings/rules_quality_test.go` asserting metadata completeness, ID uniqueness, valid Subsystem, recommendation-floor (>=3 for declared `SeverityHintCritical`), and registry sort order.
   - Harness is the contract every future rule must satisfy.

3. **`30c0eab`** — `findings: 2 new configuration rules (max_connections_high + sync_binlog_not_one)`
   - `config.max_connections_high`: WARN/CRIT when `max_connections > 5000` and the buffer pool is small relative to thread overhead. Formula: `innodb_buffer_pool_size / (max_connections / 1000) < {1 GiB warn, 256 MiB crit}`.
   - `config.sync_binlog_not_one`: CRIT when `sync_binlog=0` AND replication is configured (server_id != 0 with binlog/gtid indicators); WARN when `sync_binlog=0` standalone or `sync_binlog>1`; INFO when `log_bin=OFF`.
   - Both rules ship with focused unit tests covering every branch.

4. **`7a781f7`** — `findings: 1 time-series rule (thread.max_queue_depth) + Advisor goldens`
   - `thread.max_queue_depth`: walks the full `Threads_running` gauge series across the capture and flags peaks scaled by `max_connections` (WARN at peak >= max/2, CRIT at peak >= max*0.9). Falls back to fixed thresholds (50/200) when `max_connections` is absent.
   - `findings/findings_golden_test.go`: snapshot-compares a sorted-by-ID JSON projection of every emitted Finding (ID, Subsystem, Title, Severity, FormulaText, Recommendations count) against `testdata/golden/findings.example2.json`. Golden is 162 lines — small enough to read in code review, resilient to incidental wording changes inside Summary / Explanation.
   - Regenerate via `go test ./findings/... -update`.

## Constitution walk

- **I (no CGO)** — pure Go, no cgo touched.
- **III (typed errors / structured diagnostics)** — Findings carry typed Severity, Subsystem, FormulaText fields; no string-error proliferation.
- **IV (deterministic)** — registry sorted by ID before dispatch; Analyze's final sort is unchanged; goldens are byte-stable.
- **VI (godoc)** — every new export has a doc comment.
- **VII (typed errors)** — n/a (no new error types introduced).
- **VIII (golden)** — new `testdata/golden/findings.example2.json`; pre-existing goldens are not regenerated.
- **X (zero deps)** — stdlib only.
- **XIII (canonical path)** — `allRules` removed; the registry is the single dispatch path.
- **XIV (English-only)** — all new content English.

## Test plan

- [x] `go vet ./...` clean.
- [x] `go test ./... -count=1` passes for findings, parse, render, tests/coverage, tests/lint.
- [x] `go test ./findings/... -count=1 -run TestGoldenAdvisor` passes.
- [x] Pre-existing goldens (`db.example2.html`, `variables.example2.html`, etc.) unchanged.
- [x] Every new export carries a godoc comment.

## Out of scope (deferred to follow-ups)

- Migrating the remaining 21 legacy-adapted rules to native `RuleDefinition` (one PR per rule, low risk).
- Per-rule Finding-level recommendation-count assertions in the quality harness (current harness validates declared metadata; per-Finding fixture coverage already exists in `findings_test.go`).
- Touching `feedback-worker/`, `.specify/memory/constitution.md`, `.github/workflows/`, or `scripts/hooks/` (PR #32 territory).

https://claude.ai/code/session_01ArJq6pXc9BjBMUhsLAJmgc

---
_Generated by [Claude Code](https://claude.ai/code/session_01ArJq6pXc9BjBMUhsLAJmgc)_