### PR TITLE
Add richer processlist metrics

### DIFF
--- a/.specify/feature.json
+++ b/.specify/feature.json
@@ -1,3 +1,3 @@
 {
-  "feature_directory": "specs/003-feedback-backend-worker"
+  "feature_directory": "specs/005-richer-processlist-metrics"
 }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,16 +1,20 @@
 <!-- SPECKIT START -->
-No active feature. The latest shipped feature is **003-feedback-backend-worker**.
-The next `/speckit.specify` invocation will overwrite this block with the new
-feature's plan / spec / tasks pointers.
+Active feature: **005-richer-processlist-metrics**
 
-For technologies, project structure, constitution gates, and shell commands
-between features, read the constitution and (optionally) the latest shipped
-feature's plan as a reference:
+For technologies, project structure, constitution gates, data model,
+package/UI contracts, and shell commands, read the current plan:
 
+- Plan: `specs/005-richer-processlist-metrics/plan.md`
+- Spec: `specs/005-richer-processlist-metrics/spec.md`
+- Research: `specs/005-richer-processlist-metrics/research.md`
+- Data model: `specs/005-richer-processlist-metrics/data-model.md`
+- Contracts: `specs/005-richer-processlist-metrics/contracts/packages.md`,
+  `specs/005-richer-processlist-metrics/contracts/ui.md`
+- Quickstart: `specs/005-richer-processlist-metrics/quickstart.md`
+- Tasks: `specs/005-richer-processlist-metrics/tasks.md`
 - Constitution: `.specify/memory/constitution.md`
-- Latest shipped plan (003): `specs/003-feedback-backend-worker/plan.md`
 
-Prior features (shipped):
+Prior features:
 - **003-feedback-backend-worker** - `specs/003-feedback-backend-worker/plan.md`
 - **002-report-feedback-button** - `specs/002-report-feedback-button/plan.md`
 - **001-ptstalk-report-mvp** - `specs/001-ptstalk-report-mvp/plan.md`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,19 +1,23 @@
 <!-- SPECKIT START -->
-No active feature. The latest shipped feature is **003-feedback-backend-worker**.
-The next `/speckit.specify` invocation will overwrite this block with the new
-feature's plan / spec / tasks pointers.
+Active feature: **005-richer-processlist-metrics**
 
-For technologies, project structure, constitution gates, and shell commands
-between features, read the constitution and (optionally) the latest shipped
-feature's plan as a reference:
+For technologies, project structure, constitution gates, data model,
+package/UI contracts, and shell commands, read the current plan:
 
+- Plan: `specs/005-richer-processlist-metrics/plan.md`
+- Spec: `specs/005-richer-processlist-metrics/spec.md`
+- Research: `specs/005-richer-processlist-metrics/research.md`
+- Data model: `specs/005-richer-processlist-metrics/data-model.md`
+- Contracts: `specs/005-richer-processlist-metrics/contracts/packages.md`,
+  `specs/005-richer-processlist-metrics/contracts/ui.md`
+- Quickstart: `specs/005-richer-processlist-metrics/quickstart.md`
+- Tasks: `specs/005-richer-processlist-metrics/tasks.md`
 - Constitution: `.specify/memory/constitution.md`
-- Latest shipped plan (003): `specs/003-feedback-backend-worker/plan.md`
 
-Prior features (shipped):
-- **003-feedback-backend-worker** — `specs/003-feedback-backend-worker/plan.md`
-- **002-report-feedback-button** — `specs/002-report-feedback-button/plan.md`
-- **001-ptstalk-report-mvp** — `specs/001-ptstalk-report-mvp/plan.md`
+Prior features:
+- **003-feedback-backend-worker** - `specs/003-feedback-backend-worker/plan.md`
+- **002-report-feedback-button** - `specs/002-report-feedback-button/plan.md`
+- **001-ptstalk-report-mvp** - `specs/001-ptstalk-report-mvp/plan.md`
 <!-- SPECKIT END -->
 
 ## Language convention

--- a/model/model.go
+++ b/model/model.go
@@ -572,16 +572,32 @@ type ThreadStateSample struct {
 	// sample, derived from Time_ms when present and Time otherwise.
 	MaxTimeMS float64
 
+	// HasTimeMetric reports whether MaxTimeMS came from at least one
+	// valid Time_ms or Time value in this sample.
+	HasTimeMetric bool
+
 	// MaxRowsExamined is the largest Rows_examined value seen in this
 	// sample.
 	MaxRowsExamined float64
 
+	// HasRowsExaminedMetric reports whether this sample contained at
+	// least one valid Rows_examined value.
+	HasRowsExaminedMetric bool
+
 	// MaxRowsSent is the largest Rows_sent value seen in this sample.
 	MaxRowsSent float64
+
+	// HasRowsSentMetric reports whether this sample contained at least
+	// one valid Rows_sent value.
+	HasRowsSentMetric bool
 
 	// RowsWithQueryText is the count of rows whose Info field is
 	// non-empty and not NULL.
 	RowsWithQueryText int
+
+	// HasQueryTextMetric reports whether this sample contained at
+	// least one Info field, even when every value was empty or NULL.
+	HasQueryTextMetric bool
 }
 
 // NetstatSocketsData is the typed payload merged from every

--- a/model/model.go
+++ b/model/model.go
@@ -555,6 +555,33 @@ type ThreadStateSample struct {
 	HostCounts    map[string]int
 	CommandCounts map[string]int
 	DbCounts      map[string]int
+
+	// TotalThreads is the number of completed processlist rows in
+	// this sample.
+	TotalThreads int
+
+	// ActiveThreads is the number of rows whose Command is not
+	// exactly "Sleep".
+	ActiveThreads int
+
+	// SleepingThreads is the number of rows whose Command is exactly
+	// "Sleep".
+	SleepingThreads int
+
+	// MaxTimeMS is the largest row age in milliseconds for this
+	// sample, derived from Time_ms when present and Time otherwise.
+	MaxTimeMS float64
+
+	// MaxRowsExamined is the largest Rows_examined value seen in this
+	// sample.
+	MaxRowsExamined float64
+
+	// MaxRowsSent is the largest Rows_sent value seen in this sample.
+	MaxRowsSent float64
+
+	// RowsWithQueryText is the count of rows whose Info field is
+	// non-empty and not NULL.
+	RowsWithQueryText int
 }
 
 // NetstatSocketsData is the typed payload merged from every

--- a/parse/processlist.go
+++ b/parse/processlist.go
@@ -66,9 +66,13 @@ func parseProcesslist(r io.Reader, sourcePath string) (*model.ProcesslistData, [
 		active            int
 		sleeping          int
 		maxTimeMS         float64
+		hasTimeMetric     bool
 		maxRowsExamined   float64
+		hasRowsExamined   bool
 		maxRowsSent       float64
+		hasRowsSent       bool
 		rowsWithQueryText int
+		hasQueryText      bool
 	}
 	var samples []sampleBuild
 	var current *sampleBuild
@@ -141,14 +145,26 @@ func parseProcesslist(r io.Reader, sourcePath string) (*model.ProcesslistData, [
 		} else if current.row.haveTime {
 			ageMS = current.row.timeSeconds * 1000
 		}
+		if current.row.haveTimeMS || current.row.haveTime {
+			current.hasTimeMetric = true
+		}
 		if ageMS > current.maxTimeMS {
 			current.maxTimeMS = ageMS
+		}
+		if current.row.haveRowsExamined {
+			current.hasRowsExamined = true
 		}
 		if current.row.haveRowsExamined && current.row.rowsExamined > current.maxRowsExamined {
 			current.maxRowsExamined = current.row.rowsExamined
 		}
+		if current.row.haveRowsSent {
+			current.hasRowsSent = true
+		}
 		if current.row.haveRowsSent && current.row.rowsSent > current.maxRowsSent {
 			current.maxRowsSent = current.row.rowsSent
+		}
+		if current.row.haveInfo {
+			current.hasQueryText = true
 		}
 		if current.row.haveInfo && hasProcesslistQueryText(current.row.info) {
 			current.rowsWithQueryText++
@@ -289,19 +305,23 @@ func parseProcesslist(r io.Reader, sourcePath string) (*model.ProcesslistData, [
 	out := make([]model.ThreadStateSample, len(samples))
 	for i, s := range samples {
 		out[i] = model.ThreadStateSample{
-			Timestamp:         s.t,
-			StateCounts:       s.state,
-			UserCounts:        s.user,
-			HostCounts:        s.host,
-			CommandCounts:     s.command,
-			DbCounts:          s.db,
-			TotalThreads:      s.total,
-			ActiveThreads:     s.active,
-			SleepingThreads:   s.sleeping,
-			MaxTimeMS:         s.maxTimeMS,
-			MaxRowsExamined:   s.maxRowsExamined,
-			MaxRowsSent:       s.maxRowsSent,
-			RowsWithQueryText: s.rowsWithQueryText,
+			Timestamp:             s.t,
+			StateCounts:           s.state,
+			UserCounts:            s.user,
+			HostCounts:            s.host,
+			CommandCounts:         s.command,
+			DbCounts:              s.db,
+			TotalThreads:          s.total,
+			ActiveThreads:         s.active,
+			SleepingThreads:       s.sleeping,
+			MaxTimeMS:             s.maxTimeMS,
+			HasTimeMetric:         s.hasTimeMetric,
+			MaxRowsExamined:       s.maxRowsExamined,
+			HasRowsExaminedMetric: s.hasRowsExamined,
+			MaxRowsSent:           s.maxRowsSent,
+			HasRowsSentMetric:     s.hasRowsSent,
+			RowsWithQueryText:     s.rowsWithQueryText,
+			HasQueryTextMetric:    s.hasQueryText,
 		}
 	}
 

--- a/parse/processlist.go
+++ b/parse/processlist.go
@@ -48,7 +48,6 @@ func parseProcesslist(r io.Reader, sourcePath string) (*model.ProcesslistData, [
 		rowsExamined     float64
 		info             string
 		haveTime         bool
-		sawTimeMS        bool
 		haveTimeMS       bool
 		haveRowsSent     bool
 		haveRowsExamined bool
@@ -139,7 +138,7 @@ func parseProcesslist(r io.Reader, sourcePath string) (*model.ProcesslistData, [
 		ageMS := 0.0
 		if current.row.haveTimeMS {
 			ageMS = current.row.timeMS
-		} else if !current.row.sawTimeMS && current.row.haveTime {
+		} else if current.row.haveTime {
 			ageMS = current.row.timeSeconds * 1000
 		}
 		if ageMS > current.maxTimeMS {
@@ -220,7 +219,6 @@ func parseProcesslist(r io.Reader, sourcePath string) (*model.ProcesslistData, [
 			}
 			current.row.anyField = true
 		case "Time_ms":
-			current.row.sawTimeMS = true
 			if parsed, ok := parseProcesslistNonNegativeFloat(val); ok {
 				current.row.timeMS = parsed
 				current.row.haveTimeMS = true

--- a/parse/processlist.go
+++ b/parse/processlist.go
@@ -52,7 +52,7 @@ func parseProcesslist(r io.Reader, sourcePath string) (*model.ProcesslistData, [
 		haveRowsSent     bool
 		haveRowsExamined bool
 		haveInfo         bool
-		anyField         bool
+		hasCoreField     bool
 	}
 	type sampleBuild struct {
 		t                 time.Time
@@ -89,13 +89,14 @@ func parseProcesslist(r io.Reader, sourcePath string) (*model.ProcesslistData, [
 		if current == nil {
 			return
 		}
-		if !current.row.anyField {
+		if !current.row.hasCoreField {
 			// Row-separator fired with none of the tracked fields
 			// populated — nothing to attribute. This is expected for
 			// the first `*** 1. row ***` marker in every sample (it
 			// delimits the start of the first row, not the end of a
 			// prior row), so skip quietly and do not emit a
 			// diagnostic.
+			current.row = rowBuild{}
 			return
 		}
 		label := current.row.state
@@ -215,47 +216,42 @@ func parseProcesslist(r io.Reader, sourcePath string) (*model.ProcesslistData, [
 		switch key {
 		case "State":
 			current.row.state = val
-			current.row.anyField = true
+			current.row.hasCoreField = true
 		case "User":
 			current.row.user = val
-			current.row.anyField = true
+			current.row.hasCoreField = true
 		case "Host":
 			current.row.host = val
-			current.row.anyField = true
+			current.row.hasCoreField = true
 		case "Command":
 			current.row.command = val
-			current.row.anyField = true
+			current.row.hasCoreField = true
 		case "db":
 			current.row.db = val
-			current.row.anyField = true
+			current.row.hasCoreField = true
 		case "Time":
 			if parsed, ok := parseProcesslistNonNegativeFloat(val); ok {
 				current.row.timeSeconds = parsed
 				current.row.haveTime = true
 			}
-			current.row.anyField = true
 		case "Time_ms":
 			if parsed, ok := parseProcesslistNonNegativeFloat(val); ok {
 				current.row.timeMS = parsed
 				current.row.haveTimeMS = true
 			}
-			current.row.anyField = true
 		case "Rows_sent":
 			if parsed, ok := parseProcesslistNonNegativeFloat(val); ok {
 				current.row.rowsSent = parsed
 				current.row.haveRowsSent = true
 			}
-			current.row.anyField = true
 		case "Rows_examined":
 			if parsed, ok := parseProcesslistNonNegativeFloat(val); ok {
 				current.row.rowsExamined = parsed
 				current.row.haveRowsExamined = true
 			}
-			current.row.anyField = true
 		case "Info":
 			current.row.info = val
 			current.row.haveInfo = true
-			current.row.anyField = true
 		}
 	}
 	if err := scanner.Err(); err != nil {

--- a/parse/processlist.go
+++ b/parse/processlist.go
@@ -37,21 +37,39 @@ func parseProcesslist(r io.Reader, sourcePath string) (*model.ProcesslistData, [
 	var diagnostics []model.Diagnostic
 
 	type rowBuild struct {
-		user     string
-		host     string
-		command  string
-		db       string
-		state    string
-		anyField bool
+		user             string
+		host             string
+		command          string
+		db               string
+		state            string
+		timeSeconds      float64
+		timeMS           float64
+		rowsSent         float64
+		rowsExamined     float64
+		info             string
+		haveTime         bool
+		sawTimeMS        bool
+		haveTimeMS       bool
+		haveRowsSent     bool
+		haveRowsExamined bool
+		haveInfo         bool
+		anyField         bool
 	}
 	type sampleBuild struct {
-		t       time.Time
-		state   map[string]int
-		user    map[string]int
-		host    map[string]int
-		command map[string]int
-		db      map[string]int
-		row     rowBuild
+		t                 time.Time
+		state             map[string]int
+		user              map[string]int
+		host              map[string]int
+		command           map[string]int
+		db                map[string]int
+		row               rowBuild
+		total             int
+		active            int
+		sleeping          int
+		maxTimeMS         float64
+		maxRowsExamined   float64
+		maxRowsSent       float64
+		rowsWithQueryText int
 	}
 	var samples []sampleBuild
 	var current *sampleBuild
@@ -112,6 +130,31 @@ func parseProcesslist(r io.Reader, sourcePath string) (*model.ProcesslistData, [
 		current.db[db]++
 		dbsSet[db] = struct{}{}
 
+		current.total++
+		if current.row.command == "Sleep" {
+			current.sleeping++
+		} else {
+			current.active++
+		}
+		ageMS := 0.0
+		if current.row.haveTimeMS {
+			ageMS = current.row.timeMS
+		} else if !current.row.sawTimeMS && current.row.haveTime {
+			ageMS = current.row.timeSeconds * 1000
+		}
+		if ageMS > current.maxTimeMS {
+			current.maxTimeMS = ageMS
+		}
+		if current.row.haveRowsExamined && current.row.rowsExamined > current.maxRowsExamined {
+			current.maxRowsExamined = current.row.rowsExamined
+		}
+		if current.row.haveRowsSent && current.row.rowsSent > current.maxRowsSent {
+			current.maxRowsSent = current.row.rowsSent
+		}
+		if current.row.haveInfo && hasProcesslistQueryText(current.row.info) {
+			current.rowsWithQueryText++
+		}
+
 		current.row = rowBuild{}
 	}
 
@@ -170,6 +213,35 @@ func parseProcesslist(r io.Reader, sourcePath string) (*model.ProcesslistData, [
 		case "db":
 			current.row.db = val
 			current.row.anyField = true
+		case "Time":
+			if parsed, ok := parseProcesslistNonNegativeFloat(val); ok {
+				current.row.timeSeconds = parsed
+				current.row.haveTime = true
+			}
+			current.row.anyField = true
+		case "Time_ms":
+			current.row.sawTimeMS = true
+			if parsed, ok := parseProcesslistNonNegativeFloat(val); ok {
+				current.row.timeMS = parsed
+				current.row.haveTimeMS = true
+			}
+			current.row.anyField = true
+		case "Rows_sent":
+			if parsed, ok := parseProcesslistNonNegativeFloat(val); ok {
+				current.row.rowsSent = parsed
+				current.row.haveRowsSent = true
+			}
+			current.row.anyField = true
+		case "Rows_examined":
+			if parsed, ok := parseProcesslistNonNegativeFloat(val); ok {
+				current.row.rowsExamined = parsed
+				current.row.haveRowsExamined = true
+			}
+			current.row.anyField = true
+		case "Info":
+			current.row.info = val
+			current.row.haveInfo = true
+			current.row.anyField = true
 		}
 	}
 	if err := scanner.Err(); err != nil {
@@ -219,12 +291,19 @@ func parseProcesslist(r io.Reader, sourcePath string) (*model.ProcesslistData, [
 	out := make([]model.ThreadStateSample, len(samples))
 	for i, s := range samples {
 		out[i] = model.ThreadStateSample{
-			Timestamp:     s.t,
-			StateCounts:   s.state,
-			UserCounts:    s.user,
-			HostCounts:    s.host,
-			CommandCounts: s.command,
-			DbCounts:      s.db,
+			Timestamp:         s.t,
+			StateCounts:       s.state,
+			UserCounts:        s.user,
+			HostCounts:        s.host,
+			CommandCounts:     s.command,
+			DbCounts:          s.db,
+			TotalThreads:      s.total,
+			ActiveThreads:     s.active,
+			SleepingThreads:   s.sleeping,
+			MaxTimeMS:         s.maxTimeMS,
+			MaxRowsExamined:   s.maxRowsExamined,
+			MaxRowsSent:       s.maxRowsSent,
+			RowsWithQueryText: s.rowsWithQueryText,
 		}
 	}
 
@@ -236,6 +315,19 @@ func parseProcesslist(r io.Reader, sourcePath string) (*model.ProcesslistData, [
 		Commands:           commands,
 		Dbs:                dbs,
 	}, diagnostics
+}
+
+func parseProcesslistNonNegativeFloat(s string) (float64, bool) {
+	v, err := strconv.ParseFloat(strings.TrimSpace(s), 64)
+	if err != nil || v < 0 || math.IsNaN(v) || math.IsInf(v, 0) {
+		return 0, false
+	}
+	return v, true
+}
+
+func hasProcesslistQueryText(s string) bool {
+	trimmed := strings.TrimSpace(s)
+	return trimmed != "" && !strings.EqualFold(trimmed, "NULL")
 }
 
 // stripHostPort trims the ":port" suffix from a processlist Host value.

--- a/parse/processlist_test.go
+++ b/parse/processlist_test.go
@@ -164,14 +164,26 @@ TS 1769702443.006126802 2026-01-29 16:00:43
 	if got, want := first.MaxTimeMS, 99000.0; got != want {
 		t.Errorf("first.MaxTimeMS = %v, want %v", got, want)
 	}
+	if !first.HasTimeMetric {
+		t.Error("first.HasTimeMetric = false, want true")
+	}
 	if got, want := first.MaxRowsExamined, 100.0; got != want {
 		t.Errorf("first.MaxRowsExamined = %v, want %v", got, want)
+	}
+	if !first.HasRowsExaminedMetric {
+		t.Error("first.HasRowsExaminedMetric = false, want true")
 	}
 	if got, want := first.MaxRowsSent, 5.0; got != want {
 		t.Errorf("first.MaxRowsSent = %v, want %v", got, want)
 	}
+	if !first.HasRowsSentMetric {
+		t.Error("first.HasRowsSentMetric = false, want true")
+	}
 	if got, want := first.RowsWithQueryText, 1; got != want {
 		t.Errorf("first.RowsWithQueryText = %d, want %d", got, want)
+	}
+	if !first.HasQueryTextMetric {
+		t.Error("first.HasQueryTextMetric = false, want true")
 	}
 
 	second := data.ThreadStateSamples[1]
@@ -184,8 +196,20 @@ TS 1769702443.006126802 2026-01-29 16:00:43
 	if got, want := second.MaxTimeMS, 7000.0; got != want {
 		t.Errorf("second.MaxTimeMS = %v, want %v", got, want)
 	}
+	if !second.HasTimeMetric {
+		t.Error("second.HasTimeMetric = false, want true")
+	}
+	if second.HasRowsExaminedMetric {
+		t.Error("second.HasRowsExaminedMetric = true, want false")
+	}
+	if second.HasRowsSentMetric {
+		t.Error("second.HasRowsSentMetric = true, want false")
+	}
 	if got, want := second.RowsWithQueryText, 0; got != want {
 		t.Errorf("second.RowsWithQueryText = %d, want %d", got, want)
+	}
+	if !second.HasQueryTextMetric {
+		t.Error("second.HasQueryTextMetric = false, want true")
 	}
 }
 

--- a/parse/processlist_test.go
+++ b/parse/processlist_test.go
@@ -128,6 +128,11 @@ Rows_examined: not-a-number
       Time_ms: not-a-number
     Rows_sent: 2
 Rows_examined: 50
+*************************** 4. row ***************************
+         Time: 999
+         Info: select phantom
+    Rows_sent: 9999
+Rows_examined: 9999
 TS 1769702443.006126802 2026-01-29 16:00:43
 *************************** 1. row ***************************
            Id: 14

--- a/parse/processlist_test.go
+++ b/parse/processlist_test.go
@@ -3,6 +3,7 @@ package parse
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/matias-sanchez/My-gather/tests/goldens"
@@ -88,6 +89,104 @@ func TestProcesslistGolden(t *testing.T) {
 		Diagnostics:        diags,
 	})
 	goldens.Compare(t, goldenPath, got)
+}
+
+func TestProcesslistRicherMetrics(t *testing.T) {
+	input := strings.NewReader(`TS 1769702442.006126802 2026-01-29 16:00:42
+*************************** 1. row ***************************
+           Id: 12
+         User: app
+         Host: 10.0.0.1:59136
+           db: shop
+      Command: Sleep
+         Time: 10
+        State:
+         Info: NULL
+      Time_ms: 10050
+    Rows_sent: 3
+Rows_examined: 100
+*************************** 2. row ***************************
+           Id: 13
+         User: app
+         Host: 10.0.0.2:59137
+           db: shop
+      Command: Query
+         Time: 1
+        State: Sending data
+         Info: select * from orders
+    Rows_sent: 5
+Rows_examined: not-a-number
+*************************** 3. row ***************************
+           Id: 15
+         User: app
+         Host: 10.0.0.4:59139
+           db: shop
+      Command: Execute
+         Time: 99
+        State: executing
+         Info: NULL
+      Time_ms: not-a-number
+    Rows_sent: 2
+Rows_examined: 50
+TS 1769702443.006126802 2026-01-29 16:00:43
+*************************** 1. row ***************************
+           Id: 14
+         User: app
+         Host: 10.0.0.3:59138
+           db: shop
+      Command: Connect
+         Time: 7
+        State:
+         Info:
+`)
+
+	data, diags := parseProcesslist(input, "synthetic-processlist")
+	if len(diags) != 0 {
+		t.Fatalf("unexpected diagnostics: %+v", diags)
+	}
+	if data == nil {
+		t.Fatal("parseProcesslist returned nil")
+	}
+	if got, want := len(data.ThreadStateSamples), 2; got != want {
+		t.Fatalf("ThreadStateSamples len = %d, want %d", got, want)
+	}
+
+	first := data.ThreadStateSamples[0]
+	if got, want := first.TotalThreads, 3; got != want {
+		t.Errorf("first.TotalThreads = %d, want %d", got, want)
+	}
+	if got, want := first.ActiveThreads, 2; got != want {
+		t.Errorf("first.ActiveThreads = %d, want %d", got, want)
+	}
+	if got, want := first.SleepingThreads, 1; got != want {
+		t.Errorf("first.SleepingThreads = %d, want %d", got, want)
+	}
+	if got, want := first.MaxTimeMS, 10050.0; got != want {
+		t.Errorf("first.MaxTimeMS = %v, want %v", got, want)
+	}
+	if got, want := first.MaxRowsExamined, 100.0; got != want {
+		t.Errorf("first.MaxRowsExamined = %v, want %v", got, want)
+	}
+	if got, want := first.MaxRowsSent, 5.0; got != want {
+		t.Errorf("first.MaxRowsSent = %v, want %v", got, want)
+	}
+	if got, want := first.RowsWithQueryText, 1; got != want {
+		t.Errorf("first.RowsWithQueryText = %d, want %d", got, want)
+	}
+
+	second := data.ThreadStateSamples[1]
+	if got, want := second.ActiveThreads, 1; got != want {
+		t.Errorf("second.ActiveThreads = %d, want %d", got, want)
+	}
+	if got, want := second.SleepingThreads, 0; got != want {
+		t.Errorf("second.SleepingThreads = %d, want %d", got, want)
+	}
+	if got, want := second.MaxTimeMS, 7000.0; got != want {
+		t.Errorf("second.MaxTimeMS = %v, want %v", got, want)
+	}
+	if got, want := second.RowsWithQueryText, 0; got != want {
+		t.Errorf("second.RowsWithQueryText = %d, want %d", got, want)
+	}
 }
 
 func TestStripHostPort(t *testing.T) {

--- a/parse/processlist_test.go
+++ b/parse/processlist_test.go
@@ -161,7 +161,7 @@ TS 1769702443.006126802 2026-01-29 16:00:43
 	if got, want := first.SleepingThreads, 1; got != want {
 		t.Errorf("first.SleepingThreads = %d, want %d", got, want)
 	}
-	if got, want := first.MaxTimeMS, 10050.0; got != want {
+	if got, want := first.MaxTimeMS, 99000.0; got != want {
 		t.Errorf("first.MaxTimeMS = %v, want %v", got, want)
 	}
 	if got, want := first.MaxRowsExamined, 100.0; got != want {

--- a/render/assets/app.js
+++ b/render/assets/app.js
@@ -1329,6 +1329,16 @@
       var n = data.timestamps.length;
       var hiddenLabels = currentHidden();
 
+      if (dim.key === "activity") {
+        plot = buildLineChart(el, {
+          timestamps: data.timestamps,
+          series: seriesData,
+          snapshotBoundaries: data.snapshotBoundaries,
+        }, dim.unit || "threads");
+        legendEl = el.nextSibling;
+        return;
+      }
+
       // Raw per-segment values per bucket. When a bucket is hidden via
       // the legend, its row is replaced with zeros so it contributes
       // nothing to the cumulative stack — the visible buckets then

--- a/render/build_view.go
+++ b/render/build_view.go
@@ -184,6 +184,9 @@ func buildView(r *model.Report, c *model.Collection, sigs []string) (*reportView
 		v.HasInnoDB = len(v.InnoDBMetrics) > 0
 		v.HasMysqladmin = r.DBSection.Mysqladmin != nil
 		v.HasProcesslist = r.DBSection.Processlist != nil
+		if v.HasProcesslist {
+			v.ProcesslistSummary = summariseProcesslist(r.DBSection.Processlist)
+		}
 		if v.HasMysqladmin {
 			v.MysqladminVariables = append(v.MysqladminVariables, r.DBSection.Mysqladmin.VariableNames...)
 			v.MysqladminCount = len(r.DBSection.Mysqladmin.VariableNames)

--- a/render/db_test.go
+++ b/render/db_test.go
@@ -167,3 +167,21 @@ func TestMysqladminToggleMarkup(t *testing.T) {
 		}
 	}
 }
+
+func TestProcesslistRicherMetricMarkup(t *testing.T) {
+	html := renderGolden(t, model.SuffixInnodbStatus, model.SuffixMysqladmin, model.SuffixProcesslist)
+	section := extractDetailsSection(t, html, "sec-db")
+
+	for _, want := range []string{
+		`peak active`,
+		`peak sleeping`,
+		`longest age`,
+		`peak rows examined`,
+		`peak rows sent`,
+		`query text rows`,
+	} {
+		if !strings.Contains(section, want) {
+			t.Errorf("sec-db processlist markup missing %q", want)
+		}
+	}
+}

--- a/render/payloads.go
+++ b/render/payloads.go
@@ -202,6 +202,27 @@ func processlistChartPayload(d *model.ProcesslistData) map[string]any {
 		return out
 	}
 
+	activitySeries := []map[string]any{
+		{
+			"label": "Active",
+			"values": processlistMetricValues(d, func(s model.ThreadStateSample) float64 {
+				return float64(s.ActiveThreads)
+			}),
+		},
+		{
+			"label": "Sleeping",
+			"values": processlistMetricValues(d, func(s model.ThreadStateSample) float64 {
+				return float64(s.SleepingThreads)
+			}),
+		},
+		{
+			"label": "Total",
+			"values": processlistMetricValues(d, func(s model.ThreadStateSample) float64 {
+				return float64(s.TotalThreads)
+			}),
+		},
+	}
+
 	dimensions := []map[string]any{
 		{
 			"key":    "state",
@@ -233,16 +254,44 @@ func processlistChartPayload(d *model.ProcesslistData) map[string]any {
 			"unit":   "threads",
 			"series": buildSeries(d.Dbs, func(s model.ThreadStateSample, l string) int { return s.DbCounts[l] }),
 		},
+		{
+			"key":    "activity",
+			"label":  "Activity",
+			"unit":   "threads",
+			"series": activitySeries,
+		},
 	}
 
 	// Primary `series` stays pointed at the State dimension so the
 	// existing renderTimeSeries fallback path remains functional.
 	return map[string]any{
-		"timestamps":         timestamps,
-		"series":             dimensions[0]["series"],
-		"dimensions":         dimensions,
+		"timestamps": timestamps,
+		"series":     dimensions[0]["series"],
+		"dimensions": dimensions,
+		"metrics": map[string]any{
+			"maxTimeSeconds": processlistMetricValues(d, func(s model.ThreadStateSample) float64 {
+				return s.MaxTimeMS / 1000
+			}),
+			"maxRowsExamined": processlistMetricValues(d, func(s model.ThreadStateSample) float64 {
+				return s.MaxRowsExamined
+			}),
+			"maxRowsSent": processlistMetricValues(d, func(s model.ThreadStateSample) float64 {
+				return s.MaxRowsSent
+			}),
+			"rowsWithQueryText": processlistMetricValues(d, func(s model.ThreadStateSample) float64 {
+				return float64(s.RowsWithQueryText)
+			}),
+		},
 		"snapshotBoundaries": d.SnapshotBoundaries,
 	}
+}
+
+func processlistMetricValues(d *model.ProcesslistData, pick func(model.ThreadStateSample) float64) []float64 {
+	values := make([]float64, len(d.ThreadStateSamples))
+	for i, s := range d.ThreadStateSamples {
+		values[i] = pick(s)
+	}
+	return values
 }
 
 // chartTimestamps extracts a unified timestamp axis from an arbitrary

--- a/render/payloads.go
+++ b/render/payloads.go
@@ -272,14 +272,26 @@ func processlistChartPayload(d *model.ProcesslistData) map[string]any {
 			"maxTimeSeconds": processlistMetricValues(d, func(s model.ThreadStateSample) float64 {
 				return s.MaxTimeMS / 1000
 			}),
+			"hasMaxTimeSeconds": processlistBoolValues(d, func(s model.ThreadStateSample) bool {
+				return s.HasTimeMetric
+			}),
 			"maxRowsExamined": processlistMetricValues(d, func(s model.ThreadStateSample) float64 {
 				return s.MaxRowsExamined
+			}),
+			"hasRowsExamined": processlistBoolValues(d, func(s model.ThreadStateSample) bool {
+				return s.HasRowsExaminedMetric
 			}),
 			"maxRowsSent": processlistMetricValues(d, func(s model.ThreadStateSample) float64 {
 				return s.MaxRowsSent
 			}),
+			"hasRowsSent": processlistBoolValues(d, func(s model.ThreadStateSample) bool {
+				return s.HasRowsSentMetric
+			}),
 			"rowsWithQueryText": processlistMetricValues(d, func(s model.ThreadStateSample) float64 {
 				return float64(s.RowsWithQueryText)
+			}),
+			"hasQueryText": processlistBoolValues(d, func(s model.ThreadStateSample) bool {
+				return s.HasQueryTextMetric
 			}),
 		},
 		"snapshotBoundaries": d.SnapshotBoundaries,
@@ -288,6 +300,14 @@ func processlistChartPayload(d *model.ProcesslistData) map[string]any {
 
 func processlistMetricValues(d *model.ProcesslistData, pick func(model.ThreadStateSample) float64) []float64 {
 	values := make([]float64, len(d.ThreadStateSamples))
+	for i, s := range d.ThreadStateSamples {
+		values[i] = pick(s)
+	}
+	return values
+}
+
+func processlistBoolValues(d *model.ProcesslistData, pick func(model.ThreadStateSample) bool) []bool {
+	values := make([]bool, len(d.ThreadStateSamples))
 	for i, s := range d.ThreadStateSamples {
 		values[i] = pick(s)
 	}

--- a/render/render_test.go
+++ b/render/render_test.go
@@ -285,26 +285,34 @@ func twoSnapshotCollection() *model.Collection {
 			States: []string{"Sending data", "Sleep"},
 			ThreadStateSamples: []model.ThreadStateSample{
 				{
-					Timestamp:         ts(tsOffset),
-					StateCounts:       map[string]int{"Sending data": 2, "Sleep": 8},
-					TotalThreads:      10,
-					ActiveThreads:     2,
-					SleepingThreads:   8,
-					MaxTimeMS:         1200,
-					MaxRowsExamined:   200,
-					MaxRowsSent:       20,
-					RowsWithQueryText: 2,
+					Timestamp:             ts(tsOffset),
+					StateCounts:           map[string]int{"Sending data": 2, "Sleep": 8},
+					TotalThreads:          10,
+					ActiveThreads:         2,
+					SleepingThreads:       8,
+					MaxTimeMS:             1200,
+					HasTimeMetric:         true,
+					MaxRowsExamined:       200,
+					HasRowsExaminedMetric: true,
+					MaxRowsSent:           20,
+					HasRowsSentMetric:     true,
+					RowsWithQueryText:     2,
+					HasQueryTextMetric:    true,
 				},
 				{
-					Timestamp:         ts(tsOffset + 1),
-					StateCounts:       map[string]int{"Sending data": 3, "Sleep": 7},
-					TotalThreads:      10,
-					ActiveThreads:     3,
-					SleepingThreads:   7,
-					MaxTimeMS:         2500,
-					MaxRowsExamined:   350,
-					MaxRowsSent:       25,
-					RowsWithQueryText: 3,
+					Timestamp:             ts(tsOffset + 1),
+					StateCounts:           map[string]int{"Sending data": 3, "Sleep": 7},
+					TotalThreads:          10,
+					ActiveThreads:         3,
+					SleepingThreads:       7,
+					MaxTimeMS:             2500,
+					HasTimeMetric:         true,
+					MaxRowsExamined:       350,
+					HasRowsExaminedMetric: true,
+					MaxRowsSent:           25,
+					HasRowsSentMetric:     true,
+					RowsWithQueryText:     3,
+					HasQueryTextMetric:    true,
 				},
 			},
 			SnapshotBoundaries: []int{0},
@@ -367,9 +375,13 @@ func TestProcesslistPayloadIncludesRicherMetrics(t *testing.T) {
 				} `json:"dimensions"`
 				Metrics struct {
 					MaxTimeSeconds    []float64 `json:"maxTimeSeconds"`
+					HasMaxTimeSeconds []bool    `json:"hasMaxTimeSeconds"`
 					MaxRowsExamined   []float64 `json:"maxRowsExamined"`
+					HasRowsExamined   []bool    `json:"hasRowsExamined"`
 					MaxRowsSent       []float64 `json:"maxRowsSent"`
+					HasRowsSent       []bool    `json:"hasRowsSent"`
 					RowsWithQueryText []float64 `json:"rowsWithQueryText"`
+					HasQueryText      []bool    `json:"hasQueryText"`
 				} `json:"metrics"`
 			} `json:"processlist"`
 		} `json:"charts"`
@@ -400,11 +412,69 @@ func TestProcesslistPayloadIncludesRicherMetrics(t *testing.T) {
 	if got, want := parsed.Charts.Processlist.Metrics.MaxTimeSeconds[1], 2.5; got != want {
 		t.Errorf("MaxTimeSeconds[1] = %v, want %v", got, want)
 	}
+	if got, want := parsed.Charts.Processlist.Metrics.HasMaxTimeSeconds[1], true; got != want {
+		t.Errorf("HasMaxTimeSeconds[1] = %v, want %v", got, want)
+	}
 	if got, want := parsed.Charts.Processlist.Metrics.MaxRowsExamined[1], 350.0; got != want {
 		t.Errorf("MaxRowsExamined[1] = %v, want %v", got, want)
 	}
+	if got, want := parsed.Charts.Processlist.Metrics.HasRowsExamined[1], true; got != want {
+		t.Errorf("HasRowsExamined[1] = %v, want %v", got, want)
+	}
 	if got, want := parsed.Charts.Processlist.Metrics.RowsWithQueryText[1], 3.0; got != want {
 		t.Errorf("RowsWithQueryText[1] = %v, want %v", got, want)
+	}
+	if got, want := parsed.Charts.Processlist.Metrics.HasQueryText[1], true; got != want {
+		t.Errorf("HasQueryText[1] = %v, want %v", got, want)
+	}
+}
+
+func TestProcesslistSummaryOmitsUnavailableOptionalMetrics(t *testing.T) {
+	ts := time.Date(2026, 4, 21, 16, 52, 0, 0, time.UTC)
+	c := &model.Collection{
+		RootPath: "/tmp/example",
+		Hostname: "example-db-01",
+		Snapshots: []*model.Snapshot{
+			{
+				Timestamp: ts,
+				Prefix:    "2026_04_21_16_52_00",
+				SourceFiles: map[model.Suffix]*model.SourceFile{
+					model.SuffixProcesslist: {
+						Suffix: model.SuffixProcesslist,
+						Parsed: &model.ProcesslistData{
+							States: []string{"Sleep"},
+							ThreadStateSamples: []model.ThreadStateSample{
+								{
+									Timestamp:       ts,
+									StateCounts:     map[string]int{"Sleep": 4},
+									TotalThreads:    4,
+									ActiveThreads:   0,
+									SleepingThreads: 4,
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	var buf bytes.Buffer
+	opts := render.RenderOptions{GeneratedAt: fixedTime(), Version: "v0.0.1-test"}
+	if err := render.Render(&buf, c, opts); err != nil {
+		t.Fatalf("Render: %v", err)
+	}
+	section := extractDetailsSection(t, buf.String(), "sec-db")
+
+	for _, want := range []string{"peak active", "peak sleeping", "samples"} {
+		if !strings.Contains(section, want) {
+			t.Errorf("sec-db processlist markup missing available callout %q", want)
+		}
+	}
+	for _, notWant := range []string{"longest age", "peak rows examined", "peak rows sent", "query text rows"} {
+		if strings.Contains(section, notWant) {
+			t.Errorf("sec-db processlist markup contains unavailable callout %q", notWant)
+		}
 	}
 }
 

--- a/render/render_test.go
+++ b/render/render_test.go
@@ -2,6 +2,7 @@ package render_test
 
 import (
 	"bytes"
+	"encoding/json"
 	"strings"
 	"testing"
 	"time"
@@ -283,8 +284,28 @@ func twoSnapshotCollection() *model.Collection {
 		return &model.ProcesslistData{
 			States: []string{"Sending data", "Sleep"},
 			ThreadStateSamples: []model.ThreadStateSample{
-				{Timestamp: ts(tsOffset), StateCounts: map[string]int{"Sending data": 2, "Sleep": 8}},
-				{Timestamp: ts(tsOffset + 1), StateCounts: map[string]int{"Sending data": 3, "Sleep": 7}},
+				{
+					Timestamp:         ts(tsOffset),
+					StateCounts:       map[string]int{"Sending data": 2, "Sleep": 8},
+					TotalThreads:      10,
+					ActiveThreads:     2,
+					SleepingThreads:   8,
+					MaxTimeMS:         1200,
+					MaxRowsExamined:   200,
+					MaxRowsSent:       20,
+					RowsWithQueryText: 2,
+				},
+				{
+					Timestamp:         ts(tsOffset + 1),
+					StateCounts:       map[string]int{"Sending data": 3, "Sleep": 7},
+					TotalThreads:      10,
+					ActiveThreads:     3,
+					SleepingThreads:   7,
+					MaxTimeMS:         2500,
+					MaxRowsExamined:   350,
+					MaxRowsSent:       25,
+					RowsWithQueryText: 3,
+				},
 			},
 			SnapshotBoundaries: []int{0},
 		}
@@ -322,6 +343,68 @@ func twoSnapshotCollection() *model.Collection {
 		RootPath:  "/tmp/example",
 		Hostname:  "example-db-01",
 		Snapshots: []*model.Snapshot{snap("2026_04_21_16_52_11", 0, 100), snap("2026_04_21_16_52_41", 30, 500)},
+	}
+}
+
+func TestProcesslistPayloadIncludesRicherMetrics(t *testing.T) {
+	c := twoSnapshotCollection()
+	var buf bytes.Buffer
+	opts := render.RenderOptions{GeneratedAt: fixedTime(), Version: "v0.0.1-test"}
+	if err := render.Render(&buf, c, opts); err != nil {
+		t.Fatalf("Render: %v", err)
+	}
+
+	var parsed struct {
+		Charts struct {
+			Processlist struct {
+				Dimensions []struct {
+					Key    string `json:"key"`
+					Label  string `json:"label"`
+					Series []struct {
+						Label  string    `json:"label"`
+						Values []float64 `json:"values"`
+					} `json:"series"`
+				} `json:"dimensions"`
+				Metrics struct {
+					MaxTimeSeconds    []float64 `json:"maxTimeSeconds"`
+					MaxRowsExamined   []float64 `json:"maxRowsExamined"`
+					MaxRowsSent       []float64 `json:"maxRowsSent"`
+					RowsWithQueryText []float64 `json:"rowsWithQueryText"`
+				} `json:"metrics"`
+			} `json:"processlist"`
+		} `json:"charts"`
+	}
+	if err := json.Unmarshal([]byte(extractJSONPayload(t, buf.String())), &parsed); err != nil {
+		t.Fatalf("report-data payload is not valid JSON: %v", err)
+	}
+
+	foundActivity := false
+	for _, dim := range parsed.Charts.Processlist.Dimensions {
+		if dim.Key != "activity" {
+			continue
+		}
+		foundActivity = true
+		if got, want := len(dim.Series), 3; got != want {
+			t.Fatalf("activity series len = %d, want %d", got, want)
+		}
+		if dim.Series[0].Label != "Active" || dim.Series[1].Label != "Sleeping" || dim.Series[2].Label != "Total" {
+			t.Fatalf("unexpected activity labels: %#v", dim.Series)
+		}
+		if got, want := dim.Series[0].Values[0], 2.0; got != want {
+			t.Errorf("first active value = %v, want %v", got, want)
+		}
+	}
+	if !foundActivity {
+		t.Fatal("processlist payload missing activity dimension")
+	}
+	if got, want := parsed.Charts.Processlist.Metrics.MaxTimeSeconds[1], 2.5; got != want {
+		t.Errorf("MaxTimeSeconds[1] = %v, want %v", got, want)
+	}
+	if got, want := parsed.Charts.Processlist.Metrics.MaxRowsExamined[1], 350.0; got != want {
+		t.Errorf("MaxRowsExamined[1] = %v, want %v", got, want)
+	}
+	if got, want := parsed.Charts.Processlist.Metrics.RowsWithQueryText[1], 3.0; got != want {
+		t.Errorf("RowsWithQueryText[1] = %v, want %v", got, want)
 	}
 }
 

--- a/render/summaries.go
+++ b/render/summaries.go
@@ -249,3 +249,37 @@ func summariseNetwork(counters *model.NetstatCountersData, sockets *model.Netsta
 	}
 	return sum
 }
+
+func summariseProcesslist(d *model.ProcesslistData) *processlistSummaryView {
+	sum := &processlistSummaryView{}
+	var peakActive, peakSleeping, peakQueryTextRows int
+	var longestAgeMS, peakRowsExamined, peakRowsSent float64
+	for _, s := range d.ThreadStateSamples {
+		sum.SampleCount++
+		if s.ActiveThreads > peakActive {
+			peakActive = s.ActiveThreads
+		}
+		if s.SleepingThreads > peakSleeping {
+			peakSleeping = s.SleepingThreads
+		}
+		if s.MaxTimeMS > longestAgeMS {
+			longestAgeMS = s.MaxTimeMS
+		}
+		if s.MaxRowsExamined > peakRowsExamined {
+			peakRowsExamined = s.MaxRowsExamined
+		}
+		if s.MaxRowsSent > peakRowsSent {
+			peakRowsSent = s.MaxRowsSent
+		}
+		if s.RowsWithQueryText > peakQueryTextRows {
+			peakQueryTextRows = s.RowsWithQueryText
+		}
+	}
+	sum.PeakActive = fmt.Sprintf("%d", peakActive)
+	sum.PeakSleeping = fmt.Sprintf("%d", peakSleeping)
+	sum.LongestAge = formatFloat(longestAgeMS/1000, 1)
+	sum.PeakRowsExamined = formatFloat(peakRowsExamined, 0)
+	sum.PeakRowsSent = formatFloat(peakRowsSent, 0)
+	sum.PeakQueryTextRows = fmt.Sprintf("%d", peakQueryTextRows)
+	return sum
+}

--- a/render/summaries.go
+++ b/render/summaries.go
@@ -265,14 +265,26 @@ func summariseProcesslist(d *model.ProcesslistData) *processlistSummaryView {
 		if s.SleepingThreads > peakSleeping {
 			peakSleeping = s.SleepingThreads
 		}
+		if s.HasTimeMetric {
+			sum.HasLongestAge = true
+		}
 		if s.MaxTimeMS > longestAgeMS {
 			longestAgeMS = s.MaxTimeMS
+		}
+		if s.HasRowsExaminedMetric {
+			sum.HasPeakRowsExamined = true
 		}
 		if s.MaxRowsExamined > peakRowsExamined {
 			peakRowsExamined = s.MaxRowsExamined
 		}
+		if s.HasRowsSentMetric {
+			sum.HasPeakRowsSent = true
+		}
 		if s.MaxRowsSent > peakRowsSent {
 			peakRowsSent = s.MaxRowsSent
+		}
+		if s.HasQueryTextMetric {
+			sum.HasPeakQueryTextRows = true
 		}
 		if s.RowsWithQueryText > peakQueryTextRows {
 			peakQueryTextRows = s.RowsWithQueryText
@@ -280,9 +292,17 @@ func summariseProcesslist(d *model.ProcesslistData) *processlistSummaryView {
 	}
 	sum.PeakActive = fmt.Sprintf("%d", peakActive)
 	sum.PeakSleeping = fmt.Sprintf("%d", peakSleeping)
-	sum.LongestAge = formatFloat(longestAgeMS/1000, 1)
-	sum.PeakRowsExamined = formatFloat(peakRowsExamined, 0)
-	sum.PeakRowsSent = formatFloat(peakRowsSent, 0)
-	sum.PeakQueryTextRows = fmt.Sprintf("%d", peakQueryTextRows)
+	if sum.HasLongestAge {
+		sum.LongestAge = formatFloat(longestAgeMS/1000, 1)
+	}
+	if sum.HasPeakRowsExamined {
+		sum.PeakRowsExamined = formatFloat(peakRowsExamined, 0)
+	}
+	if sum.HasPeakRowsSent {
+		sum.PeakRowsSent = formatFloat(peakRowsSent, 0)
+	}
+	if sum.HasPeakQueryTextRows {
+		sum.PeakQueryTextRows = fmt.Sprintf("%d", peakQueryTextRows)
+	}
 	return sum
 }

--- a/render/summaries.go
+++ b/render/summaries.go
@@ -252,6 +252,9 @@ func summariseNetwork(counters *model.NetstatCountersData, sockets *model.Netsta
 
 func summariseProcesslist(d *model.ProcesslistData) *processlistSummaryView {
 	sum := &processlistSummaryView{}
+	if d == nil {
+		return sum
+	}
 	var peakActive, peakSleeping, peakQueryTextRows int
 	var longestAgeMS, peakRowsExamined, peakRowsSent float64
 	for _, s := range d.ThreadStateSamples {

--- a/render/summaries_test.go
+++ b/render/summaries_test.go
@@ -1,6 +1,11 @@
 package render
 
-import "testing"
+import (
+	"testing"
+	"time"
+
+	"github.com/matias-sanchez/My-gather/model"
+)
 
 func TestSummariseProcesslistNilSafe(t *testing.T) {
 	sum := summariseProcesslist(nil)
@@ -9,5 +14,34 @@ func TestSummariseProcesslistNilSafe(t *testing.T) {
 	}
 	if sum.SampleCount != 0 {
 		t.Errorf("summariseProcesslist(nil).SampleCount = %d, want 0", sum.SampleCount)
+	}
+}
+
+func TestSummariseProcesslistPreservesAvailableZeroMetrics(t *testing.T) {
+	sum := summariseProcesslist(&model.ProcesslistData{
+		ThreadStateSamples: []model.ThreadStateSample{
+			{
+				Timestamp:             time.Date(2026, 4, 21, 16, 52, 0, 0, time.UTC),
+				TotalThreads:          1,
+				ActiveThreads:         1,
+				HasTimeMetric:         true,
+				HasRowsExaminedMetric: true,
+				HasRowsSentMetric:     true,
+				HasQueryTextMetric:    true,
+			},
+		},
+	})
+
+	if !sum.HasLongestAge || sum.LongestAge != "0.0" {
+		t.Errorf("LongestAge = (%t, %q), want available 0.0", sum.HasLongestAge, sum.LongestAge)
+	}
+	if !sum.HasPeakRowsExamined || sum.PeakRowsExamined != "0" {
+		t.Errorf("PeakRowsExamined = (%t, %q), want available 0", sum.HasPeakRowsExamined, sum.PeakRowsExamined)
+	}
+	if !sum.HasPeakRowsSent || sum.PeakRowsSent != "0" {
+		t.Errorf("PeakRowsSent = (%t, %q), want available 0", sum.HasPeakRowsSent, sum.PeakRowsSent)
+	}
+	if !sum.HasPeakQueryTextRows || sum.PeakQueryTextRows != "0" {
+		t.Errorf("PeakQueryTextRows = (%t, %q), want available 0", sum.HasPeakQueryTextRows, sum.PeakQueryTextRows)
 	}
 }

--- a/render/summaries_test.go
+++ b/render/summaries_test.go
@@ -1,0 +1,13 @@
+package render
+
+import "testing"
+
+func TestSummariseProcesslistNilSafe(t *testing.T) {
+	sum := summariseProcesslist(nil)
+	if sum == nil {
+		t.Fatal("summariseProcesslist(nil) returned nil")
+	}
+	if sum.SampleCount != 0 {
+		t.Errorf("summariseProcesslist(nil).SampleCount = %d, want 0", sum.SampleCount)
+	}
+}

--- a/render/templates/db.html.tmpl
+++ b/render/templates/db.html.tmpl
@@ -194,6 +194,17 @@
   <summary><span>Thread states</span><span class="badge">-processlist</span></summary>
   <div class="body">
     {{- if .HasProcesslist }}
+    {{- with .ProcesslistSummary }}
+    <div class="chart-summary">
+      <span class="stat"><span class="k">peak active</span> <span class="v">{{.PeakActive}}</span> <span class="ctx">threads</span></span>
+      <span class="stat"><span class="k">peak sleeping</span> <span class="v">{{.PeakSleeping}}</span> <span class="ctx">threads</span></span>
+      <span class="stat"><span class="k">longest age</span> <span class="v">{{.LongestAge}}</span> <span class="ctx">s</span></span>
+      <span class="stat"><span class="k">peak rows examined</span> <span class="v">{{.PeakRowsExamined}}</span></span>
+      <span class="stat"><span class="k">peak rows sent</span> <span class="v">{{.PeakRowsSent}}</span></span>
+      <span class="stat"><span class="k">query text rows</span> <span class="v">{{.PeakQueryTextRows}}</span></span>
+      <span class="stat"><span class="k">samples</span> <span class="v">{{.SampleCount}}</span></span>
+    </div>
+    {{- end }}
     <div class="chart" id="chart-processlist" data-chart="processlist"
          aria-label="Count of threads per state over time"></div>
     <noscript><p class="banner">Charts require JavaScript. Raw processlist data is embedded in the page.</p></noscript>

--- a/render/templates/db.html.tmpl
+++ b/render/templates/db.html.tmpl
@@ -198,10 +198,18 @@
     <div class="chart-summary">
       <span class="stat"><span class="k">peak active</span> <span class="v">{{.PeakActive}}</span> <span class="ctx">threads</span></span>
       <span class="stat"><span class="k">peak sleeping</span> <span class="v">{{.PeakSleeping}}</span> <span class="ctx">threads</span></span>
+      {{- if .HasLongestAge }}
       <span class="stat"><span class="k">longest age</span> <span class="v">{{.LongestAge}}</span> <span class="ctx">s</span></span>
+      {{- end }}
+      {{- if .HasPeakRowsExamined }}
       <span class="stat"><span class="k">peak rows examined</span> <span class="v">{{.PeakRowsExamined}}</span></span>
+      {{- end }}
+      {{- if .HasPeakRowsSent }}
       <span class="stat"><span class="k">peak rows sent</span> <span class="v">{{.PeakRowsSent}}</span></span>
+      {{- end }}
+      {{- if .HasPeakQueryTextRows }}
       <span class="stat"><span class="k">query text rows</span> <span class="v">{{.PeakQueryTextRows}}</span></span>
+      {{- end }}
       <span class="stat"><span class="k">samples</span> <span class="v">{{.SampleCount}}</span></span>
     </div>
     {{- end }}

--- a/render/view.go
+++ b/render/view.go
@@ -307,11 +307,15 @@ type networkSummaryView struct {
 }
 
 type processlistSummaryView struct {
-	PeakActive        string
-	PeakSleeping      string
-	LongestAge        string
-	PeakRowsExamined  string
-	PeakRowsSent      string
-	PeakQueryTextRows string
-	SampleCount       int
+	PeakActive           string
+	PeakSleeping         string
+	LongestAge           string
+	HasLongestAge        bool
+	PeakRowsExamined     string
+	HasPeakRowsExamined  bool
+	PeakRowsSent         string
+	HasPeakRowsSent      bool
+	PeakQueryTextRows    string
+	HasPeakQueryTextRows bool
+	SampleCount          int
 }

--- a/render/view.go
+++ b/render/view.go
@@ -70,6 +70,7 @@ type reportView struct {
 	MysqladminCount     int
 	MysqladminSelectID  string
 	HasProcesslist      bool
+	ProcesslistSummary  *processlistSummaryView
 }
 
 type variableSnapshotView struct {
@@ -303,4 +304,14 @@ type networkSummaryView struct {
 	PeakTimeWait        string
 	PeakCloseWait       string
 	SampleCount         int
+}
+
+type processlistSummaryView struct {
+	PeakActive        string
+	PeakSleeping      string
+	LongestAge        string
+	PeakRowsExamined  string
+	PeakRowsSent      string
+	PeakQueryTextRows string
+	SampleCount       int
 }

--- a/specs/005-richer-processlist-metrics/checklists/requirements.md
+++ b/specs/005-richer-processlist-metrics/checklists/requirements.md
@@ -1,0 +1,34 @@
+# Specification Quality Checklist: Richer Processlist Metrics
+
+**Purpose**: Validate specification completeness and quality before planning  
+**Created**: 2026-04-28  
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- Specification is ready for planning with no clarification markers.

--- a/specs/005-richer-processlist-metrics/contracts/packages.md
+++ b/specs/005-richer-processlist-metrics/contracts/packages.md
@@ -17,6 +17,8 @@ Additional contract for this feature:
 - Do not fail the sample when optional numeric fields are missing or malformed.
 - Compute the richer metrics on row flush so each completed row contributes at
   most once.
+- Treat `State`, `User`, `Host`, `Command`, and `db` as core row fields for row
+  completion. Optional metric fields alone must not create phantom rows.
 - Leave `SnapshotBoundaries` unset; merged boundaries remain render-owned.
 
 ## `model` package

--- a/specs/005-richer-processlist-metrics/contracts/packages.md
+++ b/specs/005-richer-processlist-metrics/contracts/packages.md
@@ -1,0 +1,60 @@
+# Phase 1 Package Contract: Richer Processlist Metrics
+
+## `parse` package
+
+### `parseProcesslist`
+
+Input: an `io.Reader` containing pt-stalk `-processlist` output in vertical
+`SHOW FULL PROCESSLIST \G` format.
+
+Output: `*model.ProcesslistData` with one `ThreadStateSample` per `TS` block.
+
+Additional contract for this feature:
+
+- Parse `Time`, `Time_ms`, `Rows_sent`, `Rows_examined`, and `Info` fields when
+  present.
+- Preserve existing state/user/host/command/db bucketing behavior.
+- Do not fail the sample when optional numeric fields are missing or malformed.
+- Compute the richer metrics on row flush so each completed row contributes at
+  most once.
+- Leave `SnapshotBoundaries` unset; merged boundaries remain render-owned.
+
+## `model` package
+
+### `ThreadStateSample`
+
+`ThreadStateSample` adds exported fields for:
+
+- `TotalThreads`
+- `ActiveThreads`
+- `SleepingThreads`
+- `MaxTimeMS`
+- `MaxRowsExamined`
+- `MaxRowsSent`
+- `RowsWithQueryText`
+
+Each exported field must have a godoc comment and must marshal
+deterministically in existing golden tests.
+
+## `render` package
+
+### `concatProcesslist`
+
+Merging multiple `ProcesslistData` values must preserve the richer per-sample
+fields exactly while continuing to union label sets and set
+`SnapshotBoundaries`.
+
+### `processlistChartPayload`
+
+The payload must keep the existing `timestamps`, `dimensions`, and
+`snapshotBoundaries` keys. It must add:
+
+- an `Activity` dimension containing active, sleeping, and total thread counts
+- a `metrics` object containing longest age in seconds, peak rows examined,
+  peak rows sent, and query-text row count arrays
+
+### `summariseProcesslist`
+
+The summary helper must return formatted peak values for the Processlist
+subview callouts. It must accept empty data and return an empty summary rather
+than panicking.

--- a/specs/005-richer-processlist-metrics/contracts/packages.md
+++ b/specs/005-richer-processlist-metrics/contracts/packages.md
@@ -29,9 +29,13 @@ Additional contract for this feature:
 - `ActiveThreads`
 - `SleepingThreads`
 - `MaxTimeMS`
+- `HasTimeMetric`
 - `MaxRowsExamined`
+- `HasRowsExaminedMetric`
 - `MaxRowsSent`
+- `HasRowsSentMetric`
 - `RowsWithQueryText`
+- `HasQueryTextMetric`
 
 Each exported field must have a godoc comment and must marshal
 deterministically in existing golden tests.
@@ -52,9 +56,12 @@ The payload must keep the existing `timestamps`, `dimensions`, and
 - an `Activity` dimension containing active, sleeping, and total thread counts
 - a `metrics` object containing longest age in seconds, peak rows examined,
   peak rows sent, and query-text row count arrays
+- boolean availability arrays for each optional `metrics` value so consumers
+  can distinguish unavailable source fields from real zero values
 
 ### `summariseProcesslist`
 
 The summary helper must return formatted peak values for the Processlist
 subview callouts. It must accept empty data and return an empty summary rather
-than panicking.
+than panicking. Optional callouts must be marked unavailable unless at least one
+sample contains the corresponding source metric.

--- a/specs/005-richer-processlist-metrics/contracts/ui.md
+++ b/specs/005-richer-processlist-metrics/contracts/ui.md
@@ -1,0 +1,57 @@
+# Phase 1 UI Contract: Processlist Subview
+
+## Scope
+
+This contract extends the existing Database Usage Processlist subview. It does
+not add a new top-level report section.
+
+## Summary callouts
+
+When processlist data exists, the subview must render compact callouts before
+the chart:
+
+- peak active threads
+- peak sleeping threads
+- longest thread age
+- peak rows examined
+- peak rows sent
+- peak query-text rows
+- samples
+
+Each callout is omitted only if the underlying metric is unavailable. A metric
+with a real zero value may render as `0`.
+
+## Chart controls
+
+The existing Processlist chart dimension toolbar must continue to provide:
+
+- State
+- User
+- Host
+- Command
+- db
+
+The feature adds:
+
+- Activity
+
+The Activity view shows active, sleeping, and total thread counts on the same
+timeline as the other Processlist dimensions. It uses the same offline chart
+library and embedded payload as the existing views.
+
+## Payload contract
+
+The browser receives all values from the existing `report-data` JSON script.
+The report must not fetch any processlist data at view time.
+
+The `processlist.metrics` object is reserved for non-stacked metric arrays. The
+first implementation may use it for summaries and hover/detail text; future UI
+work can render it as a separate mini chart without changing the parser model.
+
+## Empty and degraded states
+
+- If `-processlist` is absent or unparseable, the existing missing-data banner
+  remains the only visible Processlist body.
+- If richer optional fields are absent, the Processlist chart still renders the
+  existing dimensions.
+- The subview must not expose a new raw SQL table.

--- a/specs/005-richer-processlist-metrics/contracts/ui.md
+++ b/specs/005-richer-processlist-metrics/contracts/ui.md
@@ -21,6 +21,14 @@ the chart:
 Each callout is omitted only if the underlying metric is unavailable. A metric
 with a real zero value may render as `0`.
 
+Optional metrics are available only when at least one sample contains the
+corresponding source field:
+
+- longest thread age requires a valid `Time_ms` or `Time`
+- peak rows examined requires a valid `Rows_examined`
+- peak rows sent requires a valid `Rows_sent`
+- peak query-text rows requires an `Info` field
+
 ## Chart controls
 
 The existing Processlist chart dimension toolbar must continue to provide:

--- a/specs/005-richer-processlist-metrics/data-model.md
+++ b/specs/005-richer-processlist-metrics/data-model.md
@@ -30,9 +30,13 @@ The feature adds these aggregate fields:
 | `ActiveThreads` | `int` | Rows whose command is not `Sleep` | `Command` |
 | `SleepingThreads` | `int` | Rows whose command is exactly `Sleep` | `Command` |
 | `MaxTimeMS` | `float64` | Longest row age in milliseconds | `Time_ms`, fallback `Time` |
+| `HasTimeMetric` | `bool` | Whether `MaxTimeMS` is an observed metric, not a default zero | `Time_ms`, fallback `Time` |
 | `MaxRowsExamined` | `float64` | Largest rows-examined value in the sample | `Rows_examined` |
+| `HasRowsExaminedMetric` | `bool` | Whether `MaxRowsExamined` is an observed metric, not a default zero | `Rows_examined` |
 | `MaxRowsSent` | `float64` | Largest rows-sent value in the sample | `Rows_sent` |
+| `HasRowsSentMetric` | `bool` | Whether `MaxRowsSent` is an observed metric, not a default zero | `Rows_sent` |
 | `RowsWithQueryText` | `int` | Rows with non-empty, non-`NULL` `Info` | `Info` |
+| `HasQueryTextMetric` | `bool` | Whether `RowsWithQueryText` is an observed metric, not a default zero | `Info` |
 
 ### Validation and derivation rules
 
@@ -47,6 +51,9 @@ The feature adds these aggregate fields:
   values. Missing or malformed values do not emit diagnostics.
 - `RowsWithQueryText` increments when `Info` is neither empty nor `NULL` after
   trimming whitespace.
+- `Has*Metric` flags are true only when at least one source field for that
+  metric was observed and parsed, so renderers can distinguish unavailable
+  optional data from a real zero value.
 
 ## Template entity: ProcesslistSummary
 
@@ -57,9 +64,13 @@ The template view receives a compact summary derived from all samples:
 | `PeakActive` | Maximum `ActiveThreads` across samples |
 | `PeakSleeping` | Maximum `SleepingThreads` across samples |
 | `LongestAge` | Maximum `MaxTimeMS`, formatted in seconds |
+| `HasLongestAge` | Whether the longest-age callout is available |
 | `PeakRowsExamined` | Maximum `MaxRowsExamined`, formatted as a count |
+| `HasPeakRowsExamined` | Whether the rows-examined callout is available |
 | `PeakRowsSent` | Maximum `MaxRowsSent`, formatted as a count |
+| `HasPeakRowsSent` | Whether the rows-sent callout is available |
 | `PeakQueryTextRows` | Maximum `RowsWithQueryText` across samples |
+| `HasPeakQueryTextRows` | Whether the query-text count callout is available |
 | `SampleCount` | Number of processlist samples |
 
 ## Embedded chart payload
@@ -77,9 +88,13 @@ The existing `processlist` payload keeps the current shape and adds:
   },
   "metrics": {
     "maxTimeSeconds": [0],
+    "hasMaxTimeSeconds": [true],
     "maxRowsExamined": [0],
+    "hasRowsExamined": [true],
     "maxRowsSent": [0],
-    "rowsWithQueryText": [0]
+    "hasRowsSent": [true],
+    "rowsWithQueryText": [0],
+    "hasQueryText": [true]
   }
 }
 ```

--- a/specs/005-richer-processlist-metrics/data-model.md
+++ b/specs/005-richer-processlist-metrics/data-model.md
@@ -41,7 +41,9 @@ The feature adds these aggregate fields:
 ### Validation and derivation rules
 
 - `TotalThreads` increments for every completed processlist row that contains
-  at least one tracked field.
+  at least one core row field (`State`, `User`, `Host`, `Command`, or `db`).
+  Optional-only fragments (`Time`, `Time_ms`, `Rows_*`, or `Info` without a
+  core row field) do not create rows or contribute metrics.
 - `SleepingThreads` increments only when `Command == "Sleep"`.
 - `ActiveThreads` increments for all other completed rows, including missing or
   empty command values.

--- a/specs/005-richer-processlist-metrics/data-model.md
+++ b/specs/005-richer-processlist-metrics/data-model.md
@@ -1,0 +1,88 @@
+# Phase 1 Data Model: Richer Processlist Metrics
+
+## Existing entity: ProcesslistData
+
+`ProcesslistData` remains the typed payload for a merged `-processlist`
+collector. It continues to own:
+
+- `ThreadStateSamples`
+- label orders for `States`, `Users`, `Hosts`, `Commands`, and `Dbs`
+- `SnapshotBoundaries`
+
+No new top-level processlist model is introduced.
+
+## Extended entity: ThreadStateSample
+
+Each `ThreadStateSample` represents one timestamp block in a processlist file.
+It continues to include the existing count maps:
+
+- `StateCounts`
+- `UserCounts`
+- `HostCounts`
+- `CommandCounts`
+- `DbCounts`
+
+The feature adds these aggregate fields:
+
+| Field | Type | Meaning | Source field |
+|-------|------|---------|--------------|
+| `TotalThreads` | `int` | Number of rows seen in the sample | row count |
+| `ActiveThreads` | `int` | Rows whose command is not `Sleep` | `Command` |
+| `SleepingThreads` | `int` | Rows whose command is exactly `Sleep` | `Command` |
+| `MaxTimeMS` | `float64` | Longest row age in milliseconds | `Time_ms`, fallback `Time` |
+| `MaxRowsExamined` | `float64` | Largest rows-examined value in the sample | `Rows_examined` |
+| `MaxRowsSent` | `float64` | Largest rows-sent value in the sample | `Rows_sent` |
+| `RowsWithQueryText` | `int` | Rows with non-empty, non-`NULL` `Info` | `Info` |
+
+### Validation and derivation rules
+
+- `TotalThreads` increments for every completed processlist row that contains
+  at least one tracked field.
+- `SleepingThreads` increments only when `Command == "Sleep"`.
+- `ActiveThreads` increments for all other completed rows, including missing or
+  empty command values.
+- `MaxTimeMS` uses `Time_ms` when present and valid. If `Time_ms` is absent or
+  invalid, a valid `Time` value is converted from seconds to milliseconds.
+- `MaxRowsExamined` and `MaxRowsSent` use only valid non-negative numeric
+  values. Missing or malformed values do not emit diagnostics.
+- `RowsWithQueryText` increments when `Info` is neither empty nor `NULL` after
+  trimming whitespace.
+
+## Template entity: ProcesslistSummary
+
+The template view receives a compact summary derived from all samples:
+
+| Field | Meaning |
+|-------|---------|
+| `PeakActive` | Maximum `ActiveThreads` across samples |
+| `PeakSleeping` | Maximum `SleepingThreads` across samples |
+| `LongestAge` | Maximum `MaxTimeMS`, formatted in seconds |
+| `PeakRowsExamined` | Maximum `MaxRowsExamined`, formatted as a count |
+| `PeakRowsSent` | Maximum `MaxRowsSent`, formatted as a count |
+| `PeakQueryTextRows` | Maximum `RowsWithQueryText` across samples |
+| `SampleCount` | Number of processlist samples |
+
+## Embedded chart payload
+
+The existing `processlist` payload keeps the current shape and adds:
+
+```json
+{
+  "activity": {
+    "series": [
+      {"label": "Active", "values": [0]},
+      {"label": "Sleeping", "values": [0]},
+      {"label": "Total", "values": [0]}
+    ]
+  },
+  "metrics": {
+    "maxTimeSeconds": [0],
+    "maxRowsExamined": [0],
+    "maxRowsSent": [0],
+    "rowsWithQueryText": [0]
+  }
+}
+```
+
+The existing `timestamps`, `dimensions`, and `snapshotBoundaries` fields remain
+unchanged so current chart behavior stays compatible.

--- a/specs/005-richer-processlist-metrics/plan.md
+++ b/specs/005-richer-processlist-metrics/plan.md
@@ -1,0 +1,138 @@
+# Implementation Plan: Richer Processlist Metrics
+
+**Branch**: `005-richer-processlist-metrics` | **Date**: 2026-04-28 | **Spec**: [spec.md](./spec.md)  
+**Input**: Feature specification from `specs/005-richer-processlist-metrics/spec.md`
+
+## Summary
+
+Extend the existing Processlist subview so support engineers can distinguish
+idle connection pressure from active workload pressure, see long-running and
+high-row work, and know whether query text is present in captured rows. The
+feature reuses the existing `-processlist` parser, typed model, embedded chart
+payload, and Database Usage section. It adds no new runtime dependencies, no
+new top-level report section, and no network behavior.
+
+## Technical Context
+
+**Language/Version**: Go 1.24, pinned in `go.mod`.  
+**Primary Dependencies**: Standard library only. Existing embedded JavaScript
+chart asset is reused. No new Go module or browser dependency.  
+**Storage**: N/A. Reads pt-stalk input files and writes one HTML output.  
+**Testing**: `go test ./...`, focused parser tests, render payload/template
+tests, determinism coverage through the existing suite.  
+**Target Platform**: Existing My-gather targets: `linux/amd64`,
+`linux/arm64`, `darwin/amd64`, `darwin/arm64`.  
+**Project Type**: Single Go CLI with importable `parse/`, `model/`, and
+`render/` packages.  
+**Performance Goals**: Preserve current successful generation for the observed
+396 MB, 20-snapshot processlist-heavy incident collection; new metrics are
+computed in the existing line scan with no second pass over input files.  
+**Constraints**: Single self-contained HTML file, deterministic output, no
+runtime network, no writes under the input directory, graceful degradation for
+missing or malformed optional fields.  
+**Scale/Scope**: Existing processlist parser and report subview only. No full
+SQL listing, no new raw query table, no new top-level section.
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+| Principle | Pre-design status | Rationale |
+|-----------|-------------------|-----------|
+| I. Single Static Binary | PASS | Go-only change; no dynamic runtime dependency. |
+| II. Read-Only Inputs | PASS | Parser continues to read `-processlist` through existing read-only paths. |
+| III. Graceful Degradation | PASS | Optional malformed numeric fields become zero-valued metrics, while valid row data remains available. |
+| IV. Deterministic Output | PASS | New maps/slices must use existing stable ordering and deterministic JSON emission. |
+| V. Self-Contained HTML Reports | PASS | New metrics are embedded in the existing report payload and rendered by bundled JS. |
+| VI. Library-First Architecture | PASS | Changes stay in `parse/`, `model/`, and `render/`; CLI remains thin. |
+| VII. Typed Errors | PASS | No new branchable fatal error is introduced. |
+| VIII. Reference Fixtures & Golden Tests | PASS | Existing processlist fixture/golden is updated, and targeted tests cover synthetic edge cases. |
+| IX. Zero Network at Runtime | PASS | No network package or browser fetch is introduced. |
+| X. Minimal Dependencies | PASS | No new dependency. |
+| XI. Reports Optimized for Humans Under Pressure | PASS | Adds high-signal processlist summaries inside the existing DB section instead of adding a new section. |
+| XII. Pinned Go Version | PASS | Go version unchanged. |
+| XIII. Canonical Code Path | PASS | Extends the existing processlist parser/model/render path; no duplicate parser or fallback path. |
+| XIV. English-Only Durable Artifacts | PASS | All new checked-in artifacts are English. |
+
+**Pre-design gate: PASS.** No Complexity Tracking entry is required.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/005-richer-processlist-metrics/
+├── spec.md
+├── plan.md
+├── research.md
+├── data-model.md
+├── quickstart.md
+├── contracts/
+│   ├── packages.md
+│   └── ui.md
+├── checklists/
+│   └── requirements.md
+└── tasks.md
+```
+
+### Source Code (repository root)
+
+```text
+model/
+└── model.go                  # Processlist sample metric fields
+
+parse/
+├── processlist.go            # Parse Time/Time_ms, Rows_examined, Rows_sent, Info
+└── processlist_test.go       # Parser and golden coverage
+
+render/
+├── build_view.go             # Attach summary metrics to template view
+├── concat.go                 # Preserve metrics across merged snapshots
+├── payloads.go               # Embed richer processlist payload
+├── summaries.go              # Processlist summary callouts
+├── view.go                   # Template view fields
+├── templates/db.html.tmpl    # Processlist summary strip
+├── assets/app.js             # Activity/metric chart behavior
+├── render_test.go            # Embedded payload coverage
+└── db_test.go                # Markup coverage
+
+testdata/
+└── golden/
+    └── processlist.example2.2026_04_21_16_51_41.json
+```
+
+**Structure Decision**: Extend the existing processlist pipeline in place.
+This keeps one canonical code path for the `-processlist` collector and keeps
+the new output in the existing Database Usage Processlist subview.
+
+## Phase 0 Research
+
+See [research.md](./research.md).
+
+## Phase 1 Design
+
+See [data-model.md](./data-model.md), [contracts/packages.md](./contracts/packages.md),
+[contracts/ui.md](./contracts/ui.md), and [quickstart.md](./quickstart.md).
+
+## Post-design Constitution Check
+
+| Principle | Post-design status | Rationale |
+|-----------|--------------------|-----------|
+| I | PASS | No build or runtime dependency change. |
+| II | PASS | No writes inside input tree. |
+| III | PASS | Missing optional fields are represented as zero metrics, not fatal errors. |
+| IV | PASS | New summary and payload arrays are derived from sorted sample order. |
+| V | PASS | HTML remains single-file and offline. |
+| VI | PASS | Exported model fields receive godoc in `model/model.go`. |
+| VII | PASS | No new branchable error path. |
+| VIII | PASS | Parser golden and targeted tests are part of the task list. |
+| IX | PASS | No network code. |
+| X | PASS | No dependency. |
+| XI | PASS | Metrics are compact callouts plus an in-place chart dimension. |
+| XII | PASS | Go 1.24 unchanged. |
+| XIII | PASS | Existing processlist parser is extended in place. |
+| XIV | PASS | Artifacts are English. |
+
+## Complexity Tracking
+
+No constitution violations or complexity exceptions.

--- a/specs/005-richer-processlist-metrics/plan.md
+++ b/specs/005-richer-processlist-metrics/plan.md
@@ -41,7 +41,7 @@ SQL listing, no new raw query table, no new top-level section.
 |-----------|-------------------|-----------|
 | I. Single Static Binary | PASS | Go-only change; no dynamic runtime dependency. |
 | II. Read-Only Inputs | PASS | Parser continues to read `-processlist` through existing read-only paths. |
-| III. Graceful Degradation | PASS | Optional malformed numeric fields become zero-valued metrics, while valid row data remains available. |
+| III. Graceful Degradation | PASS | Optional malformed numeric fields are ignored without failing the row; age falls back from invalid `Time_ms` to valid `Time` when available. |
 | IV. Deterministic Output | PASS | New maps/slices must use existing stable ordering and deterministic JSON emission. |
 | V. Self-Contained HTML Reports | PASS | New metrics are embedded in the existing report payload and rendered by bundled JS. |
 | VI. Library-First Architecture | PASS | Changes stay in `parse/`, `model/`, and `render/`; CLI remains thin. |

--- a/specs/005-richer-processlist-metrics/quickstart.md
+++ b/specs/005-richer-processlist-metrics/quickstart.md
@@ -1,0 +1,48 @@
+# Quickstart: Richer Processlist Metrics
+
+## 1. Run focused tests
+
+```bash
+go test ./parse -run 'TestProcesslist'
+go test ./render -run 'Test.*Processlist|TestRenderIncludesProcesslist'
+```
+
+Expected result: tests pass and cover active/sleeping totals, longest age,
+row-count maxima, query-text counts, payload shape, and markup callouts.
+
+## 2. Run the full Go suite
+
+```bash
+go test ./...
+make lint
+```
+
+Expected result: all tests and vet checks pass.
+
+## 3. Validate against the incident collection
+
+```bash
+tmp="$(mktemp -d)"
+go run ./cmd/my-gather -o "$tmp/report.html" --overwrite \
+  /Users/matias/Documents/Incidents/CS0060148/eu-hrznp-d003/pt-stalk
+```
+
+Expected result:
+
+- command exits with status 0
+- generated report is a single HTML file
+- Processlist subview has summary callouts for active/sleeping, age, rows, and
+  query-text rows
+- Processlist chart includes a `By Activity` control
+
+## 4. Determinism spot check
+
+```bash
+tmp="$(mktemp -d)"
+go run ./cmd/my-gather -o "$tmp/a.html" --overwrite testdata/example2
+go run ./cmd/my-gather -o "$tmp/b.html" --overwrite testdata/example2
+diff -u "$tmp/a.html" "$tmp/b.html" | head
+```
+
+Expected result: no unexpected differences beyond the existing generated-time
+allowance already handled by the test suite.

--- a/specs/005-richer-processlist-metrics/research.md
+++ b/specs/005-richer-processlist-metrics/research.md
@@ -1,0 +1,85 @@
+# Phase 0 Research: Richer Processlist Metrics
+
+## Decision: Reuse the existing Processlist subview
+
+**Decision**: Add richer metrics to the existing Database Usage Processlist
+subview rather than creating a new top-level section.
+
+**Rationale**: The metrics are derived entirely from `-processlist` and answer
+the same operational question as the current thread-state chart. Keeping them
+together satisfies Principle XI by avoiding a second place to look for the
+same collector.
+
+**Alternatives considered**:
+
+- New top-level "Query Activity" section: rejected because it would duplicate
+  Processlist context and overstate the scope of a single-collector feature.
+- Raw SQL table: rejected because query text can be sensitive and the feature
+  only needs presence counts.
+
+## Decision: Extend the existing typed sample model
+
+**Decision**: Add richer metric fields to `model.ThreadStateSample`.
+
+**Rationale**: The current parser already emits one `ThreadStateSample` per
+processlist timestamp block. The new values are also per-sample aggregates, so
+adding fields keeps the model simple and avoids a parallel processlist metrics
+type that would need separate merge/render logic.
+
+**Alternatives considered**:
+
+- Separate `ProcesslistMetricsData`: rejected because it would duplicate
+  timestamp and boundary ownership.
+- Store raw rows in the model: rejected because it would inflate reports and
+  make sensitive query text more prominent.
+
+## Decision: Prefer Time_ms, fall back to Time
+
+**Decision**: Compute longest thread age from `Time_ms` when available. If a
+row has no valid `Time_ms`, use `Time` seconds converted to milliseconds.
+
+**Rationale**: MySQL vertical processlist captures commonly include both. The
+millisecond field is more precise, while the second-level field preserves useful
+signal in older or reduced outputs.
+
+**Alternatives considered**:
+
+- Use `Time` only: rejected because it discards available precision.
+- Emit diagnostics for malformed optional numeric fields: rejected because
+  malformed optional counters are common in real captures and should not crowd
+  diagnostics when the rest of the row is valid.
+
+## Decision: Add an Activity dimension and separate metrics payload
+
+**Decision**: Render active, sleeping, and total threads as a new Processlist
+chart dimension. Expose longest age, rows examined, rows sent, and query-text
+row count as a separate non-stacked metrics payload with summary callouts.
+
+**Rationale**: Active/sleeping/total are thread counts and fit the existing
+stacked-bar Processlist chart. Age and row counts use different units, so they
+should not be stacked with state/user/host dimensions. Summary callouts surface
+their peak values immediately.
+
+**Alternatives considered**:
+
+- Put all metrics into the existing stacked chart: rejected because mixing
+  threads, milliseconds, and row counts in one stacked chart is misleading.
+- Build a second full chart in the first iteration: rejected to keep the visual
+  change compact; the payload leaves room for a future small multiple if needed.
+
+## Decision: Use minimized synthetic tests plus updated existing golden
+
+**Decision**: Add focused synthetic parser tests for edge cases and update the
+existing processlist golden to include the new fields.
+
+**Rationale**: The real incident folder is useful for manual validation but is
+not safe to commit as a fixture because it contains hostnames, paths, users,
+and query text. A minimized fixture gives deterministic coverage without
+importing sensitive incident data.
+
+**Alternatives considered**:
+
+- Commit raw incident processlist files: rejected for privacy and repository
+  size reasons.
+- Rely only on manual validation against the incident folder: rejected because
+  the constitution requires fixtures and golden coverage.

--- a/specs/005-richer-processlist-metrics/spec.md
+++ b/specs/005-richer-processlist-metrics/spec.md
@@ -1,0 +1,179 @@
+# Feature Specification: Richer Processlist Metrics
+
+**Feature Branch**: `005-richer-processlist-metrics`  
+**Created**: 2026-04-28  
+**Status**: Complete  
+**Input**: User description: "Implement richer processlist metrics so support engineers can see active versus sleeping threads, longest thread age, peak Rows_examined/Rows_sent, and query text presence trends from pt-stalk processlist captures."
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Spot active thread pressure quickly (Priority: P1)
+
+A support engineer opens a generated report from a pt-stalk collection and
+needs to know whether the server was overloaded by active work or merely had
+many idle client sessions. The Processlist subview must make this distinction
+visible without requiring the engineer to inspect raw `-processlist` files.
+
+**Why this priority**: The incident that motivated this feature was triggered
+by high `Threads_connected`. Active versus sleeping split is the fastest way
+to tell whether that trigger represents real workload pressure or connection
+pool/idleness pressure.
+
+**Independent Test**: Generate a report from a fixture containing mixed
+`Sleep`, `Query`, and other command rows. The Processlist subview shows active
+threads, sleeping threads, and total threads over time with deterministic
+summary values.
+
+**Acceptance Scenarios**:
+
+1. **Given** a processlist sample containing sleeping and non-sleeping
+   commands, **When** the report renders, **Then** the Processlist subview
+   shows total, active, and sleeping thread counts for that sample.
+2. **Given** several processlist samples with changing command mix, **When**
+   the engineer views the Processlist subview, **Then** the active/sleeping
+   trend is visible across the capture window and can be compared with the
+   existing state/user/host/command/db breakdowns.
+3. **Given** a processlist row with an empty or missing command, **When** the
+   sample is parsed, **Then** the row is counted as active unless the command is
+   explicitly `Sleep`, and no parser failure is emitted solely for that row.
+
+---
+
+### User Story 2 - Identify long-running and high-row work (Priority: P2)
+
+A support engineer needs to find whether the processlist contains work that
+has been running for a long time or scanning/sending unusually many rows. The
+report must surface the largest `Time_ms`, `Rows_examined`, and `Rows_sent`
+signals per sample so expensive work is visible even when thread state labels
+are generic.
+
+**Why this priority**: Long-running queries and high row counts are common
+root-cause signals for MySQL incidents. The raw processlist already contains
+these fields, but the current report does not promote them.
+
+**Independent Test**: Generate a report from a fixture with known `Time_ms`,
+`Rows_examined`, and `Rows_sent` values. The parser exposes per-sample maxima,
+and the rendered report shows those maxima with stable formatting.
+
+**Acceptance Scenarios**:
+
+1. **Given** a processlist sample with `Time_ms` values, **When** the report
+   renders, **Then** the Processlist subview shows the longest thread age for
+   the sample in seconds.
+2. **Given** a processlist sample with `Rows_examined` and `Rows_sent` values,
+   **When** the report renders, **Then** the Processlist subview shows the peak
+   rows examined and peak rows sent for the sample.
+3. **Given** a processlist sample where one or more of these numeric fields are
+   absent or non-numeric, **When** the sample is parsed, **Then** valid fields
+   from the same row and sample are still preserved and invalid numeric fields
+   contribute zero to the per-sample maxima.
+
+---
+
+### User Story 3 - Understand query-text availability safely (Priority: P3)
+
+A support engineer needs to know whether processlist rows include query text
+without forcing the report to expose full SQL prominently. The report must
+show query-text presence as a count so the engineer can decide whether raw
+files need deeper review.
+
+**Why this priority**: Query text can be sensitive. A compact count gives
+useful visibility while avoiding a new prominent SQL dump in the report.
+
+**Independent Test**: Generate a report from a fixture with a mix of `Info:
+NULL`, empty `Info`, and non-empty `Info` rows. The report shows query-text
+presence counts over time and does not add a raw SQL table.
+
+**Acceptance Scenarios**:
+
+1. **Given** a processlist sample containing rows with non-empty, non-`NULL`
+   `Info`, **When** the report renders, **Then** the Processlist subview shows
+   the count of rows with query text for that sample.
+2. **Given** a row whose `Info` value is `NULL` or empty, **When** the parser
+   reads the row, **Then** the row is not counted as having query text.
+3. **Given** a generated report, **When** the engineer opens the Processlist
+   subview, **Then** the new query-text metric is visible as a count only; the
+   feature does not introduce a new prominent raw SQL listing.
+
+### Edge Cases
+
+- Processlist rows may omit `Time_ms`, `Rows_examined`, `Rows_sent`, or `Info`
+  while still containing state/user/host/command fields.
+- `Time_ms` may be present as an integer or decimal value; the rendered age is
+  shown in seconds.
+- `Time` may be present without `Time_ms`; `Time_ms` is preferred, and `Time`
+  is used only when `Time_ms` is missing.
+- Empty, `NULL`, or whitespace-only `Info` values do not count as query text.
+- Very large row counters remain numeric and deterministic in the embedded
+  report payload.
+- Existing processlist breakdowns by state/user/host/command/db must continue
+  to render when new richer metrics are absent.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: The report MUST expose active, sleeping, and total thread counts
+  for every parsed processlist sample.
+- **FR-002**: A processlist row MUST be classified as sleeping only when its
+  command is `Sleep`; all other commands count as active.
+- **FR-003**: The report MUST expose the longest thread age per processlist
+  sample, using `Time_ms` when present and falling back to `Time` when `Time_ms`
+  is absent.
+- **FR-004**: The report MUST expose peak `Rows_examined` and peak `Rows_sent`
+  per processlist sample.
+- **FR-005**: The report MUST expose the count of rows with non-empty query
+  text per processlist sample, treating empty and `NULL` `Info` values as no
+  query text.
+- **FR-006**: The richer metrics MUST be embedded in the existing self-contained
+  HTML report and MUST work offline with no external network or asset fetch.
+- **FR-007**: Existing Processlist state/user/host/command/db breakdowns MUST
+  remain available and deterministic.
+- **FR-008**: Missing or malformed optional numeric processlist fields MUST NOT
+  make the collection fail; valid processlist data from the same sample MUST
+  still render.
+- **FR-009**: The Processlist subview MUST include compact summary callouts for
+  the peak active threads, peak sleeping threads, longest thread age, peak rows
+  examined, peak rows sent, and peak query-text rows across the capture window.
+- **FR-010**: The feature MUST include parser-level and render-level tests that
+  cover all new metrics and protect the existing processlist breakdown.
+
+### Key Entities
+
+- **Processlist sample metrics**: Per-sample totals derived from all rows in a
+  single processlist timestamp block. Attributes include timestamp, total
+  threads, active threads, sleeping threads, longest age in milliseconds, peak
+  rows examined, peak rows sent, and query-text row count.
+- **Processlist summary metrics**: Capture-window maxima derived from all
+  processlist samples. Attributes include peak active threads, peak sleeping
+  threads, longest age, peak rows examined, peak rows sent, and peak query-text
+  rows.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: For a fixture containing mixed active and sleeping processlist
+  rows, the generated report shows active, sleeping, and total counts matching
+  the fixture exactly.
+- **SC-002**: For a fixture containing known `Time_ms`, `Rows_examined`, and
+  `Rows_sent` values, parser tests verify the expected per-sample maxima.
+- **SC-003**: Rendering the same fixture twice produces byte-identical HTML
+  output except for the existing explicitly allowed generated timestamp.
+- **SC-004**: A real 20-snapshot pt-stalk collection with processlist files
+  continues to generate a report successfully and includes the richer
+  processlist payload.
+- **SC-005**: No new runtime network dependency, external asset fetch, or write
+  inside the input pt-stalk directory is introduced.
+
+## Assumptions
+
+- Support engineers need aggregate processlist signals first; full SQL text
+  remains available in raw pt-stalk files and is not promoted into a new report
+  table by this feature.
+- `Time_ms` is the preferred age source because it has higher precision than
+  `Time`; `Time` is acceptable as a fallback when `Time_ms` is absent.
+- A command value of `Sleep` is the only sleeping classification for the
+  active/sleeping split.
+- The existing Processlist subview is the correct home for these metrics; no
+  new top-level report section is required.

--- a/specs/005-richer-processlist-metrics/spec.md
+++ b/specs/005-richer-processlist-metrics/spec.md
@@ -65,8 +65,8 @@ and the rendered report shows those maxima with stable formatting.
    rows examined and peak rows sent for the sample.
 3. **Given** a processlist sample where one or more of these numeric fields are
    absent or non-numeric, **When** the sample is parsed, **Then** valid fields
-   from the same row and sample are still preserved and invalid numeric fields
-   contribute zero to the per-sample maxima.
+   from the same row and sample are still preserved, and a valid `Time` value
+   is used when `Time_ms` is missing or invalid.
 
 ---
 
@@ -101,8 +101,8 @@ presence counts over time and does not add a raw SQL table.
   while still containing state/user/host/command fields.
 - `Time_ms` may be present as an integer or decimal value; the rendered age is
   shown in seconds.
-- `Time` may be present without `Time_ms`; `Time_ms` is preferred, and `Time`
-  is used only when `Time_ms` is missing.
+- `Time` may be present with or without `Time_ms`; `Time_ms` is preferred when
+  it is valid, and `Time` is used when `Time_ms` is missing or invalid.
 - Empty, `NULL`, or whitespace-only `Info` values do not count as query text.
 - Very large row counters remain numeric and deterministic in the embedded
   report payload.
@@ -118,8 +118,8 @@ presence counts over time and does not add a raw SQL table.
 - **FR-002**: A processlist row MUST be classified as sleeping only when its
   command is `Sleep`; all other commands count as active.
 - **FR-003**: The report MUST expose the longest thread age per processlist
-  sample, using `Time_ms` when present and falling back to `Time` when `Time_ms`
-  is absent.
+  sample, using `Time_ms` when present and valid and falling back to `Time`
+  when `Time_ms` is missing or invalid.
 - **FR-004**: The report MUST expose peak `Rows_examined` and peak `Rows_sent`
   per processlist sample.
 - **FR-005**: The report MUST expose the count of rows with non-empty query
@@ -172,7 +172,8 @@ presence counts over time and does not add a raw SQL table.
   remains available in raw pt-stalk files and is not promoted into a new report
   table by this feature.
 - `Time_ms` is the preferred age source because it has higher precision than
-  `Time`; `Time` is acceptable as a fallback when `Time_ms` is absent.
+  `Time`; `Time` is acceptable as a fallback when `Time_ms` is missing or
+  invalid.
 - A command value of `Sleep` is the only sleeping classification for the
   active/sleeping split.
 - The existing Processlist subview is the correct home for these metrics; no

--- a/specs/005-richer-processlist-metrics/spec.md
+++ b/specs/005-richer-processlist-metrics/spec.md
@@ -137,6 +137,9 @@ presence counts over time and does not add a raw SQL table.
   examined, peak rows sent, and peak query-text rows across the capture window.
 - **FR-010**: The feature MUST include parser-level and render-level tests that
   cover all new metrics and protect the existing processlist breakdown.
+- **FR-011**: Optional metric callouts MUST be omitted when their source fields
+  are unavailable, while real zero values from available source fields MUST
+  remain renderable as `0`.
 
 ### Key Entities
 

--- a/specs/005-richer-processlist-metrics/tasks.md
+++ b/specs/005-richer-processlist-metrics/tasks.md
@@ -1,0 +1,78 @@
+# Tasks: Richer Processlist Metrics
+
+**Input**: `specs/005-richer-processlist-metrics/`  
+**Prerequisites**: spec.md, plan.md, research.md, data-model.md, contracts/
+
+## Phase 1: Setup
+
+- [x] T001 Create feature branch `005-richer-processlist-metrics`.
+- [x] T002 Create `specs/005-richer-processlist-metrics/spec.md`.
+- [x] T003 Create planning artifacts in `specs/005-richer-processlist-metrics/`.
+
+## Phase 2: Foundational Tests
+
+- [x] T004 [P] Add parser assertions for active/sleeping totals, longest age, row maxima, and query-text counts in `parse/processlist_test.go`.
+- [x] T005 [P] Add render payload assertions for the richer processlist payload in `render/render_test.go`.
+- [x] T006 [P] Add Processlist subview markup assertions for summary callouts and Activity control in `render/db_test.go`.
+- [x] T007 Update the processlist golden fixture output in `testdata/golden/processlist.example2.2026_04_21_16_51_41.json`.
+
+## Phase 3: User Story 1 - Spot active thread pressure quickly (Priority: P1)
+
+**Goal**: Show active, sleeping, and total thread counts in the existing
+Processlist subview.
+
+**Independent Test**: Parser and render tests verify active/sleeping/total
+counts from a mixed processlist fixture.
+
+- [x] T008 [US1] Extend `model.ThreadStateSample` in `model/model.go` with thread total, active, and sleeping fields.
+- [x] T009 [US1] Update `parse/processlist.go` to classify `Command == "Sleep"` as sleeping and all other rows as active.
+- [x] T010 [US1] Update `render/payloads.go` so `processlistChartPayload` adds an Activity dimension with Active, Sleeping, and Total series.
+- [x] T011 [US1] Update `render/assets/app.js` so the Processlist toolbar exposes the Activity dimension with the existing chart path.
+
+## Phase 4: User Story 2 - Identify long-running and high-row work (Priority: P2)
+
+**Goal**: Surface longest thread age and peak row counts per sample and as
+summary callouts.
+
+**Independent Test**: Parser tests verify numeric derivation; render tests
+verify summary values and payload arrays.
+
+- [x] T012 [US2] Extend `model.ThreadStateSample` in `model/model.go` with age and row-count metric fields.
+- [x] T013 [US2] Update `parse/processlist.go` to parse `Time_ms`, fallback `Time`, `Rows_examined`, and `Rows_sent`.
+- [x] T014 [US2] Update `render/view.go`, `render/summaries.go`, and `render/build_view.go` with Processlist summary callouts.
+- [x] T015 [US2] Update `render/templates/db.html.tmpl` to render Processlist summary callouts.
+- [x] T016 [US2] Update `render/payloads.go` with processlist metric arrays for age and row counts.
+
+## Phase 5: User Story 3 - Understand query-text availability safely (Priority: P3)
+
+**Goal**: Show query-text presence counts without adding a raw SQL table.
+
+**Independent Test**: Parser tests verify `Info` counting; render tests verify
+the count is surfaced as an aggregate metric only.
+
+- [x] T017 [US3] Extend `model.ThreadStateSample` in `model/model.go` with query-text count.
+- [x] T018 [US3] Update `parse/processlist.go` to count non-empty, non-`NULL` `Info` rows.
+- [x] T019 [US3] Update `render/summaries.go`, `render/templates/db.html.tmpl`, and `render/payloads.go` to expose query-text counts.
+
+## Phase 6: Polish and Verification
+
+- [x] T020 Update `AGENTS.md`, `CLAUDE.md`, and `.specify/feature.json` so active feature pointers remain aligned.
+- [x] T021 Update `tests/coverage/agent_alignment_test.go` so it validates active feature pointers generically and still accepts no-active-feature main state.
+- [x] T022 Run `go test ./...`.
+- [x] T023 Run `make lint`.
+- [x] T024 Run quickstart validation against `/Users/matias/Documents/Incidents/CS0060148/eu-hrznp-d003/pt-stalk`.
+- [ ] T025 Open a GitHub pull request for branch `005-richer-processlist-metrics`.
+
+## Dependencies
+
+- T004-T007 must be written before implementation tasks.
+- T008-T011 deliver the MVP.
+- T012-T016 depend on the model/parser shape from T008-T009.
+- T017-T019 depend on the same row-flush parser path.
+- T020-T025 happen after implementation.
+
+## Implementation Strategy
+
+Deliver US1 first because active versus sleeping threads is the incident-triage
+signal. Then add age/row metrics, then query-text presence. Each story remains
+testable through parser assertions and rendered payload/markup checks.

--- a/specs/005-richer-processlist-metrics/tasks.md
+++ b/specs/005-richer-processlist-metrics/tasks.md
@@ -61,7 +61,7 @@ the count is surfaced as an aggregate metric only.
 - [x] T022 Run `go test ./...`.
 - [x] T023 Run `make lint`.
 - [x] T024 Run quickstart validation against `/Users/matias/Documents/Incidents/CS0060148/eu-hrznp-d003/pt-stalk`.
-- [ ] T025 Open a GitHub pull request for branch `005-richer-processlist-metrics`.
+- [x] T025 Open a GitHub pull request for branch `005-richer-processlist-metrics`.
 
 ## Dependencies
 

--- a/testdata/golden/db.example2.html
+++ b/testdata/golden/db.example2.html
@@ -177,6 +177,15 @@
 <details id="sub-db-processlist" class="subview" open>
   <summary><span>Thread states</span><span class="badge">-processlist</span></summary>
   <div class="body">
+    <div class="chart-summary">
+      <span class="stat"><span class="k">peak active</span> <span class="v">15</span> <span class="ctx">threads</span></span>
+      <span class="stat"><span class="k">peak sleeping</span> <span class="v">4</span> <span class="ctx">threads</span></span>
+      <span class="stat"><span class="k">longest age</span> <span class="v">3020.7</span> <span class="ctx">s</span></span>
+      <span class="stat"><span class="k">peak rows examined</span> <span class="v">543</span></span>
+      <span class="stat"><span class="k">peak rows sent</span> <span class="v">543</span></span>
+      <span class="stat"><span class="k">query text rows</span> <span class="v">14</span></span>
+      <span class="stat"><span class="k">samples</span> <span class="v">60</span></span>
+    </div>
     <div class="chart" id="chart-processlist" data-chart="processlist"
          aria-label="Count of threads per state over time"></div>
     <noscript><p class="banner">Charts require JavaScript. Raw processlist data is embedded in the page.</p></noscript>

--- a/testdata/golden/processlist.example2.2026_04_21_16_51_41.json
+++ b/testdata/golden/processlist.example2.2026_04_21_16_51_41.json
@@ -32,9 +32,13 @@
       "ActiveThreads": 12,
       "SleepingThreads": 1,
       "MaxTimeMS": 2961678,
+      "HasTimeMetric": true,
       "MaxRowsExamined": 543,
+      "HasRowsExaminedMetric": true,
       "MaxRowsSent": 543,
-      "RowsWithQueryText": 11
+      "HasRowsSentMetric": true,
+      "RowsWithQueryText": 11,
+      "HasQueryTextMetric": true
     },
     {
       "Timestamp": "2026-04-21T16:51:44Z",
@@ -69,9 +73,13 @@
       "ActiveThreads": 13,
       "SleepingThreads": 2,
       "MaxTimeMS": 2962678,
+      "HasTimeMetric": true,
       "MaxRowsExamined": 543,
+      "HasRowsExaminedMetric": true,
       "MaxRowsSent": 543,
-      "RowsWithQueryText": 12
+      "HasRowsSentMetric": true,
+      "RowsWithQueryText": 12,
+      "HasQueryTextMetric": true
     },
     {
       "Timestamp": "2026-04-21T16:51:45Z",
@@ -106,9 +114,13 @@
       "ActiveThreads": 13,
       "SleepingThreads": 1,
       "MaxTimeMS": 2963677,
+      "HasTimeMetric": true,
       "MaxRowsExamined": 543,
+      "HasRowsExaminedMetric": true,
       "MaxRowsSent": 543,
-      "RowsWithQueryText": 12
+      "HasRowsSentMetric": true,
+      "RowsWithQueryText": 12,
+      "HasQueryTextMetric": true
     },
     {
       "Timestamp": "2026-04-21T16:51:46Z",
@@ -142,9 +154,13 @@
       "ActiveThreads": 12,
       "SleepingThreads": 3,
       "MaxTimeMS": 2964677,
+      "HasTimeMetric": true,
       "MaxRowsExamined": 543,
+      "HasRowsExaminedMetric": true,
       "MaxRowsSent": 543,
-      "RowsWithQueryText": 11
+      "HasRowsSentMetric": true,
+      "RowsWithQueryText": 11,
+      "HasQueryTextMetric": true
     },
     {
       "Timestamp": "2026-04-21T16:51:47Z",
@@ -181,9 +197,13 @@
       "ActiveThreads": 15,
       "SleepingThreads": 1,
       "MaxTimeMS": 2965676,
+      "HasTimeMetric": true,
       "MaxRowsExamined": 543,
+      "HasRowsExaminedMetric": true,
       "MaxRowsSent": 543,
-      "RowsWithQueryText": 13
+      "HasRowsSentMetric": true,
+      "RowsWithQueryText": 13,
+      "HasQueryTextMetric": true
     },
     {
       "Timestamp": "2026-04-21T16:51:48Z",
@@ -221,9 +241,13 @@
       "ActiveThreads": 13,
       "SleepingThreads": 1,
       "MaxTimeMS": 2966677,
+      "HasTimeMetric": true,
       "MaxRowsExamined": 543,
+      "HasRowsExaminedMetric": true,
       "MaxRowsSent": 543,
-      "RowsWithQueryText": 11
+      "HasRowsSentMetric": true,
+      "RowsWithQueryText": 11,
+      "HasQueryTextMetric": true
     },
     {
       "Timestamp": "2026-04-21T16:51:49Z",
@@ -262,9 +286,13 @@
       "ActiveThreads": 13,
       "SleepingThreads": 3,
       "MaxTimeMS": 2967678,
+      "HasTimeMetric": true,
       "MaxRowsExamined": 543,
+      "HasRowsExaminedMetric": true,
       "MaxRowsSent": 543,
-      "RowsWithQueryText": 11
+      "HasRowsSentMetric": true,
+      "RowsWithQueryText": 11,
+      "HasQueryTextMetric": true
     },
     {
       "Timestamp": "2026-04-21T16:51:50Z",
@@ -302,9 +330,13 @@
       "ActiveThreads": 13,
       "SleepingThreads": 2,
       "MaxTimeMS": 2968679,
+      "HasTimeMetric": true,
       "MaxRowsExamined": 543,
+      "HasRowsExaminedMetric": true,
       "MaxRowsSent": 543,
-      "RowsWithQueryText": 11
+      "HasRowsSentMetric": true,
+      "RowsWithQueryText": 11,
+      "HasQueryTextMetric": true
     },
     {
       "Timestamp": "2026-04-21T16:51:51Z",
@@ -339,9 +371,13 @@
       "ActiveThreads": 15,
       "SleepingThreads": 1,
       "MaxTimeMS": 2969678,
+      "HasTimeMetric": true,
       "MaxRowsExamined": 543,
+      "HasRowsExaminedMetric": true,
       "MaxRowsSent": 543,
-      "RowsWithQueryText": 12
+      "HasRowsSentMetric": true,
+      "RowsWithQueryText": 12,
+      "HasQueryTextMetric": true
     },
     {
       "Timestamp": "2026-04-21T16:51:52Z",
@@ -375,9 +411,13 @@
       "ActiveThreads": 12,
       "SleepingThreads": 1,
       "MaxTimeMS": 2970677,
+      "HasTimeMetric": true,
       "MaxRowsExamined": 543,
+      "HasRowsExaminedMetric": true,
       "MaxRowsSent": 543,
-      "RowsWithQueryText": 11
+      "HasRowsSentMetric": true,
+      "RowsWithQueryText": 11,
+      "HasQueryTextMetric": true
     },
     {
       "Timestamp": "2026-04-21T16:51:53Z",
@@ -412,9 +452,13 @@
       "ActiveThreads": 13,
       "SleepingThreads": 1,
       "MaxTimeMS": 2971677,
+      "HasTimeMetric": true,
       "MaxRowsExamined": 543,
+      "HasRowsExaminedMetric": true,
       "MaxRowsSent": 543,
-      "RowsWithQueryText": 12
+      "HasRowsSentMetric": true,
+      "RowsWithQueryText": 12,
+      "HasQueryTextMetric": true
     },
     {
       "Timestamp": "2026-04-21T16:51:54Z",
@@ -451,9 +495,13 @@
       "ActiveThreads": 14,
       "SleepingThreads": 1,
       "MaxTimeMS": 2972678,
+      "HasTimeMetric": true,
       "MaxRowsExamined": 543,
+      "HasRowsExaminedMetric": true,
       "MaxRowsSent": 543,
-      "RowsWithQueryText": 12
+      "HasRowsSentMetric": true,
+      "RowsWithQueryText": 12,
+      "HasQueryTextMetric": true
     },
     {
       "Timestamp": "2026-04-21T16:51:55Z",
@@ -489,9 +537,13 @@
       "ActiveThreads": 13,
       "SleepingThreads": 1,
       "MaxTimeMS": 2973678,
+      "HasTimeMetric": true,
       "MaxRowsExamined": 543,
+      "HasRowsExaminedMetric": true,
       "MaxRowsSent": 543,
-      "RowsWithQueryText": 12
+      "HasRowsSentMetric": true,
+      "RowsWithQueryText": 12,
+      "HasQueryTextMetric": true
     },
     {
       "Timestamp": "2026-04-21T16:51:56Z",
@@ -529,9 +581,13 @@
       "ActiveThreads": 13,
       "SleepingThreads": 1,
       "MaxTimeMS": 2974678,
+      "HasTimeMetric": true,
       "MaxRowsExamined": 543,
+      "HasRowsExaminedMetric": true,
       "MaxRowsSent": 543,
-      "RowsWithQueryText": 11
+      "HasRowsSentMetric": true,
+      "RowsWithQueryText": 11,
+      "HasQueryTextMetric": true
     },
     {
       "Timestamp": "2026-04-21T16:51:57Z",
@@ -565,9 +621,13 @@
       "ActiveThreads": 13,
       "SleepingThreads": 1,
       "MaxTimeMS": 2975678,
+      "HasTimeMetric": true,
       "MaxRowsExamined": 543,
+      "HasRowsExaminedMetric": true,
       "MaxRowsSent": 543,
-      "RowsWithQueryText": 12
+      "HasRowsSentMetric": true,
+      "RowsWithQueryText": 12,
+      "HasQueryTextMetric": true
     },
     {
       "Timestamp": "2026-04-21T16:51:58Z",
@@ -604,9 +664,13 @@
       "ActiveThreads": 14,
       "SleepingThreads": 1,
       "MaxTimeMS": 2976678,
+      "HasTimeMetric": true,
       "MaxRowsExamined": 543,
+      "HasRowsExaminedMetric": true,
       "MaxRowsSent": 543,
-      "RowsWithQueryText": 11
+      "HasRowsSentMetric": true,
+      "RowsWithQueryText": 11,
+      "HasQueryTextMetric": true
     },
     {
       "Timestamp": "2026-04-21T16:51:59Z",
@@ -643,9 +707,13 @@
       "ActiveThreads": 15,
       "SleepingThreads": 1,
       "MaxTimeMS": 2977678,
+      "HasTimeMetric": true,
       "MaxRowsExamined": 543,
+      "HasRowsExaminedMetric": true,
       "MaxRowsSent": 543,
-      "RowsWithQueryText": 12
+      "HasRowsSentMetric": true,
+      "RowsWithQueryText": 12,
+      "HasQueryTextMetric": true
     },
     {
       "Timestamp": "2026-04-21T16:52:00Z",
@@ -678,9 +746,13 @@
       "ActiveThreads": 12,
       "SleepingThreads": 1,
       "MaxTimeMS": 2978677,
+      "HasTimeMetric": true,
       "MaxRowsExamined": 543,
+      "HasRowsExaminedMetric": true,
       "MaxRowsSent": 543,
-      "RowsWithQueryText": 11
+      "HasRowsSentMetric": true,
+      "RowsWithQueryText": 11,
+      "HasQueryTextMetric": true
     },
     {
       "Timestamp": "2026-04-21T16:52:01Z",
@@ -715,9 +787,13 @@
       "ActiveThreads": 13,
       "SleepingThreads": 1,
       "MaxTimeMS": 2979677,
+      "HasTimeMetric": true,
       "MaxRowsExamined": 543,
+      "HasRowsExaminedMetric": true,
       "MaxRowsSent": 543,
-      "RowsWithQueryText": 12
+      "HasRowsSentMetric": true,
+      "RowsWithQueryText": 12,
+      "HasQueryTextMetric": true
     },
     {
       "Timestamp": "2026-04-21T16:52:02Z",
@@ -752,9 +828,13 @@
       "ActiveThreads": 14,
       "SleepingThreads": 2,
       "MaxTimeMS": 2980678,
+      "HasTimeMetric": true,
       "MaxRowsExamined": 543,
+      "HasRowsExaminedMetric": true,
       "MaxRowsSent": 543,
-      "RowsWithQueryText": 13
+      "HasRowsSentMetric": true,
+      "RowsWithQueryText": 13,
+      "HasQueryTextMetric": true
     },
     {
       "Timestamp": "2026-04-21T16:52:03Z",
@@ -788,9 +868,13 @@
       "ActiveThreads": 13,
       "SleepingThreads": 1,
       "MaxTimeMS": 2981678,
+      "HasTimeMetric": true,
       "MaxRowsExamined": 543,
+      "HasRowsExaminedMetric": true,
       "MaxRowsSent": 543,
-      "RowsWithQueryText": 12
+      "HasRowsSentMetric": true,
+      "RowsWithQueryText": 12,
+      "HasQueryTextMetric": true
     },
     {
       "Timestamp": "2026-04-21T16:52:04Z",
@@ -827,9 +911,13 @@
       "ActiveThreads": 14,
       "SleepingThreads": 2,
       "MaxTimeMS": 2982678,
+      "HasTimeMetric": true,
       "MaxRowsExamined": 543,
+      "HasRowsExaminedMetric": true,
       "MaxRowsSent": 543,
-      "RowsWithQueryText": 12
+      "HasRowsSentMetric": true,
+      "RowsWithQueryText": 12,
+      "HasQueryTextMetric": true
     },
     {
       "Timestamp": "2026-04-21T16:52:05Z",
@@ -866,9 +954,13 @@
       "ActiveThreads": 14,
       "SleepingThreads": 1,
       "MaxTimeMS": 2983677,
+      "HasTimeMetric": true,
       "MaxRowsExamined": 543,
+      "HasRowsExaminedMetric": true,
       "MaxRowsSent": 543,
-      "RowsWithQueryText": 11
+      "HasRowsSentMetric": true,
+      "RowsWithQueryText": 11,
+      "HasQueryTextMetric": true
     },
     {
       "Timestamp": "2026-04-21T16:52:06Z",
@@ -904,9 +996,13 @@
       "ActiveThreads": 13,
       "SleepingThreads": 2,
       "MaxTimeMS": 2984678,
+      "HasTimeMetric": true,
       "MaxRowsExamined": 543,
+      "HasRowsExaminedMetric": true,
       "MaxRowsSent": 543,
-      "RowsWithQueryText": 12
+      "HasRowsSentMetric": true,
+      "RowsWithQueryText": 12,
+      "HasQueryTextMetric": true
     },
     {
       "Timestamp": "2026-04-21T16:52:07Z",
@@ -939,9 +1035,13 @@
       "ActiveThreads": 12,
       "SleepingThreads": 1,
       "MaxTimeMS": 2985679,
+      "HasTimeMetric": true,
       "MaxRowsExamined": 543,
+      "HasRowsExaminedMetric": true,
       "MaxRowsSent": 543,
-      "RowsWithQueryText": 11
+      "HasRowsSentMetric": true,
+      "RowsWithQueryText": 11,
+      "HasQueryTextMetric": true
     },
     {
       "Timestamp": "2026-04-21T16:52:08Z",
@@ -977,9 +1077,13 @@
       "ActiveThreads": 12,
       "SleepingThreads": 1,
       "MaxTimeMS": 2986677,
+      "HasTimeMetric": true,
       "MaxRowsExamined": 543,
+      "HasRowsExaminedMetric": true,
       "MaxRowsSent": 543,
-      "RowsWithQueryText": 11
+      "HasRowsSentMetric": true,
+      "RowsWithQueryText": 11,
+      "HasQueryTextMetric": true
     },
     {
       "Timestamp": "2026-04-21T16:52:09Z",
@@ -1016,9 +1120,13 @@
       "ActiveThreads": 14,
       "SleepingThreads": 1,
       "MaxTimeMS": 2987677,
+      "HasTimeMetric": true,
       "MaxRowsExamined": 543,
+      "HasRowsExaminedMetric": true,
       "MaxRowsSent": 543,
-      "RowsWithQueryText": 13
+      "HasRowsSentMetric": true,
+      "RowsWithQueryText": 13,
+      "HasQueryTextMetric": true
     },
     {
       "Timestamp": "2026-04-21T16:52:10Z",
@@ -1060,9 +1168,13 @@
       "ActiveThreads": 11,
       "SleepingThreads": 3,
       "MaxTimeMS": 2988677,
+      "HasTimeMetric": true,
       "MaxRowsExamined": 543,
+      "HasRowsExaminedMetric": true,
       "MaxRowsSent": 543,
-      "RowsWithQueryText": 8
+      "HasRowsSentMetric": true,
+      "RowsWithQueryText": 8,
+      "HasQueryTextMetric": true
     },
     {
       "Timestamp": "2026-04-21T16:52:11Z",
@@ -1100,9 +1212,13 @@
       "ActiveThreads": 14,
       "SleepingThreads": 1,
       "MaxTimeMS": 2989678,
+      "HasTimeMetric": true,
       "MaxRowsExamined": 543,
+      "HasRowsExaminedMetric": true,
       "MaxRowsSent": 543,
-      "RowsWithQueryText": 12
+      "HasRowsSentMetric": true,
+      "RowsWithQueryText": 12,
+      "HasQueryTextMetric": true
     },
     {
       "Timestamp": "2026-04-21T16:52:12Z",
@@ -1137,9 +1253,13 @@
       "ActiveThreads": 13,
       "SleepingThreads": 1,
       "MaxTimeMS": 2990678,
+      "HasTimeMetric": true,
       "MaxRowsExamined": 51,
+      "HasRowsExaminedMetric": true,
       "MaxRowsSent": 51,
-      "RowsWithQueryText": 12
+      "HasRowsSentMetric": true,
+      "RowsWithQueryText": 12,
+      "HasQueryTextMetric": true
     }
   ],
   "states": [

--- a/testdata/golden/processlist.example2.2026_04_21_16_51_41.json
+++ b/testdata/golden/processlist.example2.2026_04_21_16_51_41.json
@@ -27,7 +27,14 @@
       "DbCounts": {
         "Other": 3,
         "test": 10
-      }
+      },
+      "TotalThreads": 13,
+      "ActiveThreads": 12,
+      "SleepingThreads": 1,
+      "MaxTimeMS": 2961678,
+      "MaxRowsExamined": 543,
+      "MaxRowsSent": 543,
+      "RowsWithQueryText": 11
     },
     {
       "Timestamp": "2026-04-21T16:51:44Z",
@@ -57,7 +64,14 @@
       "DbCounts": {
         "Other": 5,
         "test": 10
-      }
+      },
+      "TotalThreads": 15,
+      "ActiveThreads": 13,
+      "SleepingThreads": 2,
+      "MaxTimeMS": 2962678,
+      "MaxRowsExamined": 543,
+      "MaxRowsSent": 543,
+      "RowsWithQueryText": 12
     },
     {
       "Timestamp": "2026-04-21T16:51:45Z",
@@ -87,7 +101,14 @@
       "DbCounts": {
         "Other": 4,
         "test": 10
-      }
+      },
+      "TotalThreads": 14,
+      "ActiveThreads": 13,
+      "SleepingThreads": 1,
+      "MaxTimeMS": 2963677,
+      "MaxRowsExamined": 543,
+      "MaxRowsSent": 543,
+      "RowsWithQueryText": 12
     },
     {
       "Timestamp": "2026-04-21T16:51:46Z",
@@ -116,7 +137,14 @@
       "DbCounts": {
         "Other": 5,
         "test": 10
-      }
+      },
+      "TotalThreads": 15,
+      "ActiveThreads": 12,
+      "SleepingThreads": 3,
+      "MaxTimeMS": 2964677,
+      "MaxRowsExamined": 543,
+      "MaxRowsSent": 543,
+      "RowsWithQueryText": 11
     },
     {
       "Timestamp": "2026-04-21T16:51:47Z",
@@ -148,7 +176,14 @@
       "DbCounts": {
         "Other": 6,
         "test": 10
-      }
+      },
+      "TotalThreads": 16,
+      "ActiveThreads": 15,
+      "SleepingThreads": 1,
+      "MaxTimeMS": 2965676,
+      "MaxRowsExamined": 543,
+      "MaxRowsSent": 543,
+      "RowsWithQueryText": 13
     },
     {
       "Timestamp": "2026-04-21T16:51:48Z",
@@ -181,7 +216,14 @@
       "DbCounts": {
         "Other": 4,
         "test": 10
-      }
+      },
+      "TotalThreads": 14,
+      "ActiveThreads": 13,
+      "SleepingThreads": 1,
+      "MaxTimeMS": 2966677,
+      "MaxRowsExamined": 543,
+      "MaxRowsSent": 543,
+      "RowsWithQueryText": 11
     },
     {
       "Timestamp": "2026-04-21T16:51:49Z",
@@ -215,7 +257,14 @@
       "DbCounts": {
         "Other": 6,
         "test": 10
-      }
+      },
+      "TotalThreads": 16,
+      "ActiveThreads": 13,
+      "SleepingThreads": 3,
+      "MaxTimeMS": 2967678,
+      "MaxRowsExamined": 543,
+      "MaxRowsSent": 543,
+      "RowsWithQueryText": 11
     },
     {
       "Timestamp": "2026-04-21T16:51:50Z",
@@ -248,7 +297,14 @@
       "DbCounts": {
         "Other": 5,
         "test": 10
-      }
+      },
+      "TotalThreads": 15,
+      "ActiveThreads": 13,
+      "SleepingThreads": 2,
+      "MaxTimeMS": 2968679,
+      "MaxRowsExamined": 543,
+      "MaxRowsSent": 543,
+      "RowsWithQueryText": 11
     },
     {
       "Timestamp": "2026-04-21T16:51:51Z",
@@ -278,7 +334,14 @@
       "DbCounts": {
         "Other": 6,
         "test": 10
-      }
+      },
+      "TotalThreads": 16,
+      "ActiveThreads": 15,
+      "SleepingThreads": 1,
+      "MaxTimeMS": 2969678,
+      "MaxRowsExamined": 543,
+      "MaxRowsSent": 543,
+      "RowsWithQueryText": 12
     },
     {
       "Timestamp": "2026-04-21T16:51:52Z",
@@ -307,7 +370,14 @@
       "DbCounts": {
         "Other": 3,
         "test": 10
-      }
+      },
+      "TotalThreads": 13,
+      "ActiveThreads": 12,
+      "SleepingThreads": 1,
+      "MaxTimeMS": 2970677,
+      "MaxRowsExamined": 543,
+      "MaxRowsSent": 543,
+      "RowsWithQueryText": 11
     },
     {
       "Timestamp": "2026-04-21T16:51:53Z",
@@ -337,7 +407,14 @@
       "DbCounts": {
         "Other": 4,
         "test": 10
-      }
+      },
+      "TotalThreads": 14,
+      "ActiveThreads": 13,
+      "SleepingThreads": 1,
+      "MaxTimeMS": 2971677,
+      "MaxRowsExamined": 543,
+      "MaxRowsSent": 543,
+      "RowsWithQueryText": 12
     },
     {
       "Timestamp": "2026-04-21T16:51:54Z",
@@ -369,7 +446,14 @@
       "DbCounts": {
         "Other": 5,
         "test": 10
-      }
+      },
+      "TotalThreads": 15,
+      "ActiveThreads": 14,
+      "SleepingThreads": 1,
+      "MaxTimeMS": 2972678,
+      "MaxRowsExamined": 543,
+      "MaxRowsSent": 543,
+      "RowsWithQueryText": 12
     },
     {
       "Timestamp": "2026-04-21T16:51:55Z",
@@ -400,7 +484,14 @@
       "DbCounts": {
         "Other": 4,
         "test": 10
-      }
+      },
+      "TotalThreads": 14,
+      "ActiveThreads": 13,
+      "SleepingThreads": 1,
+      "MaxTimeMS": 2973678,
+      "MaxRowsExamined": 543,
+      "MaxRowsSent": 543,
+      "RowsWithQueryText": 12
     },
     {
       "Timestamp": "2026-04-21T16:51:56Z",
@@ -433,7 +524,14 @@
       "DbCounts": {
         "Other": 4,
         "test": 10
-      }
+      },
+      "TotalThreads": 14,
+      "ActiveThreads": 13,
+      "SleepingThreads": 1,
+      "MaxTimeMS": 2974678,
+      "MaxRowsExamined": 543,
+      "MaxRowsSent": 543,
+      "RowsWithQueryText": 11
     },
     {
       "Timestamp": "2026-04-21T16:51:57Z",
@@ -462,7 +560,14 @@
       "DbCounts": {
         "Other": 4,
         "test": 10
-      }
+      },
+      "TotalThreads": 14,
+      "ActiveThreads": 13,
+      "SleepingThreads": 1,
+      "MaxTimeMS": 2975678,
+      "MaxRowsExamined": 543,
+      "MaxRowsSent": 543,
+      "RowsWithQueryText": 12
     },
     {
       "Timestamp": "2026-04-21T16:51:58Z",
@@ -494,7 +599,14 @@
       "DbCounts": {
         "Other": 5,
         "test": 10
-      }
+      },
+      "TotalThreads": 15,
+      "ActiveThreads": 14,
+      "SleepingThreads": 1,
+      "MaxTimeMS": 2976678,
+      "MaxRowsExamined": 543,
+      "MaxRowsSent": 543,
+      "RowsWithQueryText": 11
     },
     {
       "Timestamp": "2026-04-21T16:51:59Z",
@@ -526,7 +638,14 @@
       "DbCounts": {
         "Other": 6,
         "test": 10
-      }
+      },
+      "TotalThreads": 16,
+      "ActiveThreads": 15,
+      "SleepingThreads": 1,
+      "MaxTimeMS": 2977678,
+      "MaxRowsExamined": 543,
+      "MaxRowsSent": 543,
+      "RowsWithQueryText": 12
     },
     {
       "Timestamp": "2026-04-21T16:52:00Z",
@@ -554,7 +673,14 @@
       "DbCounts": {
         "Other": 3,
         "test": 10
-      }
+      },
+      "TotalThreads": 13,
+      "ActiveThreads": 12,
+      "SleepingThreads": 1,
+      "MaxTimeMS": 2978677,
+      "MaxRowsExamined": 543,
+      "MaxRowsSent": 543,
+      "RowsWithQueryText": 11
     },
     {
       "Timestamp": "2026-04-21T16:52:01Z",
@@ -584,7 +710,14 @@
       "DbCounts": {
         "Other": 4,
         "test": 10
-      }
+      },
+      "TotalThreads": 14,
+      "ActiveThreads": 13,
+      "SleepingThreads": 1,
+      "MaxTimeMS": 2979677,
+      "MaxRowsExamined": 543,
+      "MaxRowsSent": 543,
+      "RowsWithQueryText": 12
     },
     {
       "Timestamp": "2026-04-21T16:52:02Z",
@@ -614,7 +747,14 @@
       "DbCounts": {
         "Other": 6,
         "test": 10
-      }
+      },
+      "TotalThreads": 16,
+      "ActiveThreads": 14,
+      "SleepingThreads": 2,
+      "MaxTimeMS": 2980678,
+      "MaxRowsExamined": 543,
+      "MaxRowsSent": 543,
+      "RowsWithQueryText": 13
     },
     {
       "Timestamp": "2026-04-21T16:52:03Z",
@@ -643,7 +783,14 @@
       "DbCounts": {
         "Other": 4,
         "test": 10
-      }
+      },
+      "TotalThreads": 14,
+      "ActiveThreads": 13,
+      "SleepingThreads": 1,
+      "MaxTimeMS": 2981678,
+      "MaxRowsExamined": 543,
+      "MaxRowsSent": 543,
+      "RowsWithQueryText": 12
     },
     {
       "Timestamp": "2026-04-21T16:52:04Z",
@@ -675,7 +822,14 @@
       "DbCounts": {
         "Other": 6,
         "test": 10
-      }
+      },
+      "TotalThreads": 16,
+      "ActiveThreads": 14,
+      "SleepingThreads": 2,
+      "MaxTimeMS": 2982678,
+      "MaxRowsExamined": 543,
+      "MaxRowsSent": 543,
+      "RowsWithQueryText": 12
     },
     {
       "Timestamp": "2026-04-21T16:52:05Z",
@@ -707,7 +861,14 @@
       "DbCounts": {
         "Other": 5,
         "test": 10
-      }
+      },
+      "TotalThreads": 15,
+      "ActiveThreads": 14,
+      "SleepingThreads": 1,
+      "MaxTimeMS": 2983677,
+      "MaxRowsExamined": 543,
+      "MaxRowsSent": 543,
+      "RowsWithQueryText": 11
     },
     {
       "Timestamp": "2026-04-21T16:52:06Z",
@@ -738,7 +899,14 @@
       "DbCounts": {
         "Other": 5,
         "test": 10
-      }
+      },
+      "TotalThreads": 15,
+      "ActiveThreads": 13,
+      "SleepingThreads": 2,
+      "MaxTimeMS": 2984678,
+      "MaxRowsExamined": 543,
+      "MaxRowsSent": 543,
+      "RowsWithQueryText": 12
     },
     {
       "Timestamp": "2026-04-21T16:52:07Z",
@@ -766,7 +934,14 @@
       "DbCounts": {
         "Other": 3,
         "test": 10
-      }
+      },
+      "TotalThreads": 13,
+      "ActiveThreads": 12,
+      "SleepingThreads": 1,
+      "MaxTimeMS": 2985679,
+      "MaxRowsExamined": 543,
+      "MaxRowsSent": 543,
+      "RowsWithQueryText": 11
     },
     {
       "Timestamp": "2026-04-21T16:52:08Z",
@@ -797,7 +972,14 @@
       "DbCounts": {
         "Other": 3,
         "test": 10
-      }
+      },
+      "TotalThreads": 13,
+      "ActiveThreads": 12,
+      "SleepingThreads": 1,
+      "MaxTimeMS": 2986677,
+      "MaxRowsExamined": 543,
+      "MaxRowsSent": 543,
+      "RowsWithQueryText": 11
     },
     {
       "Timestamp": "2026-04-21T16:52:09Z",
@@ -829,7 +1011,14 @@
       "DbCounts": {
         "Other": 5,
         "test": 10
-      }
+      },
+      "TotalThreads": 15,
+      "ActiveThreads": 14,
+      "SleepingThreads": 1,
+      "MaxTimeMS": 2987677,
+      "MaxRowsExamined": 543,
+      "MaxRowsSent": 543,
+      "RowsWithQueryText": 13
     },
     {
       "Timestamp": "2026-04-21T16:52:10Z",
@@ -866,7 +1055,14 @@
       "DbCounts": {
         "Other": 4,
         "test": 10
-      }
+      },
+      "TotalThreads": 14,
+      "ActiveThreads": 11,
+      "SleepingThreads": 3,
+      "MaxTimeMS": 2988677,
+      "MaxRowsExamined": 543,
+      "MaxRowsSent": 543,
+      "RowsWithQueryText": 8
     },
     {
       "Timestamp": "2026-04-21T16:52:11Z",
@@ -899,7 +1095,14 @@
       "DbCounts": {
         "Other": 5,
         "test": 10
-      }
+      },
+      "TotalThreads": 15,
+      "ActiveThreads": 14,
+      "SleepingThreads": 1,
+      "MaxTimeMS": 2989678,
+      "MaxRowsExamined": 543,
+      "MaxRowsSent": 543,
+      "RowsWithQueryText": 12
     },
     {
       "Timestamp": "2026-04-21T16:52:12Z",
@@ -929,7 +1132,14 @@
       "DbCounts": {
         "Other": 4,
         "test": 10
-      }
+      },
+      "TotalThreads": 14,
+      "ActiveThreads": 13,
+      "SleepingThreads": 1,
+      "MaxTimeMS": 2990678,
+      "MaxRowsExamined": 51,
+      "MaxRowsSent": 51,
+      "RowsWithQueryText": 12
     }
   ],
   "states": [

--- a/tests/coverage/agent_alignment_test.go
+++ b/tests/coverage/agent_alignment_test.go
@@ -16,22 +16,6 @@ func TestAgentContextFeaturePointersStayAligned(t *testing.T) {
 	agents := readRepoFile(t, root, "AGENTS.md")
 	claude := readRepoFile(t, root, "CLAUDE.md")
 
-	for name, text := range map[string]string{
-		"AGENTS.md": agents,
-		"CLAUDE.md": claude,
-	} {
-		block := speckitBlock(t, text)
-		if !strings.Contains(block, "No active feature.") {
-			t.Fatalf("%s must not advertise a stale active feature on main", name)
-		}
-		if !strings.Contains(block, "latest shipped feature is **003-feedback-backend-worker**") {
-			t.Fatalf("%s must name 003-feedback-backend-worker as latest shipped", name)
-		}
-		if strings.Contains(block, "Active feature:") {
-			t.Fatalf("%s has an active-feature marker while main is between features", name)
-		}
-	}
-
 	var pointer struct {
 		FeatureDirectory string `json:"feature_directory"`
 	}
@@ -41,11 +25,39 @@ func TestAgentContextFeaturePointersStayAligned(t *testing.T) {
 	); err != nil {
 		t.Fatalf("parse .specify/feature.json: %v", err)
 	}
-	if pointer.FeatureDirectory != "specs/003-feedback-backend-worker" {
-		t.Fatalf(
-			".specify/feature.json = %q, want latest shipped feature specs/003-feedback-backend-worker",
-			pointer.FeatureDirectory,
-		)
+	if pointer.FeatureDirectory == "" {
+		t.Fatalf(".specify/feature.json must name a feature directory")
+	}
+	if _, err := os.Stat(filepath.Join(root, filepath.FromSlash(pointer.FeatureDirectory))); err != nil {
+		t.Fatalf(".specify/feature.json points at missing feature directory %q: %v", pointer.FeatureDirectory, err)
+	}
+
+	featureName := filepath.Base(pointer.FeatureDirectory)
+	for name, text := range map[string]string{"AGENTS.md": agents, "CLAUDE.md": claude} {
+		block := speckitBlock(t, text)
+		if strings.Contains(block, "No active feature.") {
+			if pointer.FeatureDirectory != "specs/003-feedback-backend-worker" {
+				t.Fatalf("%s says no active feature but .specify/feature.json = %q, want specs/003-feedback-backend-worker", name, pointer.FeatureDirectory)
+			}
+			if !strings.Contains(block, "latest shipped feature is **003-feedback-backend-worker**") {
+				t.Fatalf("%s no-active block must name 003-feedback-backend-worker as latest shipped", name)
+			}
+			continue
+		}
+		wantMarker := "Active feature: **" + featureName + "**"
+		if !strings.Contains(block, wantMarker) {
+			t.Fatalf("%s active block missing %q", name, wantMarker)
+		}
+		for _, required := range []string{
+			pointer.FeatureDirectory + "/plan.md",
+			pointer.FeatureDirectory + "/spec.md",
+			pointer.FeatureDirectory + "/tasks.md",
+			".specify/memory/constitution.md",
+		} {
+			if !strings.Contains(block, required) {
+				t.Fatalf("%s active block missing %q", name, required)
+			}
+		}
 	}
 
 	for name, text := range map[string]string{


### PR DESCRIPTION
## Summary
- Add spec-driven feature artifacts for richer processlist metrics.
- Parse active/sleeping/total threads plus longest age, peak Rows_examined, peak Rows_sent, and query-text row counts from pt-stalk processlist files.
- Render Processlist summary callouts and an Activity chart dimension while preserving existing state/user/host/command/db breakdowns.

## Validation
- go test ./...
- make lint
- node --check render/assets/app.js
- Generated a report from /Users/matias/Documents/Incidents/CS0060148/eu-hrznp-d003/pt-stalk and confirmed the richer processlist payload/markup is present.