### PR TITLE
chore: mechanise gates 5 + 8 + expand pre-push hook + CI velocity (constitution v1.4 MINOR)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,10 @@ jobs:
         env:
           CGO_ENABLED: "0"
         run: go test ./...
+      - name: godoc coverage (Principle VI, gate 5)
+        env:
+          CGO_ENABLED: "0"
+        run: go test ./tests/coverage/... -run TestGodocCoverage -count=1
 
   lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,23 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+#
+# Job dependency graph (kept here so the YAML reads top-to-bottom
+# in execution order):
+#
+#   lint  ──┐
+#   test  ──┼──► determinism   ──┐
+#           └──► cross-compile ──┴──► release
+#
+# - lint and test start in parallel from the worker pool (no `needs:`).
+# - determinism and cross-compile both wait for test to pass; they
+#   would otherwise duplicate the test job's compile work and consume
+#   runner minutes for nothing if the unit tests were broken.
+# - release waits for all four to be green.
+#
+# Module caching is handled by actions/setup-go@v5 (`cache: true` is
+# the default; we set it explicitly so the contract is visible).
+#
 jobs:
   test:
     strategy:
@@ -27,6 +44,7 @@ jobs:
         with:
           go-version-file: go.mod
           check-latest: false
+          cache: true
       - name: go vet
         run: go vet ./...
       - name: go test
@@ -45,16 +63,19 @@ jobs:
       - uses: actions/setup-go@v5
         with:
           go-version-file: go.mod
+          cache: true
       - name: make lint
         run: make lint
 
   determinism:
     runs-on: ubuntu-latest
+    needs: [test]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
           go-version-file: go.mod
+          cache: true
       - name: Build
         env:
           CGO_ENABLED: "0"
@@ -86,6 +107,7 @@ jobs:
 
   cross-compile:
     runs-on: ubuntu-latest
+    needs: [test]
     strategy:
       fail-fast: false
       matrix:
@@ -99,6 +121,7 @@ jobs:
       - uses: actions/setup-go@v5
         with:
           go-version-file: go.mod
+          cache: true
       - name: Cross-compile ${{ matrix.target }}
         env:
           CGO_ENABLED: "0"
@@ -124,6 +147,7 @@ jobs:
       - uses: actions/setup-go@v5
         with:
           go-version-file: go.mod
+          cache: true
       - name: make release
         run: make release
       - uses: actions/upload-artifact@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,14 +47,14 @@ jobs:
           cache: true
       - name: go vet
         run: go vet ./...
-      - name: go test
+      - name: go test (incl. tests/coverage/godoc — Principle VI, gate 5)
         env:
           CGO_ENABLED: "0"
+        # `go test ./...` already exercises tests/coverage/... so the
+        # godoc-coverage AST walk runs here exactly once; the step
+        # name flags the dual purpose so a future failure surfaces
+        # both the unit-test and gate-5 contexts in one CI log line.
         run: go test ./...
-      - name: godoc coverage (Principle VI, gate 5)
-        env:
-          CGO_ENABLED: "0"
-        run: go test ./tests/coverage/... -run TestGodocCoverage -count=1
 
   lint:
     runs-on: ubuntu-latest

--- a/.specify/memory/constitution.md
+++ b/.specify/memory/constitution.md
@@ -1,6 +1,84 @@
 <!--
 Sync Impact Report
 ==================
+Version change: 1.3.1 → 1.4.0
+Bump rationale: MINOR-level mechanisation of two previously REVIEW-
+  only gates. Gates 5 (Principle VI godoc-on-exports) and 8
+  (Principle XIV English-only) now flip from [REVIEW] to
+  [MECHANICAL]. Their forbidden / required behaviours are
+  unchanged - the principles still demand exactly what they
+  demanded yesterday - but a regression that previously slipped
+  through to PR review will now fail CI or the pre-push hook
+  before reaching origin. Nothing already-compliant becomes
+  non-compliant; this is a strict tightening of mechanical teeth
+  on existing principles, hence MINOR (per the Governance
+  versioning policy: "MINOR: A new principle or section is added,
+  or existing guidance is materially expanded").
+
+  Concrete checks landed in this PR (chore/pr32-mechanise-review-
+  gates):
+    - Gate 5: tests/coverage/godoc_coverage_test.go AST-walks
+      parse/, model/, render/, findings/ and asserts every
+      exported identifier has a non-empty doc comment. CI invokes
+      it via `go test ./tests/coverage/... -run TestGodocCoverage`
+      in the existing matrix `test` job. The pre-push hook runs
+      the same target locally when the push touches Go files
+      under those packages.
+    - Gate 8: scripts/hooks/pre-push-constitution-guard.sh greps
+      every changed file outside testdata/ and _references/ for
+      UTF-8 byte sequences that encode Latin-1 Supplement letters
+      (00C0-00FF, with U+00D7 multiplication and U+00F7 division
+      carved out) and Latin Extended-A (0100-017F). Math symbols,
+      em-dashes, arrows, and emoji pass; Spanish / French / German
+      / etc. accented letters do not. Two pre-existing legitimate
+      uses are exempt by file:line.
+    - Pre-push hook scope expansion (companion teeth on existing
+      MECHANICAL halves of gate 6): suspicious build tags
+      (Principles I, XII), `net/http` import or net.Dial in the
+      Go release path (Principle IX), and writes inside the
+      input-reading path (Principle II) now block the push.
+
+Added principles: none.
+
+Modified principles: none.
+
+Modified sections:
+  - Development Workflow & Quality Gates -> gates 5 and 8 flip from
+    [REVIEW] to [MECHANICAL] and gain a one-line description of
+    the new check. Gate 6 also flips from [MECHANICAL - partial]
+    to [MECHANICAL] now that the pre-push hook covers all three
+    of its sub-rules (CGO, network in release path, writes in
+    input-reading path) - the new sub-rules land in the same PR
+    that flips gate 5 and gate 8. The intro paragraph keeps its
+    mixed-tag convention sentence as a forward-compatible note;
+    no current gate uses the partial form. The closing paragraph's
+    "future direction" sentence is rewritten to mention only gate
+    7 (canonical code path) as the outstanding REVIEW gate that
+    future amendments may convert.
+
+Downstream cleanups folded into this amendment: none. The
+  mechanisation lands alongside the wording.
+
+Templates requiring updates:
+  - .specify/templates/plan-template.md             compatible
+  - .specify/templates/spec-template.md             compatible
+  - .specify/templates/tasks-template.md            compatible
+  - .specify/templates/checklist-template.md        compatible
+  - .claude/skills/speckit-*/                       compatible
+  - .claude/skills/pr-review-*-my-gather/           compatible
+    (skills reference the constitution by file path, not by gate
+    tag wording or version)
+  - .claude/agents/pre-review-constitution-guard.md compatible
+    (the agent's principle-walk does not depend on gate-tag prose
+    or the MECHANICAL / REVIEW split)
+
+Deferred items / follow-up TODOs: gate 7 (Principle XIII canonical
+  code path) remains REVIEW. A duplicate-implementation scan
+  needs more design work (a static-analysis pass or AST diff
+  rather than a regex) and is deferred to a future amendment.
+
+Prior Sync Impact Report (1.3.1) follows for history:
+-----------------------------------------------------
 Version change: 1.3.0 → 1.3.1
 Bump rationale: PATCH-level wording clarification on the Development
   Workflow & Quality Gates section. Each of the 8 merge gates is now
@@ -409,9 +487,10 @@ this constitution; the repo currently has no mechanical check that
 catches a violation). A gate may carry a partial / mixed tag
 (e.g. **[MECHANICAL — partial]** combined with an inline **[REVIEW]**
 on the un-mechanised sub-rules) when only one half of its scope is
-caught by tooling — gate 6 is the current instance. The tag tells
-you whether you can rely on tooling to catch a regression, or whether
-reviewer attention is the only line of defence:
+caught by tooling. The convention is preserved for use by future
+gates that land in a mixed state. The tag tells you whether you can
+rely on tooling to catch a regression, or whether reviewer attention
+is the only line of defence:
 
 1. **[MECHANICAL]** `go vet ./...` and `go test ./...` succeed on all
    supported platforms exercised in CI.
@@ -430,34 +509,53 @@ reviewer attention is the only line of defence:
    justification entry in the corresponding `plan.md` (Principle X). The
    pre-push hook scans new `go.mod require` entries for a matching
    citation.
-5. **[REVIEW]** Exported identifiers added or changed have godoc
-   comments describing their contract (Principle VI). Reviewers verify
-   on the diff; no mechanical check today.
-6. **[MECHANICAL — partial]** No build introduces a CGO requirement
-   (Principle I, mechanically enforced by the pre-push hook scanning for
-   `import "C"`); **[REVIEW]** for the network-call-at-runtime and
-   write-under-the-input-tree halves of the gate (Principles IX, II) —
-   reviewers verify that no new `net/http` client or `os.Create` /
-   `os.Mkdir` / `os.Rename` lands in `cmd/`, `parse/`, `model/`, `render/`,
-   `findings/`.
+5. **[MECHANICAL]** Exported identifiers added or changed have godoc
+   comments describing their contract (Principle VI). Enforced by
+   `tests/coverage/godoc_coverage_test.go`, an AST-walking test that
+   asserts every exported identifier under `parse/`, `model/`,
+   `render/`, and `findings/` carries a non-empty doc comment. CI
+   invokes it via `go test ./tests/coverage/... -run TestGodocCoverage`
+   in the matrix `test` job, and `scripts/hooks/pre-push-constitution-
+   guard.sh` runs the same target locally when the push touches Go
+   files under those packages.
+6. **[MECHANICAL]** No build introduces a CGO requirement (Principle I,
+   pre-push hook scans for `import "C"` and for `//go:build cgo`),
+   no new `net/http`, `net.Dial`, or `http.Get` / `http.Post` /
+   `http.NewRequest` / `http.Client{}` lands in `cmd/`, `parse/`,
+   `model/`, `render/`, or `findings/` (Principle IX, pre-push hook
+   greps the diff), and no `os.Create` / `os.Mkdir` / `os.MkdirAll` /
+   `os.Rename` / `os.Remove` / `os.RemoveAll` / `os.WriteFile` /
+   `ioutil.WriteFile` lands in `parse/` or `cmd/` (Principle II,
+   pre-push hook greps the diff). All three halves now block the
+   push without human action.
 7. **[REVIEW]** No change leaves a duplicated or fallback implementation
    of an existing behaviour in place (Principle XIII). Replaced
    functions, types, and code paths MUST be deleted in the same change;
    internal re-exports and compatibility shims after a rename are
    prohibited. Reviewers verify on the diff; no mechanical check today.
-8. **[REVIEW]** No change introduces non-English content into any
+8. **[MECHANICAL]** No change introduces non-English content into any
    checked-in artifact outside `testdata/` and `_references/`
-   (Principle XIV). Source code, comments, commit messages, branch
-   names, specs, docs, `.claude/` agent and skill definitions, and shell
-   scripts MUST be English-only. Reviewers verify on the diff; no
-   mechanical check today.
+   (Principle XIV). Enforced by a byte-level grep in
+   `scripts/hooks/pre-push-constitution-guard.sh` that catches
+   UTF-8 sequences encoding Latin-1 Supplement letters
+   (00C0–00FF, with U+00D7 multiplication and U+00F7 division
+   carved out) and Latin Extended-A (0100–017F). Math symbols,
+   em-dashes, arrows, and emoji pass; Spanish / French / German /
+   etc. accented letters do not. Two pre-existing legitimate uses
+   (the verbatim user-input quote at
+   `specs/003-feedback-backend-worker/spec.md:6` and the UTF-8
+   byte-counting test fixture at
+   `feedback-worker/test/validate.test.ts:69-70`) are exempt by
+   file:line.
 
 The MECHANICAL / REVIEW split documents what the repo enforces with code
 today, not the strictness of each gate — every gate is equally
-non-negotiable for a merge. Future amendments may convert REVIEW gates
-into MECHANICAL ones by extending the pre-push hook or CI; the
-constitution does not require that, but the absence of mechanical teeth
-on a REVIEW gate is a useful signal for reviewers reading a diff.
+non-negotiable for a merge. As of v1.4 only gate 7 (Principle XIII
+canonical code path) remains [REVIEW]; a future amendment may convert
+it once a duplicate-implementation scan is designed. The constitution
+does not require that conversion, but the absence of mechanical teeth
+on the one remaining REVIEW gate is a useful signal for reviewers
+reading a diff that touches existing behaviour.
 
 Reviewers MUST reject changes that violate any Core Principle unless the
 change is accompanied by a constitution amendment adopted under the
@@ -490,4 +588,4 @@ invocation via the Constitution Check gate. Runtime development guidance
 and feature-local `plan.md` / `quickstart.md` files and MUST defer to this
 constitution when conflicts arise.
 
-**Version**: 1.3.1 | **Ratified**: 2026-04-21 | **Last Amended**: 2026-04-27
+**Version**: 1.4.0 | **Ratified**: 2026-04-21 | **Last Amended**: 2026-04-27

--- a/scripts/hooks/pre-push-constitution-guard.sh
+++ b/scripts/hooks/pre-push-constitution-guard.sh
@@ -181,6 +181,84 @@ for hit in "${ENGLISH_HITS[@]}"; do
   VIOLATIONS+=("XIV: non-English Latin-script letter at $hit (Principle XIV requires English-only artifacts; testdata/ and _references/ are exempt; math/typography/emoji pass)")
 done
 
+# Rule 6 (Principle XII / Principle I): suspicious build tags on
+# non-test .go files. `// +build ...` (legacy syntax) is a smell.
+# `//go:build cgo` is a hard block under Principle I (no CGO).
+# Any other `//go:build <foo>` warrants reviewer attention because
+# Principle XII forbids build tags that diverge runtime behaviour
+# between platforms except where genuinely unavoidable
+# (path/filepath is the only documented allowlist entry).
+TAG_HITS="$(git diff "$RANGE" -- '*.go' ':!*_test.go' 2>/dev/null | awk '
+  /^\+\+\+ b\// { file = substr($0, 7); next }
+  /^\+\/\/ \+build / { print "P2|XII|" file ": legacy build tag (// +build), use //go:build instead" }
+  /^\+\/\/go:build / {
+    tag = $0
+    sub(/^\+\/\/go:build /, "", tag)
+    if (tag ~ /(^|[ |&!()])cgo($|[ |&!()])/) {
+      print "P1|I|" file ": //go:build cgo violates Principle I (no CGO in shipped binary)"
+    } else {
+      print "P2|XII|" file ": //go:build " tag " - Principle XII reviewer attention required (no allowlist match)"
+    }
+  }
+')"
+if [ -n "$TAG_HITS" ]; then
+  while IFS= read -r line; do
+    [ -z "$line" ] && continue
+    sev="${line%%|*}"
+    rest="${line#*|}"
+    principle="${rest%%|*}"
+    msg="${rest#*|}"
+    VIOLATIONS+=("$sev - $principle: $msg")
+  done <<< "$TAG_HITS"
+fi
+
+# Rule 7 (Principle IX): no outbound network in the Go release path.
+# The feedback-worker (TypeScript) is the only sanctioned outbound
+# path; the Go binary stays offline. We grep added lines under
+# parse/, model/, render/, findings/, and cmd/ for a `net/http`
+# import or net.Dial-style construct. _test.go files are excluded
+# because tests may legitimately exercise an httptest server.
+NET_HITS="$(git diff "$RANGE" -- 'parse/*.go' 'model/*.go' 'render/*.go' 'findings/*.go' 'cmd/**/*.go' ':!*_test.go' 2>/dev/null | awk '
+  /^\+\+\+ b\// { file = substr($0, 7); next }
+  /^\+[[:space:]]*"net\/http"/         { print file ": import \"net/http\" added" }
+  /^\+[[:space:]]*"net"[[:space:]]*$/  { print file ": import \"net\" added" }
+  /^\+.*net\.Dial/                      { print file ": net.Dial call added" }
+  /^\+.*http\.Get\(/                    { print file ": http.Get call added" }
+  /^\+.*http\.Post\(/                   { print file ": http.Post call added" }
+  /^\+.*http\.NewRequest/               { print file ": http.NewRequest call added" }
+  /^\+.*http\.Client\{/                 { print file ": http.Client constructor added" }
+')"
+if [ -n "$NET_HITS" ]; then
+  while IFS= read -r line; do
+    [ -z "$line" ] && continue
+    VIOLATIONS+=("P1 - IX: $line (Principle IX forbids network in the Go release path; the feedback-worker is the only outbound path)")
+  done <<< "$NET_HITS"
+fi
+
+# Rule 8 (Principle II): no writes inside the input-reading path.
+# parse/ and cmd/ MUST NOT call os.Create / os.Mkdir(All) / os.Rename
+# / os.Remove / os.RemoveAll / os.WriteFile / ioutil.WriteFile.
+# Legitimate writes belong under render/ (the user's -out path) or
+# os.TempDir(); flag everything else for review. _test.go is
+# excluded because tests can write fixtures to t.TempDir().
+WRITE_HITS="$(git diff "$RANGE" -- 'parse/*.go' 'cmd/**/*.go' ':!*_test.go' 2>/dev/null | awk '
+  /^\+\+\+ b\// { file = substr($0, 7); next }
+  /^\+.*os\.Create\b/        { print file ": os.Create" }
+  /^\+.*os\.Mkdir\b/          { print file ": os.Mkdir" }
+  /^\+.*os\.MkdirAll\b/       { print file ": os.MkdirAll" }
+  /^\+.*os\.Rename\b/         { print file ": os.Rename" }
+  /^\+.*os\.Remove\b/         { print file ": os.Remove" }
+  /^\+.*os\.RemoveAll\b/      { print file ": os.RemoveAll" }
+  /^\+.*os\.WriteFile\b/      { print file ": os.WriteFile" }
+  /^\+.*ioutil\.WriteFile\b/  { print file ": ioutil.WriteFile" }
+')"
+if [ -n "$WRITE_HITS" ]; then
+  while IFS= read -r line; do
+    [ -z "$line" ] && continue
+    VIOLATIONS+=("P2 - II: $line (Principle II forbids writes in the input-reading path; legitimate writes belong in render/ under \$TMPDIR or the user's -out path - annotate the line if intentional)")
+  done <<< "$WRITE_HITS"
+fi
+
 TS="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
 SHA="$(git rev-parse --short HEAD 2>/dev/null || echo unknown)"
 

--- a/scripts/hooks/pre-push-constitution-guard.sh
+++ b/scripts/hooks/pre-push-constitution-guard.sh
@@ -110,6 +110,28 @@ if [ -n "$CGO_HITS" ]; then
   VIOLATIONS+=("I: CGO reintroduced (import \"C\") — Principle I forbids CGO in shipped code")
 fi
 
+# Rule 4 (Principle VI, gate 5): every exported identifier under
+# parse/, model/, render/, findings/ has a godoc comment. Delegated
+# to the AST-walking test under tests/coverage/. Runs only when Go
+# files in the watched packages are touched in this push, so the
+# common case (docs-only or spec-only push) stays cheap.
+WATCHED_GO_CHANGED="$(printf '%s\n' "$CHANGED" | grep -E '^(parse|model|render|findings)/.*\.go$' || true)"
+if [ -n "$WATCHED_GO_CHANGED" ] && command -v go >/dev/null 2>&1; then
+  GODOC_OUT="$(CGO_ENABLED=0 go test ./tests/coverage/... -run TestGodocCoverage -count=1 2>&1)"
+  GODOC_RC=$?
+  if [ "$GODOC_RC" -ne 0 ]; then
+    HAD_HIT=0
+    while IFS= read -r line; do
+      [ -z "$line" ] && continue
+      VIOLATIONS+=("VI: $line")
+      HAD_HIT=1
+    done < <(printf '%s\n' "$GODOC_OUT" | grep -E ':[0-9]+: (function|method|type|identifier)' || true)
+    if [ "$HAD_HIT" -eq 0 ]; then
+      VIOLATIONS+=("VI: godoc coverage test failed — re-run \`go test ./tests/coverage/... -run TestGodocCoverage -v\` for the missing-godoc list")
+    fi
+  fi
+fi
+
 TS="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
 SHA="$(git rev-parse --short HEAD 2>/dev/null || echo unknown)"
 

--- a/scripts/hooks/pre-push-constitution-guard.sh
+++ b/scripts/hooks/pre-push-constitution-guard.sh
@@ -125,7 +125,7 @@ if [ -n "$WATCHED_GO_CHANGED" ] && command -v go >/dev/null 2>&1; then
       [ -z "$line" ] && continue
       VIOLATIONS+=("VI: $line")
       HAD_HIT=1
-    done < <(printf '%s\n' "$GODOC_OUT" | grep -E ':[0-9]+: (function|method|type|identifier)' || true)
+    done < <(printf '%s\n' "$GODOC_OUT" | grep -E ':[0-9]+: (.+: )?(function|method|type|identifier)\b' || true)
     if [ "$HAD_HIT" -eq 0 ]; then
       VIOLATIONS+=("VI: godoc coverage test failed — re-run \`go test ./tests/coverage/... -run TestGodocCoverage -v\` for the missing-godoc list")
     fi
@@ -152,10 +152,22 @@ fi
 #
 # -I tells grep to skip binary files (PNG, etc.).
 ENGLISH_PATTERN='\xC3[\x80-\x96\x98-\xB6\xB8-\xBF]|\xC4[\x80-\xBF]|\xC5[\x80-\xBF]'
-if [ -x /usr/bin/grep ]; then
+# Choose a PCRE-capable grep. /usr/bin/grep is GNU on Linux but BSD on
+# macOS, and BSD grep silently exits non-zero on -P (which `|| true`
+# below would mask, no-oping the entire gate). Probe `--version` for
+# the GNU banner first, then fall back to a feature-test on `grep -P`
+# against any grep on PATH (which catches Homebrew's ggrep installed
+# as `grep` via a shim, plus Linux distros where /usr/bin/grep is
+# missing). If no PCRE-capable grep is reachable, fail closed so the
+# operator knows the gate is unenforceable on this host instead of
+# silently passing.
+if [ -x /usr/bin/grep ] && /usr/bin/grep --version 2>/dev/null | head -1 | grep -q GNU; then
   GREP_BIN=/usr/bin/grep
-else
+elif printf '' | grep -P '' >/dev/null 2>&1; then
   GREP_BIN=grep
+else
+  printf 'pre-push-constitution-guard: PCRE-capable grep not found (need GNU grep with -P or `ggrep`); install via `brew install grep` and shim into PATH, or run on a host with GNU grep. Aborting so gate 8 is not silently bypassed.\n' >&2
+  exit 1
 fi
 ENGLISH_HITS=()
 while IFS= read -r f; do
@@ -220,13 +232,15 @@ fi
 # because tests may legitimately exercise an httptest server.
 NET_HITS="$(git diff "$RANGE" -- 'parse/*.go' 'model/*.go' 'render/*.go' 'findings/*.go' 'cmd/**/*.go' ':!*_test.go' 2>/dev/null | awk '
   /^\+\+\+ b\// { file = substr($0, 7); next }
-  /^\+[[:space:]]*"net\/http"/         { print file ": import \"net/http\" added" }
-  /^\+[[:space:]]*"net"[[:space:]]*$/  { print file ": import \"net\" added" }
-  /^\+.*net\.Dial/                      { print file ": net.Dial call added" }
-  /^\+.*http\.Get\(/                    { print file ": http.Get call added" }
-  /^\+.*http\.Post\(/                   { print file ": http.Post call added" }
-  /^\+.*http\.NewRequest/               { print file ": http.NewRequest call added" }
-  /^\+.*http\.Client\{/                 { print file ": http.Client constructor added" }
+  /^\+[[:space:]]*"net\/http"/                      { print file ": import \"net/http\" added" }
+  /^\+.*net\.Dial[A-Za-z]*\(/                        { print file ": net.Dial* call added" }
+  /^\+.*net\.Listen[A-Za-z]*\(/                      { print file ": net.Listen* call added" }
+  /^\+.*net\.Lookup[A-Za-z]*\(/                      { print file ": net.Lookup* call added" }
+  /^\+.*net\.Resolve[A-Za-z]*Addr\(/                 { print file ": net.Resolve*Addr call added" }
+  /^\+.*http\.Get\(/                                  { print file ": http.Get call added" }
+  /^\+.*http\.Post\(/                                 { print file ": http.Post call added" }
+  /^\+.*http\.NewRequest/                             { print file ": http.NewRequest call added" }
+  /^\+.*http\.Client\{/                               { print file ": http.Client constructor added" }
 ')"
 if [ -n "$NET_HITS" ]; then
   while IFS= read -r line; do
@@ -243,14 +257,14 @@ fi
 # excluded because tests can write fixtures to t.TempDir().
 WRITE_HITS="$(git diff "$RANGE" -- 'parse/*.go' 'cmd/**/*.go' ':!*_test.go' 2>/dev/null | awk '
   /^\+\+\+ b\// { file = substr($0, 7); next }
-  /^\+.*os\.Create\b/        { print file ": os.Create" }
-  /^\+.*os\.Mkdir\b/          { print file ": os.Mkdir" }
-  /^\+.*os\.MkdirAll\b/       { print file ": os.MkdirAll" }
-  /^\+.*os\.Rename\b/         { print file ": os.Rename" }
-  /^\+.*os\.Remove\b/         { print file ": os.Remove" }
-  /^\+.*os\.RemoveAll\b/      { print file ": os.RemoveAll" }
-  /^\+.*os\.WriteFile\b/      { print file ": os.WriteFile" }
-  /^\+.*ioutil\.WriteFile\b/  { print file ": ioutil.WriteFile" }
+  /^\+.*os\.Create([^[:alnum:]_]|$)/        { print file ": os.Create" }
+  /^\+.*os\.Mkdir([^[:alnum:]_]|$)/         { print file ": os.Mkdir" }
+  /^\+.*os\.MkdirAll([^[:alnum:]_]|$)/      { print file ": os.MkdirAll" }
+  /^\+.*os\.Rename([^[:alnum:]_]|$)/        { print file ": os.Rename" }
+  /^\+.*os\.Remove([^[:alnum:]_]|$)/        { print file ": os.Remove" }
+  /^\+.*os\.RemoveAll([^[:alnum:]_]|$)/     { print file ": os.RemoveAll" }
+  /^\+.*os\.WriteFile([^[:alnum:]_]|$)/     { print file ": os.WriteFile" }
+  /^\+.*ioutil\.WriteFile([^[:alnum:]_]|$)/ { print file ": ioutil.WriteFile" }
 ')"
 if [ -n "$WRITE_HITS" ]; then
   while IFS= read -r line; do

--- a/scripts/hooks/pre-push-constitution-guard.sh
+++ b/scripts/hooks/pre-push-constitution-guard.sh
@@ -254,6 +254,8 @@ NET_HITS="$(git diff "$RANGE" -- 'parse/*.go' 'model/*.go' 'render/*.go' 'findin
   /^\+\+\+ b\// { file = substr($0, 7); next }
   /^\+.*"net\/http"/                                 { print file ": import \"net/http\" added (any form: block, single-line, aliased, dot, blank)" }
   /^\+.*"net"/                                       { print file ": import \"net\" added (any form: block, single-line, aliased, dot, blank — alias may hide net.Dial/Listen/Lookup/ResolveAddr)" }
+  /^\+.*`net\/http`/                                 { print file ": import `net/http` added (raw-string form — non-idiomatic; flag as Principle IX bypass attempt)" }
+  /^\+.*`net`/                                       { print file ": import `net` added (raw-string form — non-idiomatic; flag as Principle IX bypass attempt)" }
   /^\+.*net\.Dial[A-Za-z]*\(/                        { print file ": net.Dial* call added" }
   /^\+.*net\.Listen[A-Za-z]*\(/                      { print file ": net.Listen* call added" }
   /^\+.*net\.Lookup[A-Za-z]*\(/                      { print file ": net.Lookup* call added" }
@@ -317,6 +319,8 @@ WRITE_HITS="$(git diff "$RANGE" -- 'parse/*.go' 'cmd/**/*.go' ':!*_test.go' 2>/d
   /^\+[[:space:]]+([^_[:space:]][^[:space:]]*|_[^[:space:]]+)[[:space:]]+"io\/ioutil"/          { print file ": aliased import of \"io/ioutil\" (alias may hide WriteFile)" }
   /^\+import[[:space:]]+([^_[:space:]][^[:space:]]*|_[^[:space:]]+)[[:space:]]+"os"/            { print file ": aliased import of \"os\" (single-line; alias may hide WriteFile/Create/Mkdir/Rename/Remove)" }
   /^\+import[[:space:]]+([^_[:space:]][^[:space:]]*|_[^[:space:]]+)[[:space:]]+"io\/ioutil"/    { print file ": aliased import of \"io/ioutil\" (single-line; alias may hide WriteFile)" }
+  /^\+.*`os`/                                                                                    { print file ": import `os` added (raw-string form — non-idiomatic; flag as Principle II bypass attempt)" }
+  /^\+.*`io\/ioutil`/                                                                            { print file ": import `io/ioutil` added (raw-string form — non-idiomatic; flag as Principle II bypass attempt)" }
 ')"
 if [ -n "$WRITE_HITS" ]; then
   while IFS= read -r line; do

--- a/scripts/hooks/pre-push-constitution-guard.sh
+++ b/scripts/hooks/pre-push-constitution-guard.sh
@@ -235,10 +235,19 @@ fi
 # parse/, model/, render/, findings/, and cmd/ for a `net/http`
 # import or net.Dial-style construct. _test.go files are excluded
 # because tests may legitimately exercise an httptest server.
+#
+# Alias resilience: the import-detection pattern matches the literal
+# string "net/http" anywhere on an added line, which catches every
+# import form — block (`\t"net/http"`), single-line
+# (`import "net/http"`), aliased (`import h "net/http"` or
+# `\th "net/http"` inside a block), and dot/blank imports. Without
+# this, an alias like `import h "net/http"` plus `h.Get(...)` would
+# bypass the gate entirely (the call-site patterns below only know
+# about the canonical `http.` prefix). The literal-string match is
+# the only forgery-proof anchor without a full Go parser.
 NET_HITS="$(git diff "$RANGE" -- 'parse/*.go' 'model/*.go' 'render/*.go' 'findings/*.go' 'cmd/**/*.go' ':!*_test.go' 2>/dev/null | awk '
   /^\+\+\+ b\// { file = substr($0, 7); next }
-  /^\+[[:space:]]*"net\/http"/                      { print file ": import \"net/http\" added (block form)" }
-  /^\+[[:space:]]*import[[:space:]]+"net\/http"/    { print file ": import \"net/http\" added (single-line form)" }
+  /^\+.*"net\/http"/                                 { print file ": import \"net/http\" added (any form: block, single-line, aliased, dot, blank)" }
   /^\+.*net\.Dial[A-Za-z]*\(/                        { print file ": net.Dial* call added" }
   /^\+.*net\.Listen[A-Za-z]*\(/                      { print file ": net.Listen* call added" }
   /^\+.*net\.Lookup[A-Za-z]*\(/                      { print file ": net.Lookup* call added" }
@@ -261,6 +270,20 @@ fi
 # Legitimate writes belong under render/ (the user's -out path) or
 # os.TempDir(); flag everything else for review. _test.go is
 # excluded because tests can write fixtures to t.TempDir().
+#
+# Alias resilience: the call-site patterns require literal `os.` /
+# `ioutil.` prefixes, which means an aliased import (`import fs "os"`
+# or `import . "os"`) plus `fs.WriteFile(...)` / bare `WriteFile(...)`
+# would bypass the gate. We can't recover the alias name without a
+# parser, so we instead flag any aliased import of "os" or
+# "io/ioutil" in the watched paths as a smell that warrants reviewer
+# attention — the canonical import is bare and uses the `os` /
+# `ioutil` identifiers verbatim, so an alias is itself the signal.
+# `_` (blank-import side effects) is intentionally not flagged: it
+# discards exported names and cannot reach WriteFile. `.` (dot
+# import) is flagged because it imports names directly into the
+# package namespace, which would let a bare `WriteFile()` call slip
+# past the literal-prefix patterns below.
 WRITE_HITS="$(git diff "$RANGE" -- 'parse/*.go' 'cmd/**/*.go' ':!*_test.go' 2>/dev/null | awk '
   /^\+\+\+ b\// { file = substr($0, 7); next }
   /^\+.*os\.Create([^[:alnum:]_]|$)/        { print file ": os.Create" }
@@ -271,6 +294,10 @@ WRITE_HITS="$(git diff "$RANGE" -- 'parse/*.go' 'cmd/**/*.go' ':!*_test.go' 2>/d
   /^\+.*os\.RemoveAll([^[:alnum:]_]|$)/     { print file ": os.RemoveAll" }
   /^\+.*os\.WriteFile([^[:alnum:]_]|$)/     { print file ": os.WriteFile" }
   /^\+.*ioutil\.WriteFile([^[:alnum:]_]|$)/ { print file ": ioutil.WriteFile" }
+  /^\+[[:space:]]+([A-Za-z][A-Za-z0-9_]*|\.)[[:space:]]+"os"/                  { print file ": aliased import of \"os\" (alias may hide WriteFile/Create/Mkdir/Rename/Remove)" }
+  /^\+[[:space:]]+([A-Za-z][A-Za-z0-9_]*|\.)[[:space:]]+"io\/ioutil"/          { print file ": aliased import of \"io/ioutil\" (alias may hide WriteFile)" }
+  /^\+import[[:space:]]+([A-Za-z][A-Za-z0-9_]*|\.)[[:space:]]+"os"/            { print file ": aliased import of \"os\" (single-line; alias may hide WriteFile/Create/Mkdir/Rename/Remove)" }
+  /^\+import[[:space:]]+([A-Za-z][A-Za-z0-9_]*|\.)[[:space:]]+"io\/ioutil"/    { print file ": aliased import of \"io/ioutil\" (single-line; alias may hide WriteFile)" }
 ')"
 if [ -n "$WRITE_HITS" ]; then
   while IFS= read -r line; do

--- a/scripts/hooks/pre-push-constitution-guard.sh
+++ b/scripts/hooks/pre-push-constitution-guard.sh
@@ -163,11 +163,16 @@ ENGLISH_PATTERN='\xC3[\x80-\x96\x98-\xB6\xB8-\xBF]|\xC4[\x80-\xBF]|\xC5[\x80-\xB
 # silently passing.
 if [ -x /usr/bin/grep ] && /usr/bin/grep --version 2>/dev/null | head -1 | grep -q GNU; then
   GREP_BIN=/usr/bin/grep
-elif printf '' | grep -P '' >/dev/null 2>&1; then
+elif printf '\n' | grep -P '' >/dev/null 2>&1; then
   GREP_BIN=grep
 else
-  printf 'pre-push-constitution-guard: PCRE-capable grep not found (need GNU grep with -P or `ggrep`); install via `brew install grep` and shim into PATH, or run on a host with GNU grep. Aborting so gate 8 is not silently bypassed.\n' >&2
-  exit 1
+  # No PCRE-capable grep found. Push a sentinel violation so the hook
+  # fails closed through the standard JSON-deny path rather than
+  # exiting 1 with no JSON on stdout (which the Claude Code hook
+  # runtime would treat as a hook error and allow the push, inverting
+  # the fail-closed intent).
+  VIOLATIONS+=("XIV: PCRE-capable grep not found on this host — gate 8 (Principle XIV English-only) cannot be enforced. Install GNU grep (brew install grep on macOS) and shim into PATH, then re-push.")
+  GREP_BIN=grep  # unused below because VIOLATIONS already set; placeholder to keep subsequent code syntactically valid
 fi
 ENGLISH_HITS=()
 while IFS= read -r f; do
@@ -206,7 +211,7 @@ TAG_HITS="$(git diff "$RANGE" -- '*.go' ':!*_test.go' 2>/dev/null | awk '
   /^\+\/\/go:build / {
     tag = $0
     sub(/^\+\/\/go:build /, "", tag)
-    if (tag ~ /(^|[ |&!()])cgo($|[ |&!()])/) {
+    if (tag ~ /(^|[ |&()])cgo($|[ |&!()])/) {
       print "P1|I|" file ": //go:build cgo violates Principle I (no CGO in shipped binary)"
     } else {
       print "P2|XII|" file ": //go:build " tag " - Principle XII reviewer attention required (no allowlist match)"

--- a/scripts/hooks/pre-push-constitution-guard.sh
+++ b/scripts/hooks/pre-push-constitution-guard.sh
@@ -236,18 +236,24 @@ fi
 # import or net.Dial-style construct. _test.go files are excluded
 # because tests may legitimately exercise an httptest server.
 #
-# Alias resilience: the import-detection pattern matches the literal
-# string "net/http" anywhere on an added line, which catches every
-# import form — block (`\t"net/http"`), single-line
+# Alias resilience: import-detection patterns match the literal
+# strings "net/http" and "net" anywhere on an added line, which
+# catches every import form — block (`\t"net/http"`), single-line
 # (`import "net/http"`), aliased (`import h "net/http"` or
 # `\th "net/http"` inside a block), and dot/blank imports. Without
-# this, an alias like `import h "net/http"` plus `h.Get(...)` would
-# bypass the gate entirely (the call-site patterns below only know
-# about the canonical `http.` prefix). The literal-string match is
-# the only forgery-proof anchor without a full Go parser.
+# this, an alias like `import h "net/http"` plus `h.Get(...)` or
+# `import n "net"` plus `n.Dial(...)` would bypass the gate entirely
+# (the call-site patterns below only know about the canonical
+# `http.` / `net.` prefixes). The literal-string match is the only
+# forgery-proof anchor without a full Go parser. The bare `"net"`
+# pattern is precise: `"net/http"`, `"net/url"`, `"vendor/net"` etc.
+# do NOT contain `"net"` as a substring (the closing quote is in a
+# different position), so legitimate sub-package imports are not
+# flagged.
 NET_HITS="$(git diff "$RANGE" -- 'parse/*.go' 'model/*.go' 'render/*.go' 'findings/*.go' 'cmd/**/*.go' ':!*_test.go' 2>/dev/null | awk '
   /^\+\+\+ b\// { file = substr($0, 7); next }
   /^\+.*"net\/http"/                                 { print file ": import \"net/http\" added (any form: block, single-line, aliased, dot, blank)" }
+  /^\+.*"net"/                                       { print file ": import \"net\" added (any form: block, single-line, aliased, dot, blank — alias may hide net.Dial/Listen/Lookup/ResolveAddr)" }
   /^\+.*net\.Dial[A-Za-z]*\(/                        { print file ": net.Dial* call added" }
   /^\+.*net\.Listen[A-Za-z]*\(/                      { print file ": net.Listen* call added" }
   /^\+.*net\.Lookup[A-Za-z]*\(/                      { print file ": net.Lookup* call added" }
@@ -284,6 +290,19 @@ fi
 # import) is flagged because it imports names directly into the
 # package namespace, which would let a bare `WriteFile()` call slip
 # past the literal-prefix patterns below.
+#
+# Unicode safety: the alias char class uses negation
+# `([^_[:space:]][^[:space:]]*|_[^[:space:]]+)` rather than an
+# enumerated `[A-Za-z_]+` list. Go identifiers can start with any
+# Unicode letter (e.g. `import Ω "os"`), so an ASCII-only allowlist
+# leaves a real bypass. Negation is inherently Unicode-safe: the
+# multi-byte UTF-8 sequences for letters in any script (Greek,
+# Cyrillic, CJK, …) consist of bytes outside the `_`/whitespace
+# set, so `[^_[:space:]]` matches them as a side effect. The first
+# alternative excludes leading-`_` to keep the blank-import
+# carve-out; the second alternative re-admits leading-`_` only
+# when followed by at least one more non-whitespace char, so
+# `_x`/`__init` fire while bare `_` does not.
 WRITE_HITS="$(git diff "$RANGE" -- 'parse/*.go' 'cmd/**/*.go' ':!*_test.go' 2>/dev/null | awk '
   /^\+\+\+ b\// { file = substr($0, 7); next }
   /^\+.*os\.Create([^[:alnum:]_]|$)/        { print file ": os.Create" }
@@ -294,10 +313,10 @@ WRITE_HITS="$(git diff "$RANGE" -- 'parse/*.go' 'cmd/**/*.go' ':!*_test.go' 2>/d
   /^\+.*os\.RemoveAll([^[:alnum:]_]|$)/     { print file ": os.RemoveAll" }
   /^\+.*os\.WriteFile([^[:alnum:]_]|$)/     { print file ": os.WriteFile" }
   /^\+.*ioutil\.WriteFile([^[:alnum:]_]|$)/ { print file ": ioutil.WriteFile" }
-  /^\+[[:space:]]+([A-Za-z][A-Za-z0-9_]*|_[A-Za-z0-9_]+|\.)[[:space:]]+"os"/                  { print file ": aliased import of \"os\" (alias may hide WriteFile/Create/Mkdir/Rename/Remove)" }
-  /^\+[[:space:]]+([A-Za-z][A-Za-z0-9_]*|_[A-Za-z0-9_]+|\.)[[:space:]]+"io\/ioutil"/          { print file ": aliased import of \"io/ioutil\" (alias may hide WriteFile)" }
-  /^\+import[[:space:]]+([A-Za-z][A-Za-z0-9_]*|_[A-Za-z0-9_]+|\.)[[:space:]]+"os"/            { print file ": aliased import of \"os\" (single-line; alias may hide WriteFile/Create/Mkdir/Rename/Remove)" }
-  /^\+import[[:space:]]+([A-Za-z][A-Za-z0-9_]*|_[A-Za-z0-9_]+|\.)[[:space:]]+"io\/ioutil"/    { print file ": aliased import of \"io/ioutil\" (single-line; alias may hide WriteFile)" }
+  /^\+[[:space:]]+([^_[:space:]][^[:space:]]*|_[^[:space:]]+)[[:space:]]+"os"/                  { print file ": aliased import of \"os\" (alias may hide WriteFile/Create/Mkdir/Rename/Remove)" }
+  /^\+[[:space:]]+([^_[:space:]][^[:space:]]*|_[^[:space:]]+)[[:space:]]+"io\/ioutil"/          { print file ": aliased import of \"io/ioutil\" (alias may hide WriteFile)" }
+  /^\+import[[:space:]]+([^_[:space:]][^[:space:]]*|_[^[:space:]]+)[[:space:]]+"os"/            { print file ": aliased import of \"os\" (single-line; alias may hide WriteFile/Create/Mkdir/Rename/Remove)" }
+  /^\+import[[:space:]]+([^_[:space:]][^[:space:]]*|_[^[:space:]]+)[[:space:]]+"io\/ioutil"/    { print file ": aliased import of \"io/ioutil\" (single-line; alias may hide WriteFile)" }
 ')"
 if [ -n "$WRITE_HITS" ]; then
   while IFS= read -r line; do

--- a/scripts/hooks/pre-push-constitution-guard.sh
+++ b/scripts/hooks/pre-push-constitution-guard.sh
@@ -132,6 +132,55 @@ if [ -n "$WATCHED_GO_CHANGED" ] && command -v go >/dev/null 2>&1; then
   fi
 fi
 
+# Rule 5 (Principle XIV, gate 8): no non-English Latin-script letters
+# in checked-in artifacts outside testdata/ and _references/. The
+# pattern targets the UTF-8 byte sequences for the Latin-1 Supplement
+# letter block (00C0-00FF, with U+00D7 multiplication sign and
+# U+00F7 division sign carved out) plus Latin Extended-A (0100-017F).
+# Math symbols, em-dashes, arrows, and emoji do NOT match because
+# their UTF-8 byte sequences fall outside the C3/C4/C5 leading bytes.
+# We force the real GNU grep at /usr/bin/grep when present so an
+# interactive shell that aliases grep to ugrep cannot mask the check.
+#
+# Two existing legitimate uses are exempt by file:line:
+#   - specs/003-feedback-backend-worker/spec.md:6 - verbatim
+#     user-input quote (Spanish), preserved by the spec exemption
+#     ratified at constitution v1.2.0.
+#   - feedback-worker/test/validate.test.ts:69-70 - a UTF-8
+#     byte-counting test fixture that uses a 2-byte rune by
+#     construction.
+#
+# -I tells grep to skip binary files (PNG, etc.).
+ENGLISH_PATTERN='\xC3[\x80-\x96\x98-\xB6\xB8-\xBF]|\xC4[\x80-\xBF]|\xC5[\x80-\xBF]'
+if [ -x /usr/bin/grep ]; then
+  GREP_BIN=/usr/bin/grep
+else
+  GREP_BIN=grep
+fi
+ENGLISH_HITS=()
+while IFS= read -r f; do
+  [ -z "$f" ] && continue
+  case "$f" in
+    testdata/*|_references/*) continue ;;
+  esac
+  if [ ! -f "$f" ]; then
+    continue
+  fi
+  while IFS= read -r match; do
+    [ -z "$match" ] && continue
+    line_num="${match%%:*}"
+    case "$f:$line_num" in
+      specs/003-feedback-backend-worker/spec.md:6) continue ;;
+      feedback-worker/test/validate.test.ts:69) continue ;;
+      feedback-worker/test/validate.test.ts:70) continue ;;
+    esac
+    ENGLISH_HITS+=("$f:$line_num")
+  done < <("$GREP_BIN" -InP "$ENGLISH_PATTERN" "$f" 2>/dev/null || true)
+done < <(printf '%s\n' "$CHANGED")
+for hit in "${ENGLISH_HITS[@]}"; do
+  VIOLATIONS+=("XIV: non-English Latin-script letter at $hit (Principle XIV requires English-only artifacts; testdata/ and _references/ are exempt; math/typography/emoji pass)")
+done
+
 TS="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
 SHA="$(git rev-parse --short HEAD 2>/dev/null || echo unknown)"
 

--- a/scripts/hooks/pre-push-constitution-guard.sh
+++ b/scripts/hooks/pre-push-constitution-guard.sh
@@ -294,10 +294,10 @@ WRITE_HITS="$(git diff "$RANGE" -- 'parse/*.go' 'cmd/**/*.go' ':!*_test.go' 2>/d
   /^\+.*os\.RemoveAll([^[:alnum:]_]|$)/     { print file ": os.RemoveAll" }
   /^\+.*os\.WriteFile([^[:alnum:]_]|$)/     { print file ": os.WriteFile" }
   /^\+.*ioutil\.WriteFile([^[:alnum:]_]|$)/ { print file ": ioutil.WriteFile" }
-  /^\+[[:space:]]+([A-Za-z][A-Za-z0-9_]*|\.)[[:space:]]+"os"/                  { print file ": aliased import of \"os\" (alias may hide WriteFile/Create/Mkdir/Rename/Remove)" }
-  /^\+[[:space:]]+([A-Za-z][A-Za-z0-9_]*|\.)[[:space:]]+"io\/ioutil"/          { print file ": aliased import of \"io/ioutil\" (alias may hide WriteFile)" }
-  /^\+import[[:space:]]+([A-Za-z][A-Za-z0-9_]*|\.)[[:space:]]+"os"/            { print file ": aliased import of \"os\" (single-line; alias may hide WriteFile/Create/Mkdir/Rename/Remove)" }
-  /^\+import[[:space:]]+([A-Za-z][A-Za-z0-9_]*|\.)[[:space:]]+"io\/ioutil"/    { print file ": aliased import of \"io/ioutil\" (single-line; alias may hide WriteFile)" }
+  /^\+[[:space:]]+([A-Za-z][A-Za-z0-9_]*|_[A-Za-z0-9_]+|\.)[[:space:]]+"os"/                  { print file ": aliased import of \"os\" (alias may hide WriteFile/Create/Mkdir/Rename/Remove)" }
+  /^\+[[:space:]]+([A-Za-z][A-Za-z0-9_]*|_[A-Za-z0-9_]+|\.)[[:space:]]+"io\/ioutil"/          { print file ": aliased import of \"io/ioutil\" (alias may hide WriteFile)" }
+  /^\+import[[:space:]]+([A-Za-z][A-Za-z0-9_]*|_[A-Za-z0-9_]+|\.)[[:space:]]+"os"/            { print file ": aliased import of \"os\" (single-line; alias may hide WriteFile/Create/Mkdir/Rename/Remove)" }
+  /^\+import[[:space:]]+([A-Za-z][A-Za-z0-9_]*|_[A-Za-z0-9_]+|\.)[[:space:]]+"io\/ioutil"/    { print file ": aliased import of \"io/ioutil\" (single-line; alias may hide WriteFile)" }
 ')"
 if [ -n "$WRITE_HITS" ]; then
   while IFS= read -r line; do

--- a/scripts/hooks/pre-push-constitution-guard.sh
+++ b/scripts/hooks/pre-push-constitution-guard.sh
@@ -232,7 +232,8 @@ fi
 # because tests may legitimately exercise an httptest server.
 NET_HITS="$(git diff "$RANGE" -- 'parse/*.go' 'model/*.go' 'render/*.go' 'findings/*.go' 'cmd/**/*.go' ':!*_test.go' 2>/dev/null | awk '
   /^\+\+\+ b\// { file = substr($0, 7); next }
-  /^\+[[:space:]]*"net\/http"/                      { print file ": import \"net/http\" added" }
+  /^\+[[:space:]]*"net\/http"/                      { print file ": import \"net/http\" added (block form)" }
+  /^\+[[:space:]]*import[[:space:]]+"net\/http"/    { print file ": import \"net/http\" added (single-line form)" }
   /^\+.*net\.Dial[A-Za-z]*\(/                        { print file ": net.Dial* call added" }
   /^\+.*net\.Listen[A-Za-z]*\(/                      { print file ": net.Listen* call added" }
   /^\+.*net\.Lookup[A-Za-z]*\(/                      { print file ": net.Lookup* call added" }

--- a/tests/coverage/godoc_coverage_test.go
+++ b/tests/coverage/godoc_coverage_test.go
@@ -1,6 +1,12 @@
 // Package coverage_test (godoc) enforces Constitution Principle VI:
 // every exported identifier in the shipped packages (parse, model,
-// render) has a non-empty doc comment.
+// render, findings) has a non-empty doc comment.
+//
+// CI invokes this test directly via
+// `go test ./tests/coverage/... -run TestGodocCoverage` and the
+// pre-push constitution guard runs the same target locally so a
+// missing godoc fails before the push reaches origin (Gate 5,
+// MECHANICAL as of constitution v1.4).
 package coverage_test
 
 import (
@@ -16,7 +22,15 @@ import (
 	"github.com/matias-sanchez/My-gather/tests/goldens"
 )
 
-var godocCheckedPackages = []string{"parse", "model", "render"}
+var godocCheckedPackages = []string{"parse", "model", "render", "findings"}
+
+// TestGodocCoverage is the canonical entry point invoked by CI and
+// the pre-push hook. It delegates to the table-driven sub-tests in
+// TestEveryExportedIdentifierIsDocumented so the existing assertion
+// logic stays in one place.
+func TestGodocCoverage(t *testing.T) {
+	TestEveryExportedIdentifierIsDocumented(t)
+}
 
 func TestEveryExportedIdentifierIsDocumented(t *testing.T) {
 	root := goldens.RepoRoot(t)


### PR DESCRIPTION
## Summary

Mechanise two of the three remaining REVIEW merge gates, expand the pre-push hook to catch more constitution violations locally, parallelise CI, and bump the constitution to v1.4.0 (MINOR) to reflect the new mechanical teeth.

Forbidden / required behaviours are unchanged. Nothing already-compliant becomes non-compliant. This is a strict tightening of mechanical enforcement on existing principles.

## Commits (5)

### 1. `chore: mechanise gate 5 (Principle VI godoc-on-exports)` — b099fdb

- `tests/coverage/godoc_coverage_test.go`: extend the AST-walked package list from `{parse, model, render}` to include `findings/`, and add a `TestGodocCoverage` entry point so CI and the pre-push hook share one test target.
- `.github/workflows/ci.yml`: invoke the new entry point in the matrix `test` job.
- `scripts/hooks/pre-push-constitution-guard.sh`: run the same `go test` target locally before each push, gated on whether the push touches `*.go` files under `parse/model/render/findings`.

### 2. `chore: mechanise gate 8 (Principle XIV English-only)` — 066e547

- `scripts/hooks/pre-push-constitution-guard.sh`: add a byte-level grep using PCRE pattern ``\xC3[\x80-\x96\x98-\xB6\xB8-\xBF]|\xC4[\x80-\xBF]|\xC5[\x80-\xBF]`` to catch UTF-8 sequences encoding Latin-1 Supplement letters (00C0-00FF, with U+00D7 multiplication and U+00F7 division carved out) and Latin Extended-A (0100-017F).
- Math symbols, em-dashes, arrows, and emoji do **not** match because their UTF-8 leading bytes fall outside C3/C4/C5.
- Two pre-existing legitimate uses are exempt by `file:line`:
  - `specs/003-feedback-backend-worker/spec.md:6` — verbatim user-input quote already exempted by constitution v1.2.0 wording.
  - `feedback-worker/test/validate.test.ts:69-70` — UTF-8 byte-counting test fixture that uses a 2-byte rune by construction.
- The script forces `/usr/bin/grep` when present so an interactive shell that aliases `grep` to `ugrep` cannot mask the check.

Why a byte pattern rather than `\p{Latin}`: under POSIX locale GNU grep treats `\p{Latin}` as matching any Latin letter including ASCII A–Z, which combined with a `(?=[^\x00-\x7F])` lookahead matches the entire line whenever any non-ASCII byte appears anywhere on it. The byte pattern is locale-independent.

### 3. `chore: expand pre-push hook scope (build tags, network, writes)` — ce61c85

Three new mechanical checks added to `scripts/hooks/pre-push-constitution-guard.sh`:

- **Rule 6 (Principles XII / I)** — suspicious build tags: legacy `// +build` and any `//go:build`. P1 block on `cgo`, P2 advisory on others.
- **Rule 7 (Principle IX)** — no `net/http`, `net.Dial`, `http.Get/Post/NewRequest`, or `http.Client{}` in `cmd/parse/model/render/findings`. The feedback-worker (TS) is the only sanctioned outbound path.
- **Rule 8 (Principle II)** — no `os.Create / os.Mkdir / os.MkdirAll / os.Rename / os.Remove / os.RemoveAll / os.WriteFile / ioutil.WriteFile` in `parse/` or `cmd/`. The input tree must stay read-only.

Existing rules (collector parser fixture+golden, go.mod justification, no CGO `import "C"`, godoc coverage, English-only) remain wired and continue to fire.

### 4. `chore: parallelise CI jobs and document graph` — 9293fd1

- `determinism` and `cross-compile` now `needs: [test]`. Previously they ran in parallel with `test`, wasting runner minutes whenever unit tests were broken.
- `lint` stays parallel with `test` from the start.
- `release` continues to wait on all four predecessors.
- `cache: true` is now explicit on every `actions/setup-go@v5` invocation (it was the v5 default for `go-version-file`; making it visible keeps the contract honest in code review).
- ASCII dependency-graph comment block above `jobs:`.
- The determinism job's `diff_lines == 0 || 2` tolerance is preserved verbatim — tightening it is a separate row deferred per the mechanisation survey.

### 5. `chore: bump constitution to v1.4.0 (MINOR — mechanise gates 5 + 6 + 8)` — 9481bbf

- Version line `1.3.1` → `1.4.0`. Ratified date unchanged. Last Amended bumps to 2026-04-27.
- Sync Impact Report: new v1.4.0 entry above the v1.3.1 entry; v1.3.1 moves under "Prior Sync Impact Report".
- Gate 5 `[REVIEW]` → `[MECHANICAL]`.
- Gate 8 `[REVIEW]` → `[MECHANICAL]`.
- Gate 6 `[MECHANICAL — partial]` → `[MECHANICAL]` (the network and write halves became mechanical in commit 3 of this PR).
- Closing paragraph rewritten: only gate 7 (Principle XIII canonical code path) remains REVIEW.

## Why MINOR rather than PATCH or MAJOR

Per the Governance versioning policy: "MINOR: A new principle or section is added, or existing guidance is materially expanded." The mechanisation materially expands the existing guidance: where reviewers used to verify gate 5 / 6 / 8 by reading the diff, the repository now blocks the push or the CI build before the diff reaches review. The principles themselves did not move — every behaviour that was forbidden yesterday is still forbidden today, and every behaviour that was required yesterday is still required today.

## What's still outstanding

- **Gate 7 (Principle XIII canonical code path)** — remains `[REVIEW]`. A duplicate-implementation scan needs more design work (a static-analysis pass or AST diff rather than a regex) and is deferred to a future amendment.
- **Determinism diff_lines tolerance** — preserved at `0 or 2` per the mechanisation survey row deferred to a later PR.

## Test plan

- [ ] CI `test` job runs `go test ./tests/coverage/... -run TestGodocCoverage -count=1` on ubuntu and macos and passes.
- [ ] CI `test`, `lint` start in parallel; `determinism` and `cross-compile` wait for `test`; `release` waits for all four.
- [ ] Pre-push hook returns `PASS 0_violations` on this branch.
- [ ] `go vet ./...` clean.
- [ ] `go test ./... -count=1` clean.
- [ ] YAML parses (`python3 -c "import yaml; yaml.safe_load(open('.github/workflows/ci.yml'))"`).
- [ ] Constitution renders cleanly; gate flips read top-to-bottom in execution order.

https://claude.ai/code/session_01ArJq6pXc9BjBMUhsLAJmgc

---
_Generated by [Claude Code](https://claude.ai/code/session_01ArJq6pXc9BjBMUhsLAJmgc)_