### PR TITLE
Add observed slowest processlist queries

### DIFF
--- a/.specify/feature.json
+++ b/.specify/feature.json
@@ -1,3 +1,3 @@
 {
-  "feature_directory": "specs/005-richer-processlist-metrics"
+  "feature_directory": "specs/006-observed-slowest-queries"
 }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,20 +1,21 @@
 <!-- SPECKIT START -->
-Active feature: **005-richer-processlist-metrics**
+Active feature: **006-observed-slowest-queries**
 
 For technologies, project structure, constitution gates, data model,
 package/UI contracts, and shell commands, read the current plan:
 
-- Plan: `specs/005-richer-processlist-metrics/plan.md`
-- Spec: `specs/005-richer-processlist-metrics/spec.md`
-- Research: `specs/005-richer-processlist-metrics/research.md`
-- Data model: `specs/005-richer-processlist-metrics/data-model.md`
-- Contracts: `specs/005-richer-processlist-metrics/contracts/packages.md`,
-  `specs/005-richer-processlist-metrics/contracts/ui.md`
-- Quickstart: `specs/005-richer-processlist-metrics/quickstart.md`
-- Tasks: `specs/005-richer-processlist-metrics/tasks.md`
+- Plan: `specs/006-observed-slowest-queries/plan.md`
+- Spec: `specs/006-observed-slowest-queries/spec.md`
+- Research: `specs/006-observed-slowest-queries/research.md`
+- Data model: `specs/006-observed-slowest-queries/data-model.md`
+- Contracts: `specs/006-observed-slowest-queries/contracts/packages.md`,
+  `specs/006-observed-slowest-queries/contracts/ui.md`
+- Quickstart: `specs/006-observed-slowest-queries/quickstart.md`
+- Tasks: `specs/006-observed-slowest-queries/tasks.md`
 - Constitution: `.specify/memory/constitution.md`
 
 Prior features:
+- **005-richer-processlist-metrics** - `specs/005-richer-processlist-metrics/plan.md`
 - **003-feedback-backend-worker** - `specs/003-feedback-backend-worker/plan.md`
 - **002-report-feedback-button** - `specs/002-report-feedback-button/plan.md`
 - **001-ptstalk-report-mvp** - `specs/001-ptstalk-report-mvp/plan.md`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,20 +1,21 @@
 <!-- SPECKIT START -->
-Active feature: **005-richer-processlist-metrics**
+Active feature: **006-observed-slowest-queries**
 
 For technologies, project structure, constitution gates, data model,
 package/UI contracts, and shell commands, read the current plan:
 
-- Plan: `specs/005-richer-processlist-metrics/plan.md`
-- Spec: `specs/005-richer-processlist-metrics/spec.md`
-- Research: `specs/005-richer-processlist-metrics/research.md`
-- Data model: `specs/005-richer-processlist-metrics/data-model.md`
-- Contracts: `specs/005-richer-processlist-metrics/contracts/packages.md`,
-  `specs/005-richer-processlist-metrics/contracts/ui.md`
-- Quickstart: `specs/005-richer-processlist-metrics/quickstart.md`
-- Tasks: `specs/005-richer-processlist-metrics/tasks.md`
+- Plan: `specs/006-observed-slowest-queries/plan.md`
+- Spec: `specs/006-observed-slowest-queries/spec.md`
+- Research: `specs/006-observed-slowest-queries/research.md`
+- Data model: `specs/006-observed-slowest-queries/data-model.md`
+- Contracts: `specs/006-observed-slowest-queries/contracts/packages.md`,
+  `specs/006-observed-slowest-queries/contracts/ui.md`
+- Quickstart: `specs/006-observed-slowest-queries/quickstart.md`
+- Tasks: `specs/006-observed-slowest-queries/tasks.md`
 - Constitution: `.specify/memory/constitution.md`
 
 Prior features:
+- **005-richer-processlist-metrics** - `specs/005-richer-processlist-metrics/plan.md`
 - **003-feedback-backend-worker** - `specs/003-feedback-backend-worker/plan.md`
 - **002-report-feedback-button** - `specs/002-report-feedback-button/plan.md`
 - **001-ptstalk-report-mvp** - `specs/001-ptstalk-report-mvp/plan.md`

--- a/findings/findings_test.go
+++ b/findings/findings_test.go
@@ -13,11 +13,12 @@ import (
 // because counter helpers skip index 0 by design (pt-mext raw tally
 // convention; see inputs.go::counterTotal).
 type builder struct {
-	counters   map[string][]float64
-	gauges     map[string][]float64
-	isCounter  map[string]bool
-	vars       map[string]string
-	windowSecs float64
+	counters    map[string][]float64
+	gauges      map[string][]float64
+	isCounter   map[string]bool
+	vars        map[string]string
+	processlist *model.ProcesslistData
+	windowSecs  float64
 }
 
 func newBuilder() *builder {
@@ -81,6 +82,11 @@ func (b *builder) withWindow(sec float64) *builder {
 	return b
 }
 
+func (b *builder) withObservedQueries(queries ...model.ObservedProcesslistQuery) *builder {
+	b.processlist = &model.ProcesslistData{ObservedQueries: queries}
+	return b
+}
+
 func (b *builder) build() *model.Report {
 	deltas := map[string][]float64{}
 	for k, v := range b.counters {
@@ -134,7 +140,7 @@ func (b *builder) build() *model.Report {
 		},
 	}
 	return &model.Report{
-		DBSection:        &model.DBSection{Mysqladmin: m},
+		DBSection:        &model.DBSection{Mysqladmin: m, Processlist: b.processlist},
 		VariablesSection: vs,
 	}
 }
@@ -152,6 +158,65 @@ func TestAnalyze_SkipsWhenNoMysqladmin(t *testing.T) {
 	got := Analyze(&model.Report{})
 	if len(got) != 0 {
 		t.Fatalf("expected no findings for empty report; got %d", len(got))
+	}
+}
+
+func TestObservedSlowProcesslistQueryFinding(t *testing.T) {
+	ts := time.Unix(1_700_000_000, 0).UTC()
+	q, ok := model.NewObservedProcesslistQuery(ts, "app", "shop", "Query", "Sending data",
+		"select * from orders where customer_id = 123", 75_000, true, 42, true, 7, true)
+	if !ok {
+		t.Fatal("query unexpectedly ineligible")
+	}
+	q.SeenSamples = 5
+
+	got := Analyze(newBuilder().withObservedQueries(q).build())
+	f := findByID(got, "queryshape.observed_slow_processlist")
+	if f == nil {
+		t.Fatalf("observed slow processlist finding not found in %+v", got)
+	}
+	if f.Severity != SeverityWarn {
+		t.Fatalf("severity = %v, want %v", f.Severity, SeverityWarn)
+	}
+	for _, want := range []string{q.Fingerprint, "75", "5", "app", "shop", "Sending data"} {
+		if !strings.Contains(f.Summary+f.Explanation+f.FormulaComputed, want) {
+			t.Errorf("finding text missing %q: %+v", want, f)
+		}
+	}
+}
+
+func TestObservedSlowProcesslistQueryFindingMetadataLockCritical(t *testing.T) {
+	ts := time.Unix(1_700_000_000, 0).UTC()
+	q, ok := model.NewObservedProcesslistQuery(ts, "horizon", "horizon", "Query", "Waiting for table metadata lock",
+		"rename table horizon.site_artifact_milestone to horizon.site_artifact_milestone_old", 3_723_600, true, 0, true, 0, true)
+	if !ok {
+		t.Fatal("query unexpectedly ineligible")
+	}
+
+	got := Analyze(newBuilder().withObservedQueries(q).build())
+	f := findByID(got, "queryshape.observed_slow_processlist")
+	if f == nil {
+		t.Fatalf("observed slow processlist finding not found in %+v", got)
+	}
+	if f.Severity != SeverityCrit {
+		t.Fatalf("severity = %v, want %v", f.Severity, SeverityCrit)
+	}
+	if !strings.Contains(f.Summary, "metadata lock") {
+		t.Fatalf("summary %q does not call out metadata lock", f.Summary)
+	}
+}
+
+func TestObservedSlowProcesslistQueryFindingSkipsBelowThreshold(t *testing.T) {
+	ts := time.Unix(1_700_000_000, 0).UTC()
+	q, ok := model.NewObservedProcesslistQuery(ts, "app", "shop", "Query", "Sending data",
+		"select * from orders", 59_999, true, 0, false, 0, false)
+	if !ok {
+		t.Fatal("query unexpectedly ineligible")
+	}
+
+	got := Analyze(newBuilder().withObservedQueries(q).build())
+	if f := findByID(got, "queryshape.observed_slow_processlist"); f != nil {
+		t.Fatalf("expected slow observed query finding to skip below threshold, got %+v", f)
 	}
 }
 

--- a/findings/rules_queryshape.go
+++ b/findings/rules_queryshape.go
@@ -2,9 +2,12 @@ package findings
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/matias-sanchez/My-gather/model"
 )
+
+const observedSlowQueryWarnSeconds = 60.0
 
 // ruleFullScanSelectScan flags any Select_scan activity — joins that
 // did a full scan of the first table.
@@ -81,6 +84,80 @@ func init() {
 		Severity:           SeverityHintVariable,
 		Run:                ruleProcesslistAbuse,
 	})
+	register(RuleDefinition{
+		ID:                 "queryshape.observed_slow_processlist",
+		Subsystem:          "Query Shape",
+		Title:              "Slow observed processlist query",
+		FormulaText:        "max observed processlist query age >= 60s",
+		MinRecommendations: 3,
+		Severity:           SeverityHintVariable,
+		Run:                ruleObservedSlowProcesslistQuery,
+	})
+}
+
+// ruleObservedSlowProcesslistQuery flags the most impactful active
+// processlist query shape observed during the capture. The processlist
+// model is already sorted by max age, so the first summary at or above
+// threshold is the strongest evidence to present.
+func ruleObservedSlowProcesslistQuery(r *model.Report) Finding {
+	if r == nil || r.DBSection == nil || r.DBSection.Processlist == nil {
+		return Finding{Severity: SeveritySkip}
+	}
+	var top model.ObservedProcesslistQuery
+	found := false
+	for _, q := range r.DBSection.Processlist.ObservedQueries {
+		if !q.HasTimeMetric {
+			continue
+		}
+		if q.MaxTimeMS/1000 < observedSlowQueryWarnSeconds {
+			continue
+		}
+		top = q
+		found = true
+		break
+	}
+	if !found {
+		return Finding{Severity: SeveritySkip}
+	}
+
+	ageSeconds := top.MaxTimeMS / 1000
+	sev := SeverityWarn
+	summary := fmt.Sprintf("Observed query %s ran for %s s across %s sightings.",
+		top.Fingerprint, formatNum(ageSeconds), formatNum(float64(top.SeenSamples)))
+	stateLower := strings.ToLower(top.State)
+	if strings.Contains(stateLower, "metadata lock") {
+		sev = SeverityCrit
+		summary = fmt.Sprintf("Observed query %s waited on metadata lock for %s s across %s sightings.",
+			top.Fingerprint, formatNum(ageSeconds), formatNum(float64(top.SeenSamples)))
+	}
+
+	explanation := fmt.Sprintf(
+		"The slowest observed active processlist query was seen as user %s on database %s with state %s. Query shape: %s",
+		top.User, top.DB, top.State, top.Snippet,
+	)
+	return Finding{
+		ID:          "queryshape.observed_slow_processlist",
+		Subsystem:   "Query Shape",
+		Title:       "Slow observed processlist query",
+		Severity:    sev,
+		Summary:     summary,
+		Explanation: explanation,
+		FormulaText: "max observed processlist query age >= 60s",
+		FormulaComputed: fmt.Sprintf("%s s >= %s s  (fingerprint %s, user %s, db %s, state %s)",
+			formatNum(ageSeconds), formatNum(observedSlowQueryWarnSeconds), top.Fingerprint, top.User, top.DB, top.State),
+		Metrics: []MetricRef{
+			{Name: "max observed age", Value: ageSeconds, Unit: "s"},
+			{Name: "sightings", Value: float64(top.SeenSamples), Unit: "count"},
+			{Name: "rows examined", Value: top.MaxRowsExamined, Unit: "rows"},
+			{Name: "rows sent", Value: top.MaxRowsSent, Unit: "rows"},
+		},
+		Recommendations: []string{
+			"Use the fingerprint and query shape in this report to locate matching application code, slow log entries, or performance_schema statement history.",
+			"If the state is a lock wait, identify the blocking session or DDL path before tuning the query itself.",
+			"Review the query's EXPLAIN plan and supporting indexes once lock waits or blocking transactions are ruled out.",
+		},
+		Source: "pt-stalk processlist observed query summary",
+	}
 }
 
 // ruleFullScanSelectFullJoin flags joins that performed table scans

--- a/model/model.go
+++ b/model/model.go
@@ -14,8 +14,25 @@
 package model
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
+	"regexp"
 	"sort"
+	"strings"
 	"time"
+)
+
+// MaxObservedProcesslistQueries is the maximum number of grouped active
+// processlist query summaries rendered in the report.
+const MaxObservedProcesslistQueries = 10
+
+// MaxObservedProcesslistQuerySnippetRunes is the maximum visible length of a
+// processlist query snippet, including the trailing truncation marker.
+const MaxObservedProcesslistQuerySnippetRunes = 160
+
+var (
+	processlistQuotedLiteralRE  = regexp.MustCompile(`'([^'\\]|\\.)*'|"([^"\\]|\\.)*"|` + "`" + `([^` + "`" + `\\]|\\.)*` + "`")
+	processlistNumericLiteralRE = regexp.MustCompile(`\b0x[0-9a-fA-F]+\b|\b\d+(?:\.\d+)?\b`)
 )
 
 // Suffix is the pt-stalk collector file-suffix this feature recognises
@@ -540,6 +557,225 @@ type ProcesslistData struct {
 	// Snapshot's first sample sits within the concatenated time axis.
 	// Same semantics as IostatData.SnapshotBoundaries.
 	SnapshotBoundaries []int
+
+	// ObservedQueries is a bounded, deterministically sorted list of
+	// active processlist query shapes observed across the data set.
+	ObservedQueries []ObservedProcesslistQuery
+}
+
+// ObservedProcesslistQuery is one grouped active SQL shape observed in
+// processlist rows. It is intentionally a summary, not a raw row dump:
+// repeated sightings of the same normalized query shape are merged, snippets
+// are bounded, and context fields come from the slowest sighting.
+type ObservedProcesslistQuery struct {
+	// Fingerprint is a stable identifier derived from normalized query text.
+	Fingerprint string
+
+	// Snippet is a compact, bounded query shape suitable for report display.
+	Snippet string
+
+	// FirstSeen is the first sample timestamp where this query shape appeared.
+	FirstSeen time.Time
+
+	// LastSeen is the last sample timestamp where this query shape appeared.
+	LastSeen time.Time
+
+	// SeenSamples counts eligible processlist rows grouped into this summary.
+	SeenSamples int
+
+	// MaxTimeMS is the largest observed age for this query shape.
+	MaxTimeMS float64
+
+	// HasTimeMetric reports whether MaxTimeMS came from Time_ms or Time.
+	HasTimeMetric bool
+
+	// MaxRowsExamined is the highest observed Rows_examined value.
+	MaxRowsExamined float64
+
+	// HasRowsExaminedMetric reports whether Rows_examined was observed.
+	HasRowsExaminedMetric bool
+
+	// MaxRowsSent is the highest observed Rows_sent value.
+	MaxRowsSent float64
+
+	// HasRowsSentMetric reports whether Rows_sent was observed.
+	HasRowsSentMetric bool
+
+	// User is the MySQL user from the slowest observed sighting.
+	User string
+
+	// DB is the database from the slowest observed sighting.
+	DB string
+
+	// Command is the processlist command from the slowest observed sighting.
+	Command string
+
+	// State is the processlist state from the slowest observed sighting.
+	State string
+}
+
+// NewObservedProcesslistQuery returns a grouped-query seed for one eligible
+// active processlist row. The boolean is false when the row should not
+// participate in slow-query ranking, such as Sleep/Daemon/empty commands or
+// empty/NULL query text.
+func NewObservedProcesslistQuery(
+	ts time.Time,
+	user string,
+	db string,
+	command string,
+	state string,
+	info string,
+	timeMS float64,
+	hasTime bool,
+	rowsExamined float64,
+	hasRowsExamined bool,
+	rowsSent float64,
+	hasRowsSent bool,
+) (ObservedProcesslistQuery, bool) {
+	command = strings.TrimSpace(command)
+	if command == "" || strings.EqualFold(command, "Sleep") || strings.EqualFold(command, "Daemon") {
+		return ObservedProcesslistQuery{}, false
+	}
+	if !hasProcesslistQueryText(info) {
+		return ObservedProcesslistQuery{}, false
+	}
+
+	normalized := NormalizeProcesslistQuery(info)
+	fingerprint := processlistQueryFingerprint(normalized)
+	return ObservedProcesslistQuery{
+		Fingerprint:           fingerprint,
+		Snippet:               boundProcesslistSnippet(normalized),
+		FirstSeen:             ts,
+		LastSeen:              ts,
+		SeenSamples:           1,
+		MaxTimeMS:             timeMS,
+		HasTimeMetric:         hasTime,
+		MaxRowsExamined:       rowsExamined,
+		HasRowsExaminedMetric: hasRowsExamined,
+		MaxRowsSent:           rowsSent,
+		HasRowsSentMetric:     hasRowsSent,
+		User:                  emptyAsOther(user),
+		DB:                    nullOrEmptyAsOther(db),
+		Command:               command,
+		State:                 nullOrEmptyAsOther(state),
+	}, true
+}
+
+// MergeObservedProcesslistQueries groups query sightings by fingerprint,
+// updates first/last seen bounds, keeps peak metrics, sorts deterministically,
+// and returns at most MaxObservedProcesslistQueries rows.
+func MergeObservedProcesslistQueries(groups ...[]ObservedProcesslistQuery) []ObservedProcesslistQuery {
+	byFingerprint := map[string]ObservedProcesslistQuery{}
+	for _, group := range groups {
+		for _, q := range group {
+			if q.Fingerprint == "" {
+				continue
+			}
+			current, ok := byFingerprint[q.Fingerprint]
+			if !ok {
+				byFingerprint[q.Fingerprint] = q
+				continue
+			}
+			current.SeenSamples += q.SeenSamples
+			if current.FirstSeen.IsZero() || (!q.FirstSeen.IsZero() && q.FirstSeen.Before(current.FirstSeen)) {
+				current.FirstSeen = q.FirstSeen
+			}
+			if q.LastSeen.After(current.LastSeen) {
+				current.LastSeen = q.LastSeen
+			}
+			if q.HasTimeMetric {
+				if !current.HasTimeMetric || q.MaxTimeMS > current.MaxTimeMS {
+					current.MaxTimeMS = q.MaxTimeMS
+					current.HasTimeMetric = true
+					current.User = q.User
+					current.DB = q.DB
+					current.Command = q.Command
+					current.State = q.State
+				}
+			}
+			if q.HasRowsExaminedMetric {
+				current.HasRowsExaminedMetric = true
+				if q.MaxRowsExamined > current.MaxRowsExamined {
+					current.MaxRowsExamined = q.MaxRowsExamined
+				}
+			}
+			if q.HasRowsSentMetric {
+				current.HasRowsSentMetric = true
+				if q.MaxRowsSent > current.MaxRowsSent {
+					current.MaxRowsSent = q.MaxRowsSent
+				}
+			}
+			byFingerprint[q.Fingerprint] = current
+		}
+	}
+
+	out := make([]ObservedProcesslistQuery, 0, len(byFingerprint))
+	for _, q := range byFingerprint {
+		out = append(out, q)
+	}
+	sort.SliceStable(out, func(i, j int) bool {
+		a, b := out[i], out[j]
+		if a.MaxTimeMS != b.MaxTimeMS {
+			return a.MaxTimeMS > b.MaxTimeMS
+		}
+		if a.MaxRowsExamined != b.MaxRowsExamined {
+			return a.MaxRowsExamined > b.MaxRowsExamined
+		}
+		if a.MaxRowsSent != b.MaxRowsSent {
+			return a.MaxRowsSent > b.MaxRowsSent
+		}
+		return a.Fingerprint < b.Fingerprint
+	})
+	if len(out) > MaxObservedProcesslistQueries {
+		out = out[:MaxObservedProcesslistQueries]
+	}
+	return out
+}
+
+// NormalizeProcesslistQuery returns a stable query shape by collapsing
+// whitespace, lowercasing, and replacing quoted and numeric literals with a
+// placeholder.
+func NormalizeProcesslistQuery(query string) string {
+	shape := strings.Join(strings.Fields(strings.TrimSpace(query)), " ")
+	shape = strings.ToLower(shape)
+	shape = processlistQuotedLiteralRE.ReplaceAllString(shape, "?")
+	shape = processlistNumericLiteralRE.ReplaceAllString(shape, "?")
+	return shape
+}
+
+func processlistQueryFingerprint(normalized string) string {
+	sum := sha256.Sum256([]byte(normalized))
+	return "q_" + hex.EncodeToString(sum[:8])
+}
+
+func boundProcesslistSnippet(s string) string {
+	runes := []rune(s)
+	if len(runes) <= MaxObservedProcesslistQuerySnippetRunes {
+		return s
+	}
+	if MaxObservedProcesslistQuerySnippetRunes <= 3 {
+		return string(runes[:MaxObservedProcesslistQuerySnippetRunes])
+	}
+	return string(runes[:MaxObservedProcesslistQuerySnippetRunes-3]) + "..."
+}
+
+func hasProcesslistQueryText(s string) bool {
+	trimmed := strings.TrimSpace(s)
+	return trimmed != "" && !strings.EqualFold(trimmed, "NULL")
+}
+
+func emptyAsOther(s string) string {
+	if strings.TrimSpace(s) == "" {
+		return "Other"
+	}
+	return s
+}
+
+func nullOrEmptyAsOther(s string) string {
+	if strings.TrimSpace(s) == "" || strings.EqualFold(strings.TrimSpace(s), "NULL") {
+		return "Other"
+	}
+	return s
 }
 
 // ThreadStateSample is one record per -processlist sample. Each map

--- a/model/model.go
+++ b/model/model.go
@@ -558,8 +558,10 @@ type ProcesslistData struct {
 	// Same semantics as IostatData.SnapshotBoundaries.
 	SnapshotBoundaries []int
 
-	// ObservedQueries is a bounded, deterministically sorted list of
-	// active processlist query shapes observed across the data set.
+	// ObservedQueries is a deterministically sorted list of active
+	// processlist query shapes observed across the data set. Parser
+	// outputs may keep all fingerprints so later snapshot concatenation
+	// can merge complete evidence; render-facing merged data is bounded.
 	ObservedQueries []ObservedProcesslistQuery
 }
 
@@ -665,6 +667,17 @@ func NewObservedProcesslistQuery(
 // updates first/last seen bounds, keeps peak metrics, sorts deterministically,
 // and returns at most MaxObservedProcesslistQueries rows.
 func MergeObservedProcesslistQueries(groups ...[]ObservedProcesslistQuery) []ObservedProcesslistQuery {
+	out := MergeAllObservedProcesslistQueries(groups...)
+	if len(out) > MaxObservedProcesslistQueries {
+		out = out[:MaxObservedProcesslistQueries]
+	}
+	return out
+}
+
+// MergeAllObservedProcesslistQueries groups query sightings by fingerprint,
+// updates first/last seen bounds, keeps peak metrics, and sorts
+// deterministically without applying the render-facing top-N cap.
+func MergeAllObservedProcesslistQueries(groups ...[]ObservedProcesslistQuery) []ObservedProcesslistQuery {
 	byFingerprint := map[string]ObservedProcesslistQuery{}
 	for _, group := range groups {
 		for _, q := range group {
@@ -726,9 +739,6 @@ func MergeObservedProcesslistQueries(groups ...[]ObservedProcesslistQuery) []Obs
 		}
 		return a.Fingerprint < b.Fingerprint
 	})
-	if len(out) > MaxObservedProcesslistQueries {
-		out = out[:MaxObservedProcesslistQueries]
-	}
 	return out
 }
 

--- a/model/model.go
+++ b/model/model.go
@@ -31,7 +31,7 @@ const MaxObservedProcesslistQueries = 10
 const MaxObservedProcesslistQuerySnippetRunes = 160
 
 var (
-	processlistQuotedLiteralRE  = regexp.MustCompile(`'([^'\\]|\\.)*'|"([^"\\]|\\.)*"`)
+	processlistQuotedLiteralRE  = regexp.MustCompile(`'([^'\\]|\\.|'')*'|"([^"\\]|\\.|"")*"`)
 	processlistNumericLiteralRE = regexp.MustCompile(`\b0x[0-9a-fA-F]+\b|\b\d+(?:\.\d+)?\b`)
 )
 

--- a/model/model.go
+++ b/model/model.go
@@ -31,7 +31,7 @@ const MaxObservedProcesslistQueries = 10
 const MaxObservedProcesslistQuerySnippetRunes = 160
 
 var (
-	processlistQuotedLiteralRE  = regexp.MustCompile(`'([^'\\]|\\.)*'|"([^"\\]|\\.)*"|` + "`" + `([^` + "`" + `\\]|\\.)*` + "`")
+	processlistQuotedLiteralRE  = regexp.MustCompile(`'([^'\\]|\\.)*'|"([^"\\]|\\.)*"`)
 	processlistNumericLiteralRE = regexp.MustCompile(`\b0x[0-9a-fA-F]+\b|\b\d+(?:\.\d+)?\b`)
 )
 

--- a/model/processlist_query_test.go
+++ b/model/processlist_query_test.go
@@ -1,0 +1,98 @@
+package model
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestObservedProcesslistQueryFingerprintGroupsLiteralVariants(t *testing.T) {
+	ts := time.Date(2026, 1, 29, 16, 5, 19, 0, time.UTC)
+	first, ok := NewObservedProcesslistQuery(ts, "app", "shop", "Query", "Sending data",
+		"SELECT * FROM orders WHERE id = 123 AND email = 'a@example.com'", 1200, true, 10, true, 2, true)
+	if !ok {
+		t.Fatal("first query unexpectedly ineligible")
+	}
+	second, ok := NewObservedProcesslistQuery(ts.Add(time.Second), "app", "shop", "Query", "Sending data",
+		"select *  from orders where id = 456 and email = 'b@example.com'", 2500, true, 30, true, 4, true)
+	if !ok {
+		t.Fatal("second query unexpectedly ineligible")
+	}
+
+	merged := MergeObservedProcesslistQueries([]ObservedProcesslistQuery{first, second})
+	if got, want := len(merged), 1; got != want {
+		t.Fatalf("merged len = %d, want %d: %#v", got, want, merged)
+	}
+	got := merged[0]
+	if got.Fingerprint == "" || !strings.HasPrefix(got.Fingerprint, "q_") {
+		t.Fatalf("Fingerprint = %q, want stable q_ prefix", got.Fingerprint)
+	}
+	if got.SeenSamples != 2 {
+		t.Errorf("SeenSamples = %d, want 2", got.SeenSamples)
+	}
+	if got.MaxTimeMS != 2500 {
+		t.Errorf("MaxTimeMS = %v, want 2500", got.MaxTimeMS)
+	}
+	if got.MaxRowsExamined != 30 {
+		t.Errorf("MaxRowsExamined = %v, want 30", got.MaxRowsExamined)
+	}
+	if got.MaxRowsSent != 4 {
+		t.Errorf("MaxRowsSent = %v, want 4", got.MaxRowsSent)
+	}
+}
+
+func TestObservedProcesslistQueryExcludesIdleAndBoundsSnippet(t *testing.T) {
+	ts := time.Date(2026, 1, 29, 16, 5, 19, 0, time.UTC)
+	for _, tc := range []struct {
+		name    string
+		command string
+		info    string
+	}{
+		{name: "sleep", command: "Sleep", info: "select 1"},
+		{name: "daemon", command: "Daemon", info: "select 1"},
+		{name: "empty command", command: "", info: "select 1"},
+		{name: "null info", command: "Query", info: "NULL"},
+		{name: "empty info", command: "Query", info: "   "},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got, ok := NewObservedProcesslistQuery(ts, "app", "shop", tc.command, "state", tc.info, 1, true, 0, false, 0, false); ok {
+				t.Fatalf("NewObservedProcesslistQuery returned eligible row: %+v", got)
+			}
+		})
+	}
+
+	longInfo := "select " + strings.Repeat("very_long_column_name, ", MaxObservedProcesslistQuerySnippetRunes)
+	got, ok := NewObservedProcesslistQuery(ts, "app", "shop", "Query", "Sending data", longInfo, 1, true, 0, false, 0, false)
+	if !ok {
+		t.Fatal("long query unexpectedly ineligible")
+	}
+	if len([]rune(got.Snippet)) > MaxObservedProcesslistQuerySnippetRunes {
+		t.Fatalf("snippet rune len = %d, want <= %d", len([]rune(got.Snippet)), MaxObservedProcesslistQuerySnippetRunes)
+	}
+	if !strings.HasSuffix(got.Snippet, "...") {
+		t.Fatalf("truncated snippet = %q, want trailing ...", got.Snippet)
+	}
+}
+
+func TestMergeObservedProcesslistQueriesSortsAndBounds(t *testing.T) {
+	ts := time.Date(2026, 1, 29, 16, 5, 19, 0, time.UTC)
+	var rows []ObservedProcesslistQuery
+	for i := 0; i < MaxObservedProcesslistQueries+3; i++ {
+		q, ok := NewObservedProcesslistQuery(ts.Add(time.Duration(i)*time.Second), "app", "shop", "Query", "Sending data",
+			"select * from t where id = "+string(rune('a'+i)), float64(i+1)*1000, true, float64(i), true, 0, true)
+		if !ok {
+			t.Fatalf("query %d unexpectedly ineligible", i)
+		}
+		rows = append(rows, q)
+	}
+
+	merged := MergeObservedProcesslistQueries(rows)
+	if got, want := len(merged), MaxObservedProcesslistQueries; got != want {
+		t.Fatalf("merged len = %d, want %d", got, want)
+	}
+	for i := 1; i < len(merged); i++ {
+		if merged[i-1].MaxTimeMS < merged[i].MaxTimeMS {
+			t.Fatalf("merged not sorted by age descending at %d: %v < %v", i, merged[i-1].MaxTimeMS, merged[i].MaxTimeMS)
+		}
+	}
+}

--- a/model/processlist_query_test.go
+++ b/model/processlist_query_test.go
@@ -145,4 +145,14 @@ func TestMergeObservedProcesslistQueriesSortsAndBounds(t *testing.T) {
 			t.Fatalf("merged not sorted by age descending at %d: %v < %v", i, merged[i-1].MaxTimeMS, merged[i].MaxTimeMS)
 		}
 	}
+
+	all := MergeAllObservedProcesslistQueries(rows)
+	if got, want := len(all), MaxObservedProcesslistQueries+3; got != want {
+		t.Fatalf("unbounded merged len = %d, want %d", got, want)
+	}
+	for i := 1; i < len(all); i++ {
+		if all[i-1].MaxTimeMS < all[i].MaxTimeMS {
+			t.Fatalf("unbounded merged not sorted by age descending at %d: %v < %v", i, all[i-1].MaxTimeMS, all[i].MaxTimeMS)
+		}
+	}
 }

--- a/model/processlist_query_test.go
+++ b/model/processlist_query_test.go
@@ -41,6 +41,28 @@ func TestObservedProcesslistQueryFingerprintGroupsLiteralVariants(t *testing.T) 
 	}
 }
 
+func TestObservedProcesslistQueryFingerprintGroupsDoubledQuoteLiterals(t *testing.T) {
+	ts := time.Date(2026, 1, 29, 16, 5, 19, 0, time.UTC)
+	first, ok := NewObservedProcesslistQuery(ts, "app", "shop", "Query", "Sending data",
+		"SELECT * FROM customers WHERE name = 'Alice' AND note = \"A\"", 1200, true, 10, true, 2, true)
+	if !ok {
+		t.Fatal("first query unexpectedly ineligible")
+	}
+	second, ok := NewObservedProcesslistQuery(ts.Add(time.Second), "app", "shop", "Query", "Sending data",
+		"SELECT * FROM customers WHERE name = 'O''Reilly' AND note = \"A \"\"quoted\"\" note\"", 2500, true, 30, true, 4, true)
+	if !ok {
+		t.Fatal("second query unexpectedly ineligible")
+	}
+
+	merged := MergeObservedProcesslistQueries([]ObservedProcesslistQuery{first, second})
+	if got, want := len(merged), 1; got != want {
+		t.Fatalf("merged len = %d, want %d: %#v", got, want, merged)
+	}
+	if strings.Contains(merged[0].Snippet, "??") {
+		t.Fatalf("snippet = %q, want doubled-quote literal normalized as one placeholder", merged[0].Snippet)
+	}
+}
+
 func TestObservedProcesslistQueryFingerprintKeepsBacktickIdentifiers(t *testing.T) {
 	ts := time.Date(2026, 1, 29, 16, 5, 19, 0, time.UTC)
 	orders, ok := NewObservedProcesslistQuery(ts, "app", "shop", "Query", "Sending data",

--- a/model/processlist_query_test.go
+++ b/model/processlist_query_test.go
@@ -41,6 +41,34 @@ func TestObservedProcesslistQueryFingerprintGroupsLiteralVariants(t *testing.T) 
 	}
 }
 
+func TestObservedProcesslistQueryFingerprintKeepsBacktickIdentifiers(t *testing.T) {
+	ts := time.Date(2026, 1, 29, 16, 5, 19, 0, time.UTC)
+	orders, ok := NewObservedProcesslistQuery(ts, "app", "shop", "Query", "Sending data",
+		"SELECT * FROM `orders` WHERE id = 123", 1200, true, 10, true, 2, true)
+	if !ok {
+		t.Fatal("orders query unexpectedly ineligible")
+	}
+	customers, ok := NewObservedProcesslistQuery(ts.Add(time.Second), "app", "shop", "Query", "Sending data",
+		"SELECT * FROM `customers` WHERE id = 456", 2500, true, 30, true, 4, true)
+	if !ok {
+		t.Fatal("customers query unexpectedly ineligible")
+	}
+
+	merged := MergeObservedProcesslistQueries([]ObservedProcesslistQuery{orders, customers})
+	if got, want := len(merged), 2; got != want {
+		t.Fatalf("merged len = %d, want %d: %#v", got, want, merged)
+	}
+	if orders.Fingerprint == customers.Fingerprint {
+		t.Fatalf("backtick-quoted identifiers collapsed into one fingerprint %q", orders.Fingerprint)
+	}
+	if !strings.Contains(orders.Snippet, "`orders`") {
+		t.Fatalf("orders snippet = %q, want quoted identifier preserved", orders.Snippet)
+	}
+	if !strings.Contains(customers.Snippet, "`customers`") {
+		t.Fatalf("customers snippet = %q, want quoted identifier preserved", customers.Snippet)
+	}
+}
+
 func TestObservedProcesslistQueryExcludesIdleAndBoundsSnippet(t *testing.T) {
 	ts := time.Date(2026, 1, 29, 16, 5, 19, 0, time.UTC)
 	for _, tc := range []struct {

--- a/parse/processlist.go
+++ b/parse/processlist.go
@@ -186,7 +186,7 @@ func parseProcesslist(r io.Reader, sourcePath string) (*model.ProcesslistData, [
 			current.row.haveRowsSent,
 		); ok {
 			if current, exists := observedQueriesByFingerprint[q.Fingerprint]; exists {
-				merged := model.MergeObservedProcesslistQueries(
+				merged := model.MergeAllObservedProcesslistQueries(
 					[]model.ObservedProcesslistQuery{current},
 					[]model.ObservedProcesslistQuery{q},
 				)
@@ -360,7 +360,7 @@ func parseProcesslist(r io.Reader, sourcePath string) (*model.ProcesslistData, [
 		Hosts:              hosts,
 		Commands:           commands,
 		Dbs:                dbs,
-		ObservedQueries:    model.MergeObservedProcesslistQueries(observedQueries),
+		ObservedQueries:    model.MergeAllObservedProcesslistQueries(observedQueries),
 	}, diagnostics
 }
 

--- a/parse/processlist.go
+++ b/parse/processlist.go
@@ -81,6 +81,7 @@ func parseProcesslist(r io.Reader, sourcePath string) (*model.ProcesslistData, [
 	hostsSet := map[string]struct{}{}
 	commandsSet := map[string]struct{}{}
 	dbsSet := map[string]struct{}{}
+	var observedQueries []model.ObservedProcesslistQuery
 
 	// flushRow records a completed vertical-format row's dimensions
 	// into the current sample. Called on row-separator lines and on
@@ -169,6 +170,22 @@ func parseProcesslist(r io.Reader, sourcePath string) (*model.ProcesslistData, [
 		}
 		if current.row.haveInfo && hasProcesslistQueryText(current.row.info) {
 			current.rowsWithQueryText++
+		}
+		if q, ok := model.NewObservedProcesslistQuery(
+			current.t,
+			current.row.user,
+			current.row.db,
+			current.row.command,
+			current.row.state,
+			current.row.info,
+			ageMS,
+			current.row.haveTimeMS || current.row.haveTime,
+			current.row.rowsExamined,
+			current.row.haveRowsExamined,
+			current.row.rowsSent,
+			current.row.haveRowsSent,
+		); ok {
+			observedQueries = append(observedQueries, q)
 		}
 
 		current.row = rowBuild{}
@@ -328,6 +345,7 @@ func parseProcesslist(r io.Reader, sourcePath string) (*model.ProcesslistData, [
 		Hosts:              hosts,
 		Commands:           commands,
 		Dbs:                dbs,
+		ObservedQueries:    model.MergeObservedProcesslistQueries(observedQueries),
 	}, diagnostics
 }
 

--- a/parse/processlist.go
+++ b/parse/processlist.go
@@ -81,7 +81,7 @@ func parseProcesslist(r io.Reader, sourcePath string) (*model.ProcesslistData, [
 	hostsSet := map[string]struct{}{}
 	commandsSet := map[string]struct{}{}
 	dbsSet := map[string]struct{}{}
-	var observedQueries []model.ObservedProcesslistQuery
+	observedQueriesByFingerprint := map[string]model.ObservedProcesslistQuery{}
 
 	// flushRow records a completed vertical-format row's dimensions
 	// into the current sample. Called on row-separator lines and on
@@ -185,7 +185,17 @@ func parseProcesslist(r io.Reader, sourcePath string) (*model.ProcesslistData, [
 			current.row.rowsSent,
 			current.row.haveRowsSent,
 		); ok {
-			observedQueries = append(observedQueries, q)
+			if current, exists := observedQueriesByFingerprint[q.Fingerprint]; exists {
+				merged := model.MergeObservedProcesslistQueries(
+					[]model.ObservedProcesslistQuery{current},
+					[]model.ObservedProcesslistQuery{q},
+				)
+				if len(merged) == 1 {
+					observedQueriesByFingerprint[q.Fingerprint] = merged[0]
+				}
+			} else {
+				observedQueriesByFingerprint[q.Fingerprint] = q
+			}
 		}
 
 		current.row = rowBuild{}
@@ -336,6 +346,11 @@ func parseProcesslist(r io.Reader, sourcePath string) (*model.ProcesslistData, [
 			RowsWithQueryText:     s.rowsWithQueryText,
 			HasQueryTextMetric:    s.hasQueryText,
 		}
+	}
+
+	observedQueries := make([]model.ObservedProcesslistQuery, 0, len(observedQueriesByFingerprint))
+	for _, q := range observedQueriesByFingerprint {
+		observedQueries = append(observedQueries, q)
 	}
 
 	return &model.ProcesslistData{

--- a/parse/processlist_test.go
+++ b/parse/processlist_test.go
@@ -1,11 +1,13 @@
 package parse
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 
+	"github.com/matias-sanchez/My-gather/model"
 	"github.com/matias-sanchez/My-gather/tests/goldens"
 )
 
@@ -316,6 +318,43 @@ Rows_examined: 0
 	}
 	if strings.Contains(grouped.Snippet, "456") {
 		t.Errorf("grouped.Snippet = %q, want bounded normalized snippet without literal-specific grouping", grouped.Snippet)
+	}
+}
+
+func TestProcesslistObservedQueriesRemainUnbounded(t *testing.T) {
+	var b strings.Builder
+	b.WriteString("TS 1769702259.006126802 2026-01-29 15:57:39\n")
+	for i := 0; i < model.MaxObservedProcesslistQueries+2; i++ {
+		tableName := string(rune('a' + i))
+		fmt.Fprintf(&b, `*************************** %d. row ***************************
+           Id: %d
+         User: app
+         Host: 10.0.0.%d:60000
+           db: shop
+      Command: Query
+         Time: %d
+        State: Sending data
+         Info: select * from table_%s where id = %d
+      Time_ms: %d
+    Rows_sent: 1
+Rows_examined: %d
+`, i+1, i+1, i+1, i+1, tableName, i+1, (i+1)*1000, i+10)
+	}
+
+	data, diags := parseProcesslist(strings.NewReader(b.String()), "synthetic-processlist")
+	if len(diags) != 0 {
+		t.Fatalf("unexpected diagnostics: %+v", diags)
+	}
+	if data == nil {
+		t.Fatal("parseProcesslist returned nil")
+	}
+	if got, want := len(data.ObservedQueries), model.MaxObservedProcesslistQueries+2; got != want {
+		t.Fatalf("ObservedQueries len = %d, want unbounded parser output len %d", got, want)
+	}
+	for i := 1; i < len(data.ObservedQueries); i++ {
+		if data.ObservedQueries[i-1].MaxTimeMS < data.ObservedQueries[i].MaxTimeMS {
+			t.Fatalf("ObservedQueries not sorted by age descending at %d: %v < %v", i, data.ObservedQueries[i-1].MaxTimeMS, data.ObservedQueries[i].MaxTimeMS)
+		}
 	}
 }
 

--- a/parse/processlist_test.go
+++ b/parse/processlist_test.go
@@ -218,6 +218,107 @@ TS 1769702443.006126802 2026-01-29 16:00:43
 	}
 }
 
+func TestProcesslistObservedSlowestQueries(t *testing.T) {
+	input := strings.NewReader(`TS 1769702442.006126802 2026-01-29 16:00:42
+*************************** 1. row ***************************
+           Id: 1
+         User: event_scheduler
+         Host: localhost
+           db: NULL
+      Command: Daemon
+         Time: 470748
+        State: Waiting on empty queue
+         Info: select should_not_rank
+      Time_ms: 470747750
+    Rows_sent: 0
+Rows_examined: 0
+*************************** 2. row ***************************
+           Id: 2
+         User: app
+         Host: 10.0.0.1:60000
+           db: shop
+      Command: Sleep
+         Time: 400
+        State:
+         Info: select sleeping_should_not_rank
+      Time_ms: 400000
+    Rows_sent: 0
+Rows_examined: 0
+*************************** 3. row ***************************
+           Id: 3
+         User: app
+         Host: 10.0.0.2:60001
+           db: shop
+      Command: Query
+         Time: 3
+        State: Sending data
+         Info: SELECT * FROM orders WHERE id = 123
+      Time_ms: 3500
+    Rows_sent: 7
+Rows_examined: 100
+TS 1769702443.006126802 2026-01-29 16:00:43
+*************************** 1. row ***************************
+           Id: 4
+         User: app
+         Host: 10.0.0.3:60002
+           db: shop
+      Command: Query
+         Time: 5
+        State: Sending data
+         Info: select *  from orders where id = 456
+    Rows_sent: 8
+Rows_examined: 250
+*************************** 2. row ***************************
+           Id: 5
+         User: app
+         Host: 10.0.0.4:60003
+           db: shop
+      Command: Query
+         Time: 2
+        State: Waiting for table metadata lock
+         Info: update customers set name = 'alice' where id = 42
+      Time_ms: 9000
+    Rows_sent: 0
+Rows_examined: 0
+`)
+
+	data, diags := parseProcesslist(input, "synthetic-processlist")
+	if len(diags) != 0 {
+		t.Fatalf("unexpected diagnostics: %+v", diags)
+	}
+	if data == nil {
+		t.Fatal("parseProcesslist returned nil")
+	}
+	if got, want := len(data.ObservedQueries), 2; got != want {
+		t.Fatalf("ObservedQueries len = %d, want %d: %#v", got, want, data.ObservedQueries)
+	}
+
+	top := data.ObservedQueries[0]
+	if !strings.Contains(top.Snippet, "update customers") {
+		t.Fatalf("top snippet = %q, want update query first", top.Snippet)
+	}
+	if got, want := top.MaxTimeMS, 9000.0; got != want {
+		t.Errorf("top.MaxTimeMS = %v, want %v", got, want)
+	}
+	if got, want := top.State, "Waiting for table metadata lock"; got != want {
+		t.Errorf("top.State = %q, want %q", got, want)
+	}
+
+	grouped := data.ObservedQueries[1]
+	if got, want := grouped.SeenSamples, 2; got != want {
+		t.Errorf("grouped.SeenSamples = %d, want %d", got, want)
+	}
+	if got, want := grouped.MaxTimeMS, 5000.0; got != want {
+		t.Errorf("grouped.MaxTimeMS = %v, want %v", got, want)
+	}
+	if got, want := grouped.MaxRowsExamined, 250.0; got != want {
+		t.Errorf("grouped.MaxRowsExamined = %v, want %v", got, want)
+	}
+	if strings.Contains(grouped.Snippet, "456") {
+		t.Errorf("grouped.Snippet = %q, want bounded normalized snippet without literal-specific grouping", grouped.Snippet)
+	}
+}
+
 func TestStripHostPort(t *testing.T) {
 	cases := []struct {
 		in, want string

--- a/render/assets/app.css
+++ b/render/assets/app.css
@@ -1268,17 +1268,70 @@ table.variables-table tr[data-changed="true"] td.status-label .label-changed {
 
 .slow-query-panel {
   margin-top: 16px;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  background: color-mix(in srgb, var(--bg-elev) 70%, transparent);
 }
-.slow-query-panel h4 {
-  margin: 0 0 10px 0;
+.slow-query-panel > summary {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 10px 12px;
+  cursor: pointer;
   font-size: 13px;
   font-weight: 700;
   color: var(--fg);
 }
+.slow-query-panel > summary::marker { color: var(--fg-muted); }
+.slow-query-panel > summary .badge {
+  flex: 0 0 auto;
+  font-size: 11px;
+}
+.slow-query-controls {
+  display: grid;
+  grid-template-columns: minmax(260px, 2fr) repeat(3, minmax(130px, 1fr)) auto;
+  gap: 10px;
+  align-items: end;
+  padding: 0 12px 12px;
+}
+.slow-query-controls label {
+  display: grid;
+  gap: 4px;
+  min-width: 0;
+}
+.slow-query-controls label span {
+  color: var(--fg-muted);
+  font-size: 10.5px;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+.slow-query-controls input {
+  width: 100%;
+  min-width: 0;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  background: var(--bg);
+  color: var(--fg);
+  padding: 7px 9px;
+  font: inherit;
+  font-size: 12px;
+}
+.slow-query-controls input:focus {
+  outline: 2px solid color-mix(in srgb, var(--accent) 60%, transparent);
+  outline-offset: 1px;
+}
+.slow-query-count {
+  color: var(--fg-muted);
+  font-size: 11px;
+  font-variant-numeric: tabular-nums;
+  white-space: nowrap;
+  padding-bottom: 8px;
+}
 .slow-query-table-wrap {
   overflow-x: auto;
-  border: 1px solid var(--border);
-  border-radius: 8px;
+  border-top: 1px solid var(--border);
   background: var(--bg);
 }
 .slow-query-table {
@@ -1314,6 +1367,18 @@ table.variables-table tr[data-changed="true"] td.status-label .label-changed {
 .slow-query-table .query-shape code {
   white-space: normal;
   overflow-wrap: anywhere;
+}
+.slow-query-filter-empty {
+  margin: 0 12px 12px;
+}
+@media (max-width: 980px) {
+  .slow-query-controls {
+    grid-template-columns: 1fr 1fr;
+  }
+  .slow-query-count {
+    grid-column: 1 / -1;
+    padding-bottom: 0;
+  }
 }
 
 /* ---------- Mysqladmin filter panel ---------- */

--- a/render/assets/app.css
+++ b/render/assets/app.css
@@ -1266,6 +1266,56 @@ table.variables-table tr[data-changed="true"] td.status-label .label-changed {
 }
 .chart-view-toolbar .view-btn:hover:not(.active) { color: var(--fg); }
 
+.slow-query-panel {
+  margin-top: 16px;
+}
+.slow-query-panel h4 {
+  margin: 0 0 10px 0;
+  font-size: 13px;
+  font-weight: 700;
+  color: var(--fg);
+}
+.slow-query-table-wrap {
+  overflow-x: auto;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  background: var(--bg);
+}
+.slow-query-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 12px;
+}
+.slow-query-table th,
+.slow-query-table td {
+  padding: 8px 10px;
+  border-bottom: 1px solid var(--border);
+  text-align: left;
+  vertical-align: top;
+  white-space: nowrap;
+}
+.slow-query-table th {
+  color: var(--fg-muted);
+  font-size: 11px;
+  font-weight: 700;
+  text-transform: uppercase;
+}
+.slow-query-table tr:last-child td {
+  border-bottom: 0;
+}
+.slow-query-table .rank {
+  color: var(--fg-muted);
+  font-weight: 700;
+}
+.slow-query-table .query-shape {
+  min-width: 360px;
+  white-space: normal;
+}
+.slow-query-table .query-shape code {
+  white-space: normal;
+  overflow-wrap: anywhere;
+}
+
 /* ---------- Mysqladmin filter panel ---------- */
 
 /* Floating counter-selection panel.

--- a/render/assets/app.js
+++ b/render/assets/app.js
@@ -9,8 +9,9 @@
  *   2. Variables-section client-side filter.                    (FR-013)
  *   3. Mysqladmin filter panel: search + category chips + scrollable
  *      checkbox list + chart.                                   (FR-015)
- *   4. uPlot chart rendering for iostat, top, vmstat, processlist.
- *   5. Nav-rail scroll-spy (pure polish).
+ *   4. Slow observed query table filters.
+ *   5. uPlot chart rendering for iostat, top, vmstat, processlist.
+ *   6. Nav-rail scroll-spy (pure polish).
  *
  * Determinism note: this script MUST NOT generate timestamps, random
  * values, or content-derived identifiers that would change the
@@ -166,6 +167,54 @@
   function cssEscape(s) {
     if (window.CSS && typeof window.CSS.escape === "function") return window.CSS.escape(s);
     return String(s).replace(/"/g, '\\"');
+  }
+
+  // --- 3. Slow observed query filters ----------------------------
+
+  function initSlowQueryFilters() {
+    var panel = document.querySelector(".slow-query-panel");
+    if (!panel) return;
+    var table = panel.querySelector(".slow-query-table");
+    if (!table || !table.tBodies || !table.tBodies.length) return;
+    var rows = table.tBodies[0].rows;
+    var inputs = panel.querySelectorAll("[data-filter-field]");
+    if (!inputs.length) return;
+    var countEl = panel.querySelector(".slow-query-count");
+    var emptyEl = panel.querySelector("[data-slow-query-empty]");
+    var filters = { query: "", user: "", db: "", state: "" };
+
+    function matches(row, field, needle) {
+      if (!needle) return true;
+      var attr = field === "query" ? "data-query-text" : "data-query-" + field;
+      var value = row.getAttribute(attr) || "";
+      return value.indexOf(needle) !== -1;
+    }
+
+    function update() {
+      var shown = 0;
+      for (var i = 0; i < rows.length; i++) {
+        var row = rows[i];
+        var hit =
+          matches(row, "query", filters.query) &&
+          matches(row, "user", filters.user) &&
+          matches(row, "db", filters.db) &&
+          matches(row, "state", filters.state);
+        row.hidden = !hit;
+        if (hit) shown++;
+      }
+      if (countEl) countEl.textContent = shown + " of " + rows.length + " shown";
+      if (emptyEl) emptyEl.hidden = shown !== 0;
+    }
+
+    inputs.forEach(function (input) {
+      input.addEventListener("input", function () {
+        var field = input.getAttribute("data-filter-field");
+        if (!Object.prototype.hasOwnProperty.call(filters, field)) return;
+        filters[field] = input.value.trim().toLowerCase();
+        update();
+      });
+    });
+    update();
   }
 
   // --- Chart registry + resize handling ---------------------------
@@ -4011,6 +4060,7 @@
   function boot() {
     initCollapsePersistence();
     initVariablesSearch();
+    initSlowQueryFilters();
     initCharts();
     initNavGroups();
     initNavCollapse();

--- a/render/concat.go
+++ b/render/concat.go
@@ -516,11 +516,14 @@ func concatProcesslist(ins []*model.ProcesslistData) *model.ProcesslistData {
 	}
 	boundaries := make([]int, 0, len(nonNil))
 	cumulative := 0
+	observedGroups := make([][]model.ObservedProcesslistQuery, 0, len(nonNil))
 	for _, d := range nonNil {
 		boundaries = append(boundaries, cumulative)
 		out.ThreadStateSamples = append(out.ThreadStateSamples, d.ThreadStateSamples...)
+		observedGroups = append(observedGroups, d.ObservedQueries)
 		cumulative += len(d.ThreadStateSamples)
 	}
+	out.ObservedQueries = model.MergeObservedProcesslistQueries(observedGroups...)
 	out.SnapshotBoundaries = boundaries
 	return out
 }

--- a/render/concat_test.go
+++ b/render/concat_test.go
@@ -2,6 +2,7 @@ package render
 
 import (
 	"math"
+	"strings"
 	"testing"
 	"time"
 
@@ -367,6 +368,64 @@ func TestConcatProcesslistUnionsDimensions(t *testing.T) {
 	wantDbs := []string{"app_db", "mysql"}
 	if !eqStrs(merged.Dbs, wantDbs) {
 		t.Errorf("Dbs = %v, want %v", merged.Dbs, wantDbs)
+	}
+}
+
+func TestConcatProcesslistMergesObservedQueries(t *testing.T) {
+	t.Parallel()
+	t0 := time.Date(2026, 1, 29, 16, 0, 0, 0, time.UTC)
+	q1, ok := model.NewObservedProcesslistQuery(t0, "app", "shop", "Query", "Sending data",
+		"select * from orders where id = 123", 1000, true, 10, true, 1, true)
+	if !ok {
+		t.Fatal("q1 unexpectedly ineligible")
+	}
+	q2, ok := model.NewObservedProcesslistQuery(t0.Add(time.Minute), "app", "shop", "Query", "Sending data",
+		"select * from orders where id = 456", 3000, true, 55, true, 2, true)
+	if !ok {
+		t.Fatal("q2 unexpectedly ineligible")
+	}
+	q3, ok := model.NewObservedProcesslistQuery(t0.Add(2*time.Minute), "app", "shop", "Query", "Waiting for table metadata lock",
+		"update customers set name = 'alice' where id = 9", 5000, true, 0, true, 0, true)
+	if !ok {
+		t.Fatal("q3 unexpectedly ineligible")
+	}
+
+	snapA := &model.ProcesslistData{
+		States: []string{"Sending data"},
+		ThreadStateSamples: []model.ThreadStateSample{{
+			Timestamp:   t0,
+			StateCounts: map[string]int{"Sending data": 1},
+		}},
+		ObservedQueries: []model.ObservedProcesslistQuery{q1},
+	}
+	snapB := &model.ProcesslistData{
+		States: []string{"Sending data", "Waiting for table metadata lock"},
+		ThreadStateSamples: []model.ThreadStateSample{{
+			Timestamp:   t0.Add(time.Minute),
+			StateCounts: map[string]int{"Sending data": 1},
+		}},
+		ObservedQueries: []model.ObservedProcesslistQuery{q2, q3},
+	}
+
+	merged := concatProcesslist([]*model.ProcesslistData{snapA, snapB})
+	if merged == nil {
+		t.Fatal("concatProcesslist returned nil")
+	}
+	if got, want := len(merged.ObservedQueries), 2; got != want {
+		t.Fatalf("ObservedQueries len = %d, want %d: %#v", got, want, merged.ObservedQueries)
+	}
+	if !strings.Contains(merged.ObservedQueries[0].Snippet, "update customers") {
+		t.Fatalf("top observed query = %q, want update query first", merged.ObservedQueries[0].Snippet)
+	}
+	grouped := merged.ObservedQueries[1]
+	if got, want := grouped.SeenSamples, 2; got != want {
+		t.Errorf("grouped.SeenSamples = %d, want %d", got, want)
+	}
+	if got, want := grouped.MaxTimeMS, 3000.0; got != want {
+		t.Errorf("grouped.MaxTimeMS = %v, want %v", got, want)
+	}
+	if got, want := grouped.MaxRowsExamined, 55.0; got != want {
+		t.Errorf("grouped.MaxRowsExamined = %v, want %v", got, want)
 	}
 }
 

--- a/render/concat_test.go
+++ b/render/concat_test.go
@@ -429,6 +429,80 @@ func TestConcatProcesslistMergesObservedQueries(t *testing.T) {
 	}
 }
 
+func TestConcatProcesslistDefersObservedQueryTopNUntilAfterMerge(t *testing.T) {
+	t.Parallel()
+	t0 := time.Date(2026, 1, 29, 16, 0, 0, 0, time.UTC)
+
+	mustQuery := func(ts time.Time, info string, ageMS float64) model.ObservedProcesslistQuery {
+		t.Helper()
+		q, ok := model.NewObservedProcesslistQuery(ts, "app", "shop", "Query", "Sending data",
+			info, ageMS, true, ageMS/100, true, 1, true)
+		if !ok {
+			t.Fatalf("query %q unexpectedly ineligible", info)
+		}
+		return q
+	}
+
+	persistentA := mustQuery(t0, "select * from persistent_orders where id = 123", 1000)
+	snapAQueries := []model.ObservedProcesslistQuery{persistentA}
+	for i := 0; i < model.MaxObservedProcesslistQueries+1; i++ {
+		tableName := string(rune('a' + i))
+		snapAQueries = append(snapAQueries, mustQuery(t0,
+			"select * from blocker_"+tableName+" where id = 123",
+			float64(i+2)*1000,
+		))
+	}
+	persistentB := mustQuery(t0.Add(time.Minute), "select * from persistent_orders where id = 456", 50000)
+
+	snapA := &model.ProcesslistData{
+		States: []string{"Sending data"},
+		ThreadStateSamples: []model.ThreadStateSample{{
+			Timestamp:   t0,
+			StateCounts: map[string]int{"Sending data": len(snapAQueries)},
+		}},
+		ObservedQueries: model.MergeAllObservedProcesslistQueries(snapAQueries),
+	}
+	snapB := &model.ProcesslistData{
+		States: []string{"Sending data"},
+		ThreadStateSamples: []model.ThreadStateSample{{
+			Timestamp:   t0.Add(time.Minute),
+			StateCounts: map[string]int{"Sending data": 1},
+		}},
+		ObservedQueries: []model.ObservedProcesslistQuery{persistentB},
+	}
+
+	merged := concatProcesslist([]*model.ProcesslistData{snapA, snapB})
+	if merged == nil {
+		t.Fatal("concatProcesslist returned nil")
+	}
+	if got, want := len(merged.ObservedQueries), model.MaxObservedProcesslistQueries; got != want {
+		t.Fatalf("ObservedQueries len = %d, want final bounded len %d", got, want)
+	}
+
+	var grouped *model.ObservedProcesslistQuery
+	for i := range merged.ObservedQueries {
+		if merged.ObservedQueries[i].Fingerprint == persistentA.Fingerprint {
+			grouped = &merged.ObservedQueries[i]
+			break
+		}
+	}
+	if grouped == nil {
+		t.Fatalf("persistent query fingerprint %s missing from final top queries: %#v", persistentA.Fingerprint, merged.ObservedQueries)
+	}
+	if got, want := grouped.SeenSamples, 2; got != want {
+		t.Errorf("SeenSamples = %d, want %d", got, want)
+	}
+	if !grouped.FirstSeen.Equal(t0) {
+		t.Errorf("FirstSeen = %s, want %s", grouped.FirstSeen, t0)
+	}
+	if !grouped.LastSeen.Equal(t0.Add(time.Minute)) {
+		t.Errorf("LastSeen = %s, want %s", grouped.LastSeen, t0.Add(time.Minute))
+	}
+	if got, want := grouped.MaxTimeMS, 50000.0; got != want {
+		t.Errorf("MaxTimeMS = %v, want %v", got, want)
+	}
+}
+
 // TestConcatNetstatSPreservesSubSecondTimestamps — regression guard
 // for the rate-math collapse Codex flagged on bf7e8fc. pt-stalk polls
 // can land within the same whole second; if concatNetstatS truncates

--- a/render/db_test.go
+++ b/render/db_test.go
@@ -1,12 +1,15 @@
 package render_test
 
 import (
+	"bytes"
 	"encoding/json"
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/matias-sanchez/My-gather/model"
+	"github.com/matias-sanchez/My-gather/render"
 	"github.com/matias-sanchez/My-gather/tests/goldens"
 )
 
@@ -183,5 +186,91 @@ func TestProcesslistRicherMetricMarkup(t *testing.T) {
 		if !strings.Contains(section, want) {
 			t.Errorf("sec-db processlist markup missing %q", want)
 		}
+	}
+}
+
+func TestProcesslistSlowestObservedQueriesMarkup(t *testing.T) {
+	ts := time.Date(2026, 1, 29, 16, 5, 19, 0, time.UTC)
+	q, ok := model.NewObservedProcesslistQuery(ts, "horizon", "horizon", "Query", "Waiting for table metadata lock",
+		"select count(contract0_.pk) from contract contract0_ where contract0_.pk = 123",
+		3723000, true, 6114, true, 17, true)
+	if !ok {
+		t.Fatal("query unexpectedly ineligible")
+	}
+	c := &model.Collection{
+		RootPath: "/tmp/example",
+		Hostname: "example-db-01",
+		Snapshots: []*model.Snapshot{{
+			Timestamp: ts,
+			Prefix:    "2026_01_29_16_05_19",
+			SourceFiles: map[model.Suffix]*model.SourceFile{
+				model.SuffixProcesslist: {
+					Suffix: model.SuffixProcesslist,
+					Parsed: &model.ProcesslistData{
+						States: []string{"Waiting for table metadata lock"},
+						ThreadStateSamples: []model.ThreadStateSample{{
+							Timestamp:     ts,
+							StateCounts:   map[string]int{"Waiting for table metadata lock": 1},
+							TotalThreads:  1,
+							ActiveThreads: 1,
+						}},
+						ObservedQueries: []model.ObservedProcesslistQuery{q},
+					},
+				},
+			},
+		}},
+	}
+
+	var buf bytes.Buffer
+	if err := render.Render(&buf, c, render.RenderOptions{GeneratedAt: fixedTime(), Version: "v0.0.1-test"}); err != nil {
+		t.Fatalf("Render: %v", err)
+	}
+	section := extractDetailsSection(t, buf.String(), "sec-db")
+	for _, want := range []string{
+		"Slowest observed queries",
+		"Waiting for table metadata lock",
+		"select count(contract0_.pk)",
+		q.Fingerprint,
+		"3723.0 s",
+		"6114",
+	} {
+		if !strings.Contains(section, want) {
+			t.Errorf("sec-db slowest-query markup missing %q", want)
+		}
+	}
+}
+
+func TestProcesslistSlowestObservedQueriesEmptyState(t *testing.T) {
+	ts := time.Date(2026, 1, 29, 16, 5, 19, 0, time.UTC)
+	c := &model.Collection{
+		RootPath: "/tmp/example",
+		Hostname: "example-db-01",
+		Snapshots: []*model.Snapshot{{
+			Timestamp: ts,
+			Prefix:    "2026_01_29_16_05_19",
+			SourceFiles: map[model.Suffix]*model.SourceFile{
+				model.SuffixProcesslist: {
+					Suffix: model.SuffixProcesslist,
+					Parsed: &model.ProcesslistData{
+						States: []string{"Sleep"},
+						ThreadStateSamples: []model.ThreadStateSample{{
+							Timestamp:       ts,
+							StateCounts:     map[string]int{"Sleep": 4},
+							TotalThreads:    4,
+							SleepingThreads: 4,
+						}},
+					},
+				},
+			},
+		}},
+	}
+
+	var buf bytes.Buffer
+	if err := render.Render(&buf, c, render.RenderOptions{GeneratedAt: fixedTime(), Version: "v0.0.1-test"}); err != nil {
+		t.Fatalf("Render: %v", err)
+	}
+	section := extractDetailsSection(t, buf.String(), "sec-db")
+	if !strings.Contains(section, "No active query text was observed in processlist rows.") {
+		t.Errorf("sec-db missing slowest-query empty state")
 	}
 }

--- a/render/db_test.go
+++ b/render/db_test.go
@@ -286,3 +286,47 @@ func TestProcesslistSlowestObservedQueriesEmptyState(t *testing.T) {
 		t.Errorf("sec-db missing slowest-query empty state")
 	}
 }
+
+func TestProcesslistSlowestObservedQueriesMissingAge(t *testing.T) {
+	ts := time.Date(2026, 1, 29, 16, 5, 19, 0, time.UTC)
+	q, ok := model.NewObservedProcesslistQuery(ts, "app", "shop", "Query", "Sending data",
+		"select * from orders", 0, false, 0, false, 0, false)
+	if !ok {
+		t.Fatal("query unexpectedly ineligible")
+	}
+	c := &model.Collection{
+		RootPath: "/tmp/example",
+		Hostname: "example-db-01",
+		Snapshots: []*model.Snapshot{{
+			Timestamp: ts,
+			Prefix:    "2026_01_29_16_05_19",
+			SourceFiles: map[model.Suffix]*model.SourceFile{
+				model.SuffixProcesslist: {
+					Suffix: model.SuffixProcesslist,
+					Parsed: &model.ProcesslistData{
+						States: []string{"Sending data"},
+						ThreadStateSamples: []model.ThreadStateSample{{
+							Timestamp:     ts,
+							StateCounts:   map[string]int{"Sending data": 1},
+							TotalThreads:  1,
+							ActiveThreads: 1,
+						}},
+						ObservedQueries: []model.ObservedProcesslistQuery{q},
+					},
+				},
+			},
+		}},
+	}
+
+	var buf bytes.Buffer
+	if err := render.Render(&buf, c, render.RenderOptions{GeneratedAt: fixedTime(), Version: "v0.0.1-test"}); err != nil {
+		t.Fatalf("Render: %v", err)
+	}
+	section := extractDetailsSection(t, buf.String(), "sec-db")
+	if strings.Contains(section, "0.0 s") {
+		t.Fatalf("missing query age rendered as 0.0 s")
+	}
+	if !strings.Contains(section, `<td class="mono">-</td>`) {
+		t.Fatalf("missing query age did not render as dash")
+	}
+}

--- a/render/db_test.go
+++ b/render/db_test.go
@@ -227,7 +227,19 @@ func TestProcesslistSlowestObservedQueriesMarkup(t *testing.T) {
 	}
 	section := extractDetailsSection(t, buf.String(), "sec-db")
 	for _, want := range []string{
-		"Slowest observed queries",
+		"<summary><span>Slowest observed queries</span><span class=\"badge\">1 query</span></summary>",
+		`class="slow-query-search"`,
+		`placeholder="Search query or fingerprint"`,
+		`class="slow-query-filter"`,
+		`data-filter-field="user"`,
+		`data-filter-field="db"`,
+		`data-filter-field="state"`,
+		`class="slow-query-count"`,
+		`data-slow-query-empty`,
+		`data-query-user="horizon"`,
+		`data-query-db="horizon"`,
+		`data-query-state="waiting for table metadata lock"`,
+		`data-query-text="select count(contract0_.pk) from contract contract0_ where contract0_.pk = ? ` + q.Fingerprint + `"`,
 		"Waiting for table metadata lock",
 		"select count(contract0_.pk)",
 		q.Fingerprint,

--- a/render/payloads.go
+++ b/render/payloads.go
@@ -265,9 +265,10 @@ func processlistChartPayload(d *model.ProcesslistData) map[string]any {
 	// Primary `series` stays pointed at the State dimension so the
 	// existing renderTimeSeries fallback path remains functional.
 	return map[string]any{
-		"timestamps": timestamps,
-		"series":     dimensions[0]["series"],
-		"dimensions": dimensions,
+		"timestamps":  timestamps,
+		"series":      dimensions[0]["series"],
+		"dimensions":  dimensions,
+		"slowQueries": processlistSlowQueryPayload(d.ObservedQueries),
 		"metrics": map[string]any{
 			"maxTimeSeconds": processlistMetricValues(d, func(s model.ThreadStateSample) float64 {
 				return s.MaxTimeMS / 1000
@@ -296,6 +297,30 @@ func processlistChartPayload(d *model.ProcesslistData) map[string]any {
 		},
 		"snapshotBoundaries": d.SnapshotBoundaries,
 	}
+}
+
+func processlistSlowQueryPayload(queries []model.ObservedProcesslistQuery) []map[string]any {
+	out := make([]map[string]any, 0, len(queries))
+	for _, q := range queries {
+		out = append(out, map[string]any{
+			"fingerprint":     q.Fingerprint,
+			"snippet":         q.Snippet,
+			"firstSeen":       q.FirstSeen.Unix(),
+			"lastSeen":        q.LastSeen.Unix(),
+			"seenSamples":     q.SeenSamples,
+			"maxTimeSeconds":  q.MaxTimeMS / 1000,
+			"hasTimeMetric":   q.HasTimeMetric,
+			"maxRowsExamined": q.MaxRowsExamined,
+			"hasRowsExamined": q.HasRowsExaminedMetric,
+			"maxRowsSent":     q.MaxRowsSent,
+			"hasRowsSent":     q.HasRowsSentMetric,
+			"user":            q.User,
+			"db":              q.DB,
+			"command":         q.Command,
+			"state":           q.State,
+		})
+	}
+	return out
 }
 
 func processlistMetricValues(d *model.ProcesslistData, pick func(model.ThreadStateSample) float64) []float64 {

--- a/render/render_test.go
+++ b/render/render_test.go
@@ -281,6 +281,11 @@ func twoSnapshotCollection() *model.Collection {
 	}
 
 	processlist := func(tsOffset int) *model.ProcesslistData {
+		q, ok := model.NewObservedProcesslistQuery(ts(tsOffset+1), "app", "shop", "Query", "Sending data",
+			"select * from orders where id = 123", 2500, true, 350, true, 25, true)
+		if !ok {
+			panic("test processlist query unexpectedly ineligible")
+		}
 		return &model.ProcesslistData{
 			States: []string{"Sending data", "Sleep"},
 			ThreadStateSamples: []model.ThreadStateSample{
@@ -315,6 +320,7 @@ func twoSnapshotCollection() *model.Collection {
 					HasQueryTextMetric:    true,
 				},
 			},
+			ObservedQueries:    []model.ObservedProcesslistQuery{q},
 			SnapshotBoundaries: []int{0},
 		}
 	}
@@ -365,6 +371,21 @@ func TestProcesslistPayloadIncludesRicherMetrics(t *testing.T) {
 	var parsed struct {
 		Charts struct {
 			Processlist struct {
+				SlowQueries []struct {
+					Fingerprint     string  `json:"fingerprint"`
+					Snippet         string  `json:"snippet"`
+					SeenSamples     int     `json:"seenSamples"`
+					MaxTimeSeconds  float64 `json:"maxTimeSeconds"`
+					HasTimeMetric   bool    `json:"hasTimeMetric"`
+					MaxRowsExamined float64 `json:"maxRowsExamined"`
+					HasRowsExamined bool    `json:"hasRowsExamined"`
+					MaxRowsSent     float64 `json:"maxRowsSent"`
+					HasRowsSent     bool    `json:"hasRowsSent"`
+					User            string  `json:"user"`
+					DB              string  `json:"db"`
+					Command         string  `json:"command"`
+					State           string  `json:"state"`
+				} `json:"slowQueries"`
 				Dimensions []struct {
 					Key    string `json:"key"`
 					Label  string `json:"label"`
@@ -426,6 +447,22 @@ func TestProcesslistPayloadIncludesRicherMetrics(t *testing.T) {
 	}
 	if got, want := parsed.Charts.Processlist.Metrics.HasQueryText[1], true; got != want {
 		t.Errorf("HasQueryText[1] = %v, want %v", got, want)
+	}
+	if got, want := len(parsed.Charts.Processlist.SlowQueries), 1; got != want {
+		t.Fatalf("SlowQueries len = %d, want %d", got, want)
+	}
+	slow := parsed.Charts.Processlist.SlowQueries[0]
+	if slow.Fingerprint == "" {
+		t.Error("SlowQueries[0].Fingerprint is empty")
+	}
+	if !strings.Contains(slow.Snippet, "select * from orders") {
+		t.Errorf("SlowQueries[0].Snippet = %q, want orders query", slow.Snippet)
+	}
+	if got, want := slow.MaxTimeSeconds, 2.5; got != want {
+		t.Errorf("SlowQueries[0].MaxTimeSeconds = %v, want %v", got, want)
+	}
+	if got, want := slow.MaxRowsExamined, 350.0; got != want {
+		t.Errorf("SlowQueries[0].MaxRowsExamined = %v, want %v", got, want)
 	}
 }
 

--- a/render/summaries.go
+++ b/render/summaries.go
@@ -304,5 +304,36 @@ func summariseProcesslist(d *model.ProcesslistData) *processlistSummaryView {
 	if sum.HasPeakQueryTextRows {
 		sum.PeakQueryTextRows = fmt.Sprintf("%d", peakQueryTextRows)
 	}
+	sum.SlowQueries = processlistSlowQueryViews(d.ObservedQueries)
+	sum.HasSlowQueries = len(sum.SlowQueries) > 0
 	return sum
+}
+
+func processlistSlowQueryViews(queries []model.ObservedProcesslistQuery) []processlistSlowQueryView {
+	out := make([]processlistSlowQueryView, 0, len(queries))
+	for i, q := range queries {
+		v := processlistSlowQueryView{
+			Rank:        i + 1,
+			Fingerprint: q.Fingerprint,
+			Snippet:     q.Snippet,
+			FirstSeen:   formatTimestamp(q.FirstSeen),
+			LastSeen:    formatTimestamp(q.LastSeen),
+			SeenSamples: q.SeenSamples,
+			MaxAge:      formatFloat(q.MaxTimeMS/1000, 1) + " s",
+			User:        q.User,
+			DB:          q.DB,
+			Command:     q.Command,
+			State:       q.State,
+		}
+		if q.HasRowsExaminedMetric {
+			v.HasRowsExamined = true
+			v.RowsExamined = formatFloat(q.MaxRowsExamined, 0)
+		}
+		if q.HasRowsSentMetric {
+			v.HasRowsSent = true
+			v.RowsSent = formatFloat(q.MaxRowsSent, 0)
+		}
+		out = append(out, v)
+	}
+	return out
 }

--- a/render/summaries.go
+++ b/render/summaries.go
@@ -3,6 +3,7 @@ package render
 import (
 	"fmt"
 	"math"
+	"strings"
 	"time"
 
 	"github.com/matias-sanchez/My-gather/model"
@@ -316,6 +317,10 @@ func processlistSlowQueryViews(queries []model.ObservedProcesslistQuery) []proce
 			Rank:        i + 1,
 			Fingerprint: q.Fingerprint,
 			Snippet:     q.Snippet,
+			FilterText:  strings.ToLower(q.Snippet + " " + q.Fingerprint),
+			FilterUser:  strings.ToLower(q.User),
+			FilterDB:    strings.ToLower(q.DB),
+			FilterState: strings.ToLower(q.State),
 			FirstSeen:   formatTimestamp(q.FirstSeen),
 			LastSeen:    formatTimestamp(q.LastSeen),
 			SeenSamples: q.SeenSamples,

--- a/render/summaries.go
+++ b/render/summaries.go
@@ -324,11 +324,14 @@ func processlistSlowQueryViews(queries []model.ObservedProcesslistQuery) []proce
 			FirstSeen:   formatTimestamp(q.FirstSeen),
 			LastSeen:    formatTimestamp(q.LastSeen),
 			SeenSamples: q.SeenSamples,
-			MaxAge:      formatFloat(q.MaxTimeMS/1000, 1) + " s",
+			MaxAge:      "-",
 			User:        q.User,
 			DB:          q.DB,
 			Command:     q.Command,
 			State:       q.State,
+		}
+		if q.HasTimeMetric {
+			v.MaxAge = formatFloat(q.MaxTimeMS/1000, 1) + " s"
 		}
 		if q.HasRowsExaminedMetric {
 			v.HasRowsExamined = true

--- a/render/templates/db.html.tmpl
+++ b/render/templates/db.html.tmpl
@@ -216,6 +216,51 @@
     <div class="chart" id="chart-processlist" data-chart="processlist"
          aria-label="Count of threads per state over time"></div>
     <noscript><p class="banner">Charts require JavaScript. Raw processlist data is embedded in the page.</p></noscript>
+    <section class="slow-query-panel" aria-label="Slowest observed processlist queries">
+      <h4>Slowest observed queries</h4>
+      {{- if .ProcesslistSummary.HasSlowQueries }}
+      <div class="slow-query-table-wrap">
+        <table class="slow-query-table">
+          <thead>
+            <tr>
+              <th scope="col">Rank</th>
+              <th scope="col">Max age</th>
+              <th scope="col">Seen</th>
+              <th scope="col">First seen</th>
+              <th scope="col">Last seen</th>
+              <th scope="col">User</th>
+              <th scope="col">DB</th>
+              <th scope="col">State</th>
+              <th scope="col">Rows examined</th>
+              <th scope="col">Rows sent</th>
+              <th scope="col">Fingerprint</th>
+              <th scope="col">Query shape</th>
+            </tr>
+          </thead>
+          <tbody>
+            {{- range .ProcesslistSummary.SlowQueries }}
+            <tr>
+              <td class="rank">{{.Rank}}</td>
+              <td class="mono">{{.MaxAge}}</td>
+              <td class="mono">{{.SeenSamples}}</td>
+              <td class="mono">{{.FirstSeen}}</td>
+              <td class="mono">{{.LastSeen}}</td>
+              <td>{{.User}}</td>
+              <td>{{.DB}}</td>
+              <td>{{.State}}</td>
+              <td class="mono">{{if .HasRowsExamined}}{{.RowsExamined}}{{else}}-{{end}}</td>
+              <td class="mono">{{if .HasRowsSent}}{{.RowsSent}}{{else}}-{{end}}</td>
+              <td class="mono">{{.Fingerprint}}</td>
+              <td class="query-shape"><code>{{.Snippet}}</code></td>
+            </tr>
+            {{- end }}
+          </tbody>
+        </table>
+      </div>
+      {{- else }}
+      <p class="banner missing">No active query text was observed in processlist rows.</p>
+      {{- end }}
+    </section>
     {{- else }}
     <p class="banner missing">Data not available — no <code>-processlist</code> files were present in this collection.</p>
     {{- end }}

--- a/render/templates/db.html.tmpl
+++ b/render/templates/db.html.tmpl
@@ -216,9 +216,29 @@
     <div class="chart" id="chart-processlist" data-chart="processlist"
          aria-label="Count of threads per state over time"></div>
     <noscript><p class="banner">Charts require JavaScript. Raw processlist data is embedded in the page.</p></noscript>
-    <section class="slow-query-panel" aria-label="Slowest observed processlist queries">
-      <h4>Slowest observed queries</h4>
+    <details class="slow-query-panel" aria-label="Slowest observed processlist queries"{{if .ProcesslistSummary.HasSlowQueries}} open{{end}}>
+      <summary><span>Slowest observed queries</span><span class="badge">{{len .ProcesslistSummary.SlowQueries}} {{if eq (len .ProcesslistSummary.SlowQueries) 1}}query{{else}}queries{{end}}</span></summary>
       {{- if .ProcesslistSummary.HasSlowQueries }}
+      <div class="slow-query-controls" role="search" aria-label="Slowest observed query filters">
+        <label>
+          <span>Query</span>
+          <input type="search" class="slow-query-search" data-filter-field="query" placeholder="Search query or fingerprint" autocomplete="off">
+        </label>
+        <label>
+          <span>User</span>
+          <input type="search" class="slow-query-filter" data-filter-field="user" placeholder="Filter user" autocomplete="off">
+        </label>
+        <label>
+          <span>DB</span>
+          <input type="search" class="slow-query-filter" data-filter-field="db" placeholder="Filter db" autocomplete="off">
+        </label>
+        <label>
+          <span>State</span>
+          <input type="search" class="slow-query-filter" data-filter-field="state" placeholder="Filter state" autocomplete="off">
+        </label>
+        <span class="slow-query-count" aria-live="polite">{{len .ProcesslistSummary.SlowQueries}} of {{len .ProcesslistSummary.SlowQueries}} shown</span>
+      </div>
+      <p class="banner missing slow-query-filter-empty" data-slow-query-empty hidden>No slowest observed queries match the active filters.</p>
       <div class="slow-query-table-wrap">
         <table class="slow-query-table">
           <thead>
@@ -239,7 +259,7 @@
           </thead>
           <tbody>
             {{- range .ProcesslistSummary.SlowQueries }}
-            <tr>
+            <tr data-query-text="{{.FilterText}}" data-query-user="{{.FilterUser}}" data-query-db="{{.FilterDB}}" data-query-state="{{.FilterState}}">
               <td class="rank">{{.Rank}}</td>
               <td class="mono">{{.MaxAge}}</td>
               <td class="mono">{{.SeenSamples}}</td>
@@ -260,7 +280,7 @@
       {{- else }}
       <p class="banner missing">No active query text was observed in processlist rows.</p>
       {{- end }}
-    </section>
+    </details>
     {{- else }}
     <p class="banner missing">Data not available — no <code>-processlist</code> files were present in this collection.</p>
     {{- end }}

--- a/render/view.go
+++ b/render/view.go
@@ -326,6 +326,10 @@ type processlistSlowQueryView struct {
 	Rank            int
 	Fingerprint     string
 	Snippet         string
+	FilterText      string
+	FilterUser      string
+	FilterDB        string
+	FilterState     string
 	FirstSeen       string
 	LastSeen        string
 	SeenSamples     int

--- a/render/view.go
+++ b/render/view.go
@@ -318,4 +318,24 @@ type processlistSummaryView struct {
 	PeakQueryTextRows    string
 	HasPeakQueryTextRows bool
 	SampleCount          int
+	SlowQueries          []processlistSlowQueryView
+	HasSlowQueries       bool
+}
+
+type processlistSlowQueryView struct {
+	Rank            int
+	Fingerprint     string
+	Snippet         string
+	FirstSeen       string
+	LastSeen        string
+	SeenSamples     int
+	MaxAge          string
+	RowsExamined    string
+	HasRowsExamined bool
+	RowsSent        string
+	HasRowsSent     bool
+	User            string
+	DB              string
+	Command         string
+	State           string
 }

--- a/specs/006-observed-slowest-queries/checklists/requirements.md
+++ b/specs/006-observed-slowest-queries/checklists/requirements.md
@@ -1,0 +1,36 @@
+# Specification Quality Checklist: Observed Slowest Processlist Queries
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning  
+**Created**: 2026-04-28  
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- Slowest query detection is intentionally scoped to observed in-flight
+  processlist rows. Completed slow-query-log or digest parsing remains outside
+  this feature.

--- a/specs/006-observed-slowest-queries/contracts/packages.md
+++ b/specs/006-observed-slowest-queries/contracts/packages.md
@@ -15,7 +15,8 @@ Additional contract:
 - Ignore empty or `NULL` `Info` values for slowest-query ranking.
 - Use valid `Time_ms`, falling back to valid `Time`, for observed age.
 - Preserve valid row data when optional numeric fields are malformed.
-- Emit deterministic grouped query summaries in `ProcesslistData`.
+- Emit deterministic grouped query summaries in `ProcesslistData` without
+  per-file top-N truncation.
 
 ## `concatProcesslist`
 

--- a/specs/006-observed-slowest-queries/contracts/packages.md
+++ b/specs/006-observed-slowest-queries/contracts/packages.md
@@ -43,3 +43,17 @@ Additional contract:
 - Add a bounded `slowQueries` array.
 - Use seconds for rendered age values in the payload.
 - Use Unix timestamps for first/last seen values.
+
+## `findings.Analyze`
+
+Input: a `*model.Report` whose `DBSection.Processlist` may contain observed
+query summaries.
+
+Additional contract:
+
+- Register one Query Shape rule for impactful observed processlist queries.
+- Skip when no observed query has a valid age at or above 60 seconds.
+- Return Warning for generic long-running observed active queries.
+- Return Critical for metadata-lock wait states.
+- Include fingerprint, max age, sightings, user, database, state, and query
+  shape evidence in the returned `Finding`.

--- a/specs/006-observed-slowest-queries/contracts/packages.md
+++ b/specs/006-observed-slowest-queries/contracts/packages.md
@@ -1,0 +1,45 @@
+# Phase 1 Package Contracts: Observed Slowest Processlist Queries
+
+## `parseProcesslist`
+
+Input: an `io.Reader` containing pt-stalk `-processlist` output in vertical
+format.
+
+Output: `*model.ProcesslistData` plus structured diagnostics.
+
+Additional contract:
+
+- Continue parsing existing thread-state dimensions.
+- Track eligible active query sightings while reading rows.
+- Exclude `Sleep`, `Daemon`, and empty commands from slowest-query ranking.
+- Ignore empty or `NULL` `Info` values for slowest-query ranking.
+- Use valid `Time_ms`, falling back to valid `Time`, for observed age.
+- Preserve valid row data when optional numeric fields are malformed.
+- Emit deterministic grouped query summaries in `ProcesslistData`.
+
+## `concatProcesslist`
+
+Input: zero or more per-snapshot `*model.ProcesslistData` values.
+
+Output: one merged `*model.ProcesslistData`.
+
+Additional contract:
+
+- Preserve existing sample concatenation and snapshot-boundary behavior.
+- Merge observed query summaries from all inputs by fingerprint.
+- Recompute first seen, last seen, sighting count, max age, and peak row
+  counters across inputs.
+- Sort and bound summaries deterministically after merging.
+
+## `processlistChartPayload`
+
+Input: merged `*model.ProcesslistData`.
+
+Output: JSON-compatible map embedded in the report.
+
+Additional contract:
+
+- Continue emitting existing processlist chart fields.
+- Add a bounded `slowQueries` array.
+- Use seconds for rendered age values in the payload.
+- Use Unix timestamps for first/last seen values.

--- a/specs/006-observed-slowest-queries/contracts/ui.md
+++ b/specs/006-observed-slowest-queries/contracts/ui.md
@@ -1,0 +1,48 @@
+# Phase 1 UI Contract: Observed Slowest Processlist Queries
+
+## Scope
+
+This contract extends the existing Database Usage Processlist subview. It does
+not add a new top-level report section.
+
+## Processlist subview additions
+
+When processlist data contains eligible active query sightings, the subview
+must render a compact "Slowest observed queries" table below the thread-state
+chart.
+
+The table must include:
+
+- maximum observed age
+- first seen timestamp
+- last seen timestamp
+- sighting count
+- user
+- database
+- state
+- peak rows examined when available
+- peak rows sent when available
+- stable fingerprint
+- bounded query snippet
+
+## Empty state
+
+When processlist data exists but there are no eligible active rows with query
+text, the subview must render a short empty-state message instead of an empty
+table.
+
+## Privacy and size constraints
+
+- The table must be bounded to a small top-N list.
+- Query snippets must be length-bounded.
+- The report must not render every raw processlist row.
+- The report must remain self-contained and work offline.
+
+## Sorting
+
+Rows must appear in deterministic rank order:
+
+1. maximum observed age descending
+2. peak rows examined descending
+3. peak rows sent descending
+4. fingerprint ascending

--- a/specs/006-observed-slowest-queries/contracts/ui.md
+++ b/specs/006-observed-slowest-queries/contracts/ui.md
@@ -8,8 +8,15 @@ not add a new top-level report section.
 ## Processlist subview additions
 
 When processlist data contains eligible active query sightings, the subview
-must render a compact "Slowest observed queries" table below the thread-state
-chart.
+must render a compact, independently collapsible "Slowest observed queries"
+panel below the thread-state chart.
+
+The panel must:
+
+- use native `<details>`/`<summary>` semantics
+- default open when query rows exist
+- show the total number of observed query summaries in the summary
+- remain readable when JavaScript is disabled
 
 The table must include:
 
@@ -25,11 +32,39 @@ The table must include:
 - stable fingerprint
 - bounded query snippet
 
+## Filters
+
+The panel must include client-side filters for:
+
+- query shape or fingerprint
+- user
+- database
+- state
+
+Filtering must:
+
+- combine populated fields with AND semantics
+- use data attributes on each rendered row instead of scraping column layout
+- update a visible row count
+- reveal a filtered-empty state when no row matches
+- keep the full server-rendered table in the HTML for no-JavaScript fallback
+
 ## Empty state
 
 When processlist data exists but there are no eligible active rows with query
 text, the subview must render a short empty-state message instead of an empty
 table.
+
+## Advisor contract
+
+The Advisor must add a Query Shape finding when the slowest observed processlist
+query is at least 60 seconds old. The finding is:
+
+- Warning for generic long-running observed active queries
+- Critical for metadata-lock wait states
+
+The finding must include the fingerprint, max age, sighting count, user,
+database, state, and bounded query shape.
 
 ## Privacy and size constraints
 

--- a/specs/006-observed-slowest-queries/data-model.md
+++ b/specs/006-observed-slowest-queries/data-model.md
@@ -67,3 +67,15 @@ The existing `processlist` chart payload adds:
 
 The existing `timestamps`, `dimensions`, `metrics`, and `snapshotBoundaries`
 fields remain unchanged.
+
+## Advisor Thresholds
+
+The Query Shape Advisor rule evaluates the bounded `ObservedQueries` list:
+
+- minimum impactful age: 60 seconds
+- generic long-running query severity: Warning
+- metadata-lock wait severity: Critical
+
+The rule uses the first sorted summary that has a valid age at or above the
+threshold. Because summaries are already sorted by max observed age, this is
+the most impactful observed query in the report.

--- a/specs/006-observed-slowest-queries/data-model.md
+++ b/specs/006-observed-slowest-queries/data-model.md
@@ -1,0 +1,69 @@
+# Phase 1 Data Model: Observed Slowest Processlist Queries
+
+`ProcesslistData` remains the typed payload for merged processlist data. The
+feature extends it with a bounded list of grouped observed query summaries.
+
+## ObservedProcesslistQuery
+
+Represents one grouped query shape observed in active processlist rows.
+
+| Field | Type | Meaning |
+|-------|------|---------|
+| `Fingerprint` | `string` | Stable identifier derived from normalized query shape |
+| `Snippet` | `string` | Bounded human-readable query snippet |
+| `FirstSeen` | `time.Time` | Earliest sample timestamp for this fingerprint |
+| `LastSeen` | `time.Time` | Latest sample timestamp for this fingerprint |
+| `SeenSamples` | `int` | Number of eligible sightings grouped into this summary |
+| `MaxTimeMS` | `float64` | Largest observed row age in milliseconds |
+| `HasTimeMetric` | `bool` | Whether `MaxTimeMS` is observed rather than default |
+| `MaxRowsExamined` | `float64` | Largest observed `Rows_examined` value |
+| `HasRowsExaminedMetric` | `bool` | Whether rows examined was observed |
+| `MaxRowsSent` | `float64` | Largest observed `Rows_sent` value |
+| `HasRowsSentMetric` | `bool` | Whether rows sent was observed |
+| `User` | `string` | User from the slowest sighting |
+| `DB` | `string` | Database from the slowest sighting |
+| `Command` | `string` | Command from the slowest sighting |
+| `State` | `string` | State from the slowest sighting |
+
+## Validation and Ranking Rules
+
+- Eligible rows require non-empty, non-`NULL` query text.
+- Eligible rows exclude `Sleep`, `Daemon`, and empty command values.
+- Age uses valid `Time_ms` first, then valid `Time` seconds converted to
+  milliseconds.
+- Query snippets are whitespace-collapsed and bounded.
+- Fingerprints are stable for normalized query shapes.
+- Summaries are sorted by max age descending, then rows examined descending,
+  then rows sent descending, then fingerprint ascending.
+- The rendered report keeps only a bounded top list.
+
+## Payload Shape
+
+The existing `processlist` chart payload adds:
+
+```json
+{
+  "slowQueries": [
+    {
+      "fingerprint": "q_1234567890abcdef",
+      "snippet": "select count(*) from table where id = ?",
+      "firstSeen": 1769702258,
+      "lastSeen": 1769702719,
+      "seenSamples": 12,
+      "maxTimeSeconds": 3723.6,
+      "hasTimeMetric": true,
+      "maxRowsExamined": 0,
+      "hasRowsExamined": true,
+      "maxRowsSent": 0,
+      "hasRowsSent": true,
+      "user": "app",
+      "db": "appdb",
+      "command": "Query",
+      "state": "Waiting for table metadata lock"
+    }
+  ]
+}
+```
+
+The existing `timestamps`, `dimensions`, `metrics`, and `snapshotBoundaries`
+fields remain unchanged.

--- a/specs/006-observed-slowest-queries/plan.md
+++ b/specs/006-observed-slowest-queries/plan.md
@@ -8,8 +8,9 @@
 Add a bounded "Slowest observed queries" summary to the existing Processlist
 subview by grouping active processlist rows with query text into stable
 fingerprints. The implementation extends the existing processlist parser,
-typed model, render merge path, embedded payload, and DB template without
-adding a new collector, dependency, or top-level report section.
+typed model, render merge path, embedded payload, DB template, client-side
+report script, and Advisor rules without adding a new collector, dependency,
+or top-level report section.
 
 ## Technical Context
 
@@ -21,7 +22,8 @@ adding a new collector, dependency, or top-level report section.
 **Project Type**: CLI plus importable Go packages  
 **Performance Goals**: Process a multi-snapshot processlist-heavy incident
 collection without materially increasing report size; bound rendered query
-summaries to top entries  
+summaries to top entries; filter already-rendered rows in the browser without
+re-parsing report payloads
 **Constraints**: Read-only input tree, deterministic output, self-contained
 HTML, no runtime network, no new dependency  
 **Scale/Scope**: Existing `-processlist` collector only; no slow-query-log or
@@ -43,7 +45,7 @@ pt-query-digest parser in this feature
 | VIII. Reference Fixtures & Golden Tests | PASS | Adds focused tests and updates render golden output intentionally. |
 | IX. Zero Network at Runtime | PASS | No network code. |
 | X. Minimal Dependencies | PASS | No new direct dependency. |
-| XI. Reports Optimized for Humans Under Pressure | PASS | Adds a bounded table inside the existing Processlist subview. |
+| XI. Reports Optimized for Humans Under Pressure | PASS | Adds a bounded table, collapse controls, filters, and Advisor guidance inside the existing report flow. |
 | XII. Pinned Go Version | PASS | No Go version change. |
 | XIII. Canonical Code Path | PASS | Extends the existing processlist path; no duplicate parser. |
 | XIV. English-Only Durable Artifacts | PASS | All durable artifacts are English. |
@@ -83,13 +85,20 @@ render/
 ├── payloads.go
 ├── summaries.go
 ├── templates/db.html.tmpl
+├── assets/app.js
 ├── assets/app.css
 ├── db_test.go
 └── render_test.go
+
+findings/
+├── rules_queryshape.go
+└── findings_test.go
 ```
 
 **Structure Decision**: Extend the existing processlist parser/model/render
-pipeline in place. This preserves the canonical path for all processlist data.
+pipeline in place. Extend the existing Query Shape Advisor subsystem rather
+than adding a separate diagnostic surface. This preserves the canonical path
+for all processlist and Advisor data.
 
 ## Complexity Tracking
 

--- a/specs/006-observed-slowest-queries/plan.md
+++ b/specs/006-observed-slowest-queries/plan.md
@@ -14,7 +14,7 @@ or top-level report section.
 
 ## Technical Context
 
-**Language/Version**: Go 1.26.2 per current toolchain and `go.mod`  
+**Language/Version**: Go version per current `go.mod` declaration
 **Primary Dependencies**: Standard library plus existing embedded uPlot assets  
 **Storage**: N/A; reads pt-stalk files and writes one user-selected HTML output  
 **Testing**: `go test ./...`, focused parser/render/model tests  

--- a/specs/006-observed-slowest-queries/plan.md
+++ b/specs/006-observed-slowest-queries/plan.md
@@ -1,0 +1,96 @@
+# Implementation Plan: Observed Slowest Processlist Queries
+
+**Branch**: `006-observed-slowest-queries` | **Date**: 2026-04-28 | **Spec**: [spec.md](./spec.md)  
+**Input**: Feature specification from `specs/006-observed-slowest-queries/spec.md`
+
+## Summary
+
+Add a bounded "Slowest observed queries" summary to the existing Processlist
+subview by grouping active processlist rows with query text into stable
+fingerprints. The implementation extends the existing processlist parser,
+typed model, render merge path, embedded payload, and DB template without
+adding a new collector, dependency, or top-level report section.
+
+## Technical Context
+
+**Language/Version**: Go 1.26.2 per current toolchain and `go.mod`  
+**Primary Dependencies**: Standard library plus existing embedded uPlot assets  
+**Storage**: N/A; reads pt-stalk files and writes one user-selected HTML output  
+**Testing**: `go test ./...`, focused parser/render/model tests  
+**Target Platform**: Static CLI binary for Linux and macOS targets  
+**Project Type**: CLI plus importable Go packages  
+**Performance Goals**: Process a multi-snapshot processlist-heavy incident
+collection without materially increasing report size; bound rendered query
+summaries to top entries  
+**Constraints**: Read-only input tree, deterministic output, self-contained
+HTML, no runtime network, no new dependency  
+**Scale/Scope**: Existing `-processlist` collector only; no slow-query-log or
+pt-query-digest parser in this feature
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+| Principle | Status | Notes |
+|-----------|--------|-------|
+| I. Single Static Binary | PASS | Standard library only; no runtime dependency. |
+| II. Read-Only Inputs | PASS | Parser reads processlist files only; no input-tree writes. |
+| III. Graceful Degradation | PASS | Malformed optional fields are ignored while valid row data remains. |
+| IV. Deterministic Output | PASS | Stable fingerprinting, sorting, and bounded lists. |
+| V. Self-Contained HTML Reports | PASS | Rendered in existing embedded HTML/CSS/JS path. |
+| VI. Library-First Architecture | PASS | Changes remain in `model/`, `parse/`, and `render/`; CLI stays thin. |
+| VII. Typed Errors | PASS | No new branchable errors expected. |
+| VIII. Reference Fixtures & Golden Tests | PASS | Adds focused tests and updates render golden output intentionally. |
+| IX. Zero Network at Runtime | PASS | No network code. |
+| X. Minimal Dependencies | PASS | No new direct dependency. |
+| XI. Reports Optimized for Humans Under Pressure | PASS | Adds a bounded table inside the existing Processlist subview. |
+| XII. Pinned Go Version | PASS | No Go version change. |
+| XIII. Canonical Code Path | PASS | Extends the existing processlist path; no duplicate parser. |
+| XIV. English-Only Durable Artifacts | PASS | All durable artifacts are English. |
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/006-observed-slowest-queries/
+├── plan.md
+├── spec.md
+├── research.md
+├── data-model.md
+├── quickstart.md
+├── contracts/
+│   ├── packages.md
+│   └── ui.md
+├── checklists/
+│   └── requirements.md
+└── tasks.md
+```
+
+### Source Code (repository root)
+
+```text
+model/
+├── model.go
+└── processlist_query_test.go
+
+parse/
+├── processlist.go
+└── processlist_test.go
+
+render/
+├── concat.go
+├── payloads.go
+├── summaries.go
+├── templates/db.html.tmpl
+├── assets/app.css
+├── db_test.go
+└── render_test.go
+```
+
+**Structure Decision**: Extend the existing processlist parser/model/render
+pipeline in place. This preserves the canonical path for all processlist data.
+
+## Complexity Tracking
+
+No constitution violations.

--- a/specs/006-observed-slowest-queries/quickstart.md
+++ b/specs/006-observed-slowest-queries/quickstart.md
@@ -20,6 +20,7 @@ my-gather --overwrite \
 Open `/tmp/report-CS0060148.html`, then inspect:
 
 Database Usage -> Thread states -> Slowest observed queries
+Advisor -> Query Shape
 
 Expected behavior:
 
@@ -27,4 +28,7 @@ Expected behavior:
 - Long-running active `Query` rows waiting on table metadata lock are visible.
 - Repeated sightings of the same query shape are grouped.
 - Query snippets are bounded.
+- The slowest observed queries panel can collapse independently.
+- User, database, state, and query/fingerprint filters narrow the table.
+- Advisor marks metadata-lock slow observed queries as Critical.
 - The page remains fully functional offline.

--- a/specs/006-observed-slowest-queries/quickstart.md
+++ b/specs/006-observed-slowest-queries/quickstart.md
@@ -1,0 +1,30 @@
+# Quickstart: Observed Slowest Processlist Queries
+
+## Validate tests
+
+```bash
+go test ./parse ./render ./model
+go test ./...
+```
+
+## Generate the motivating report
+
+```bash
+my-gather --overwrite \
+  -o /tmp/report-CS0060148.html \
+  /Users/matias/Documents/Incidents/CS0060148/eu-hrznp-d003/pt-stalk
+```
+
+## Manual validation
+
+Open `/tmp/report-CS0060148.html`, then inspect:
+
+Database Usage -> Thread states -> Slowest observed queries
+
+Expected behavior:
+
+- `Sleep` and `Daemon` rows do not appear as slow queries.
+- Long-running active `Query` rows waiting on table metadata lock are visible.
+- Repeated sightings of the same query shape are grouped.
+- Query snippets are bounded.
+- The page remains fully functional offline.

--- a/specs/006-observed-slowest-queries/research.md
+++ b/specs/006-observed-slowest-queries/research.md
@@ -1,0 +1,86 @@
+# Phase 0 Research: Observed Slowest Processlist Queries
+
+## Decision: Report observed in-flight processlist queries
+
+**Decision**: Treat the feature as "slowest observed active processlist
+queries" rather than slow-query-log or pt-query-digest analysis.
+
+**Rationale**: The current pt-stalk collections supported by the report already
+include `-processlist` snapshots. The inspected incident folder contains no
+slow-query-log or pt-query-digest artifacts, so processlist rows are the
+available query-level evidence. `Time_ms` and `Time` describe the current row's
+observed age at capture time, not completed execution duration.
+
+**Alternatives considered**:
+
+- Slow-query-log parser: rejected for this feature because the artifact is not
+  present in the current supported collector set.
+- pt-query-digest parser: rejected for this feature because no digest artifact
+  is present in the capture and it would introduce a separate collector scope.
+
+## Decision: Exclude idle and background rows from ranking
+
+**Decision**: Eligible rows must have non-empty query text and active SQL
+commands. Rows with `Sleep`, `Daemon`, or empty commands are excluded from the
+slowest-query ranking.
+
+**Rationale**: Long ages on sleeping sessions or background daemons are not
+slow queries. In the motivating capture, `event_scheduler` daemon rows have the
+largest age and would otherwise drown out blocked SQL evidence.
+
+**Alternatives considered**:
+
+- Rank every row by age: rejected because it misclassifies idle/background
+  state as query slowness.
+- Exclude only `Sleep`: rejected because daemon/background rows can also have
+  very large non-query ages.
+
+## Decision: Group by normalized query fingerprint
+
+**Decision**: Normalize query text by trimming whitespace, collapsing internal
+whitespace, lowercasing, and replacing quoted strings and numeric literals with
+placeholders. Compute a stable hash from that normalized form.
+
+**Rationale**: Processlist captures can see the same query across many
+seconds. Grouping repeated and literal-varied sightings keeps the report
+bounded and highlights query shapes instead of duplicates.
+
+**Alternatives considered**:
+
+- Group by raw query text: rejected because literal-only differences create too
+  many rows.
+- Full SQL parser: rejected because standard-library text normalization is
+  sufficient for a bounded incident report and avoids a new dependency.
+
+## Decision: Keep query text bounded but visible
+
+**Decision**: Render a compact snippet for each top query summary and a stable
+fingerprint. Do not render every raw processlist row.
+
+**Rationale**: Support engineers need enough identity to act, but the previous
+processlist feature intentionally avoided a raw SQL dump. A bounded top-N table
+keeps the feature useful while respecting the report's privacy posture.
+
+**Alternatives considered**:
+
+- Hide query text entirely: rejected because fingerprints alone are hard to act
+  on during an incident.
+- Render full SQL for all sightings: rejected because it expands sensitive data
+  exposure and makes the Processlist subview noisy.
+
+## Decision: Extend the existing processlist model
+
+**Decision**: Add bounded query summary fields to the existing
+`ProcesslistData` model and compute summaries during parsing and render-layer
+concatenation.
+
+**Rationale**: This keeps one canonical processlist path and satisfies the
+constitution's canonical-code-path requirement. The existing parser already
+extracts the fields needed for eligibility, age, row counters, and query text.
+
+**Alternatives considered**:
+
+- Separate query parser: rejected because it would duplicate processlist
+  parsing.
+- Browser-side grouping from all raw rows: rejected because it would inflate
+  the report payload and expose more raw query text than necessary.

--- a/specs/006-observed-slowest-queries/spec.md
+++ b/specs/006-observed-slowest-queries/spec.md
@@ -1,0 +1,179 @@
+# Feature Specification: Observed Slowest Processlist Queries
+
+**Feature Branch**: `006-observed-slowest-queries`  
+**Created**: 2026-04-28  
+**Status**: Draft  
+**Input**: User description: "Detect the slowest queries obtained or reported in pt-stalk captures and add this to the report using the spec-driven workflow."
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Find slow in-flight queries quickly (Priority: P1)
+
+A support engineer opens a generated report from a pt-stalk collection and
+needs to see which active SQL statements were observed running the longest
+during the capture window. The report must show this without requiring the
+engineer to manually scan every raw `-processlist` file.
+
+**Why this priority**: Processlist captures often hold the only query-level
+evidence available during an incident. Surfacing the slowest observed active
+queries turns the current aggregate processlist metrics into actionable
+diagnostic evidence.
+
+**Independent Test**: Generate a report from a fixture containing several
+active `Query` rows with different `Time_ms` values. The Processlist subview
+shows the highest-aged query fingerprints in deterministic order.
+
+**Acceptance Scenarios**:
+
+1. **Given** a processlist capture with active `Query` rows containing query
+   text and `Time_ms`, **When** the report renders, **Then** the Processlist
+   subview lists the slowest observed query fingerprints with their maximum
+   observed age.
+2. **Given** repeated sightings of the same query text across adjacent
+   processlist samples, **When** the report renders, **Then** the repeated
+   sightings are grouped into one row with first seen, last seen, sample count,
+   and maximum observed age.
+3. **Given** a capture containing `Sleep` or `Daemon` rows with very large
+   ages, **When** slowest queries are ranked, **Then** those idle or background
+   rows do not outrank active SQL statements.
+
+---
+
+### User Story 2 - Preserve row-count and wait-state evidence (Priority: P2)
+
+A support engineer needs to distinguish a long-running query that is blocked
+from a query that is actively scanning or sending many rows. The slowest-query
+summary must keep the strongest row-count and state evidence seen for each
+query fingerprint.
+
+**Why this priority**: Long age alone can be misleading. Row counters and
+thread state clarify whether the query is blocked, scanning, sending results,
+or waiting on a lock.
+
+**Independent Test**: Generate a report from a fixture where the same query
+fingerprint appears with changing states and row counters. The report shows
+the highest rows examined, highest rows sent, and representative state.
+
+**Acceptance Scenarios**:
+
+1. **Given** repeated sightings of the same query with increasing
+   `Rows_examined`, **When** the summary groups the query, **Then** the row
+   shows the peak `Rows_examined` value across all sightings.
+2. **Given** repeated sightings of the same query with multiple states,
+   **When** the report renders, **Then** the row shows the state associated
+   with the slowest observed sighting and keeps a count of total sightings.
+3. **Given** malformed or missing optional row counters, **When** the capture
+   is parsed, **Then** valid age and query evidence from the same row remains
+   available.
+
+---
+
+### User Story 3 - Keep query text useful but controlled (Priority: P3)
+
+A support engineer needs enough query identity to act, but the report must not
+turn into an unbounded raw SQL dump. The report must show compact query
+snippets and stable fingerprints while bounding the amount of SQL text exposed.
+
+**Why this priority**: The existing richer processlist feature intentionally
+avoids a raw SQL table because query text can be sensitive. This feature should
+add targeted evidence without weakening that privacy posture.
+
+**Independent Test**: Generate a report from a fixture with long query text and
+repeated whitespace/literal variants. The report shows bounded snippets,
+stable fingerprints, and grouped variants deterministically.
+
+**Acceptance Scenarios**:
+
+1. **Given** a processlist row with long query text, **When** the report
+   renders, **Then** the visible query snippet is bounded to a fixed maximum
+   length.
+2. **Given** two query texts that differ only by whitespace or literal values,
+   **When** the summary computes fingerprints, **Then** they group together as
+   the same query shape.
+3. **Given** a generated report, **When** the engineer opens the Processlist
+   subview, **Then** only the bounded top query summaries are shown, not every
+   raw processlist row.
+
+### Edge Cases
+
+- Processlist files may contain no active rows with non-empty query text.
+- A row may have `Command: Query` but empty, whitespace-only, or `NULL` `Info`.
+- `Time_ms` may be absent or malformed; valid `Time` remains a fallback.
+- Background rows such as `event_scheduler` daemon can have very large ages
+  but must not be ranked as slow SQL.
+- Many repeated sightings of the same query must not produce duplicate report
+  rows.
+- Query text may contain newlines, extra whitespace, quoted literals, numeric
+  literals, or very long statements.
+- Large captures must keep the embedded report bounded and deterministic.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: The report MUST expose a bounded list of the slowest observed
+  active processlist query fingerprints when active query text is present.
+- **FR-002**: A processlist row MUST be eligible for slowest-query ranking only
+  when it has non-empty, non-`NULL` `Info` text and its command represents
+  active SQL work. `Sleep`, `Daemon`, and empty commands MUST be excluded.
+- **FR-003**: Slowest-query age MUST use `Time_ms` when valid and fall back to
+  `Time` seconds when `Time_ms` is missing or invalid.
+- **FR-004**: Repeated sightings of the same query shape MUST be grouped under
+  a stable fingerprint rather than rendered as duplicate rows.
+- **FR-005**: Each grouped query summary MUST include maximum observed age,
+  first seen timestamp, last seen timestamp, sighting count, user, database,
+  state from the slowest sighting, peak `Rows_examined`, and peak `Rows_sent`
+  when those values are available.
+- **FR-006**: Visible query text MUST be bounded to a compact snippet and MUST
+  not render every raw query row from the processlist capture.
+- **FR-007**: Slowest-query rows MUST be sorted deterministically by maximum
+  observed age descending, then peak rows examined descending, then peak rows
+  sent descending, then fingerprint ascending.
+- **FR-008**: Missing or malformed optional numeric fields MUST NOT make the
+  collection fail; valid processlist data from the same row and sample MUST
+  still render.
+- **FR-009**: The feature MUST be embedded in the existing self-contained HTML
+  report and MUST work offline with no external network or asset fetch.
+- **FR-010**: The feature MUST include parser-level, merge-level, payload-level,
+  and render-level tests that protect grouping, ranking, bounded text, and the
+  existing processlist breakdown.
+- **FR-011**: When no eligible query rows exist, the Processlist subview MUST
+  show a clear empty state instead of an empty table.
+
+### Key Entities
+
+- **Observed processlist query sighting**: One eligible active row observed in a
+  processlist timestamp block. Attributes include timestamp, command, user,
+  database, state, age, row counters, and query text.
+- **Observed query summary**: A bounded grouped summary of one normalized query
+  shape across the capture window. Attributes include fingerprint, snippet,
+  first seen, last seen, sighting count, maximum age, peak row counters, and
+  context from the slowest sighting.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: For a fixture with known active processlist queries, the report
+  lists the expected top query fingerprints in exact deterministic order.
+- **SC-002**: For repeated sightings of the same query shape, the report shows
+  one grouped row with correct first seen, last seen, sighting count, and
+  maximum age.
+- **SC-003**: For a fixture containing long-running `Sleep` and `Daemon` rows,
+  those rows are excluded from slowest-query ranking.
+- **SC-004**: Rendering the same fixture twice produces byte-identical HTML
+  output except for the existing explicitly allowed generated timestamp.
+- **SC-005**: A real multi-snapshot pt-stalk collection continues to generate a
+  report successfully and includes bounded slowest-query summaries when active
+  query text exists.
+
+## Assumptions
+
+- This feature reports slowest **observed in-flight processlist rows**, not
+  completed slow-query-log events.
+- The existing Processlist subview is the correct home for the feature; no new
+  top-level report section is required.
+- Query snippets are useful enough when combined with stable fingerprints and
+  context fields.
+- The report should default to a small bounded list so query evidence is
+  actionable during an incident and does not dominate the page.

--- a/specs/006-observed-slowest-queries/spec.md
+++ b/specs/006-observed-slowest-queries/spec.md
@@ -94,6 +94,63 @@ stable fingerprints, and grouped variants deterministically.
    subview, **Then** only the bounded top query summaries are shown, not every
    raw processlist row.
 
+---
+
+### User Story 4 - Work the slow-query list interactively (Priority: P1)
+
+A support engineer needs to narrow the slowest observed query table while
+reviewing an incident. The panel must be easy to collapse when the chart is the
+focus, and easy to filter when query-level evidence is the focus.
+
+**Why this priority**: The slow-query table can contain wide SQL snippets and
+incident context. Clear collapse and filtering controls keep the report usable
+without removing the evidence.
+
+**Independent Test**: Render a report with several observed query rows and
+assert that the Processlist subview includes an independently collapsible query
+panel plus search/filter controls targeting user, database, state, and query
+shape fields.
+
+**Acceptance Scenarios**:
+
+1. **Given** slowest observed queries exist, **When** the Processlist subview
+   renders, **Then** the slow-query panel is an independently collapsible
+   section with a clear summary label and count.
+2. **Given** multiple slowest observed queries with different users,
+   databases, states, and query snippets, **When** the engineer enters filter
+   terms, **Then** only rows matching all populated filters remain visible.
+3. **Given** no rows match the active filters, **When** the table updates,
+   **Then** a clear filtered-empty state is shown without deleting the full
+   server-rendered table.
+
+---
+
+### User Story 5 - Surface impactful observed queries in Advisor (Priority: P1)
+
+A support engineer needs the report to call out when the observed slowest
+queries themselves are likely incident drivers, especially long metadata-lock
+waits or long-running active statements that appeared throughout the capture.
+
+**Why this priority**: The table provides evidence, but the Advisor should
+convert that evidence into a diagnostic finding so the report is smart enough
+to guide triage.
+
+**Independent Test**: Build a report with an observed processlist query older
+than the configured threshold and assert that the Advisor emits a Query Shape
+finding with the expected severity, metrics, and remediation guidance.
+
+**Acceptance Scenarios**:
+
+1. **Given** an observed query remains active for at least 60 seconds, **When**
+   Advisor findings are computed, **Then** a Query Shape warning identifies the
+   slowest observed query fingerprint and age.
+2. **Given** the slowest observed query is waiting for table metadata lock,
+   **When** Advisor findings are computed, **Then** the finding is Critical
+   because the query is blocked and likely holding or waiting on DDL/MDL.
+3. **Given** no observed active query reaches the configured age threshold,
+   **When** Advisor findings are computed, **Then** no slow-observed-query
+   finding is emitted.
+
 ### Edge Cases
 
 - Processlist files may contain no active rows with non-empty query text.
@@ -106,6 +163,8 @@ stable fingerprints, and grouped variants deterministically.
 - Query text may contain newlines, extra whitespace, quoted literals, numeric
   literals, or very long statements.
 - Large captures must keep the embedded report bounded and deterministic.
+- Client-side filters must work without network access and must degrade to the
+  fully rendered table when JavaScript is disabled.
 
 ## Requirements *(mandatory)*
 
@@ -139,6 +198,22 @@ stable fingerprints, and grouped variants deterministically.
   existing processlist breakdown.
 - **FR-011**: When no eligible query rows exist, the Processlist subview MUST
   show a clear empty state instead of an empty table.
+- **FR-012**: The slowest-observed-query panel MUST be independently
+  collapsible inside the Processlist subview and MUST show the number of
+  observed query summaries in the collapsed summary.
+- **FR-013**: The report MUST provide client-side filters for slowest observed
+  queries by user, database, state, and query text/fingerprint.
+- **FR-014**: Slow-query filters MUST combine with AND semantics across
+  populated fields and MUST show a filtered-empty state when no rendered rows
+  match.
+- **FR-015**: The Advisor MUST emit a Query Shape finding when the slowest
+  observed active query reaches at least 60 seconds.
+- **FR-016**: The slow-observed-query Advisor finding MUST be Critical when the
+  slowest observed query state indicates a metadata lock wait; otherwise it
+  MUST be Warning for age at or above 60 seconds.
+- **FR-017**: The Advisor finding MUST include the slowest query fingerprint,
+  maximum age, sighting count, representative user/database/state, and bounded
+  query shape in its metrics or explanation.
 
 ### Key Entities
 
@@ -166,6 +241,12 @@ stable fingerprints, and grouped variants deterministically.
 - **SC-005**: A real multi-snapshot pt-stalk collection continues to generate a
   report successfully and includes bounded slowest-query summaries when active
   query text exists.
+- **SC-006**: Slow-query table controls are present in the generated HTML and
+  allow rows to be filtered by user, database, state, and query content without
+  requiring any external asset.
+- **SC-007**: A capture with a 60-second or older observed query produces an
+  Advisor finding; a metadata-lock wait at that age produces a Critical
+  finding.
 
 ## Assumptions
 
@@ -177,3 +258,8 @@ stable fingerprints, and grouped variants deterministically.
   context fields.
 - The report should default to a small bounded list so query evidence is
   actionable during an incident and does not dominate the page.
+- The slowest-query panel should default open when query evidence exists, but
+  remain independently collapsible so readers can hide it while using the chart.
+- The first Advisor threshold is intentionally conservative: 60 seconds is
+  enough to be actionable in an incident processlist capture, while metadata
+  lock waits are considered more severe than generic long-running work.

--- a/specs/006-observed-slowest-queries/tasks.md
+++ b/specs/006-observed-slowest-queries/tasks.md
@@ -76,6 +76,24 @@ capture.
 - [x] T019 Generate `/tmp/report-CS0060148.html` from the motivating incident and validate the slowest observed queries appear.
 - [x] T020 Update `AGENTS.md` active feature block to `006-observed-slowest-queries`.
 
+---
+
+## Phase 7: Interactive Query Panel and Advisor Enhancement
+
+**Purpose**: Add the requested collapse/filter workflow and make the Advisor
+flag impactful observed queries.
+
+- [x] T021 [US4] Amend `specs/006-observed-slowest-queries/spec.md`, `plan.md`, `contracts/ui.md`, `contracts/packages.md`, `data-model.md`, and `quickstart.md` for collapsible/filterable slow-query UI and Advisor impact detection.
+- [x] T022 [P] [US4] Extend `render/db_test.go` to require the collapsible slow-query panel, filter controls, row data attributes, visible count, and filtered-empty state.
+- [x] T023 [P] [US5] Extend `findings/findings_test.go` to require Warning and Critical Advisor findings for impactful observed processlist queries and skip behavior below threshold.
+- [x] T024 [US4] Update `render/templates/db.html.tmpl`, `render/assets/app.css`, and `render/assets/app.js` to implement independent collapse and client-side filters.
+- [x] T025 [US5] Update `findings/rules_queryshape.go` to register and compute the observed slow-query Advisor finding.
+- [x] T026 [US4] Update `testdata/golden/db.example2.html` after intentional render changes.
+- [x] T027 Run `gofmt` on modified Go files.
+- [x] T028 Run `go test ./render ./findings`.
+- [x] T029 Run `go test ./...`.
+- [x] T030 Regenerate `/tmp/report-CS0060148.html` and validate the panel filters and Advisor finding are present.
+
 ## Dependencies & Execution Order
 
 - Phase 1 must complete first.

--- a/specs/006-observed-slowest-queries/tasks.md
+++ b/specs/006-observed-slowest-queries/tasks.md
@@ -1,0 +1,86 @@
+# Tasks: Observed Slowest Processlist Queries
+
+**Input**: Design documents from `specs/006-observed-slowest-queries/`  
+**Prerequisites**: `plan.md`, `spec.md`, `research.md`, `data-model.md`, `contracts/`
+
+**Tests**: Tests are required by FR-010 and must be written before the matching
+implementation tasks.
+
+## Phase 1: Setup
+
+**Purpose**: Establish feature artifacts and active spec context.
+
+- [x] T001 Create feature branch `006-observed-slowest-queries`.
+- [x] T002 Create `specs/006-observed-slowest-queries/spec.md`.
+- [x] T003 Create planning artifacts in `specs/006-observed-slowest-queries/`.
+
+---
+
+## Phase 2: Foundational Model and Parser Tests
+
+**Purpose**: Define the slow-query summary contract before implementation.
+
+- [x] T004 [P] Add model ranking and merge tests in `model/processlist_query_test.go`.
+- [x] T005 [P] Add parser tests for eligible active rows, idle/background exclusion, fingerprint grouping, and bounded snippets in `parse/processlist_test.go`.
+
+---
+
+## Phase 3: User Story 1 - Find slow in-flight queries quickly (Priority: P1)
+
+**Goal**: Show the top slowest observed active processlist query fingerprints.
+
+**Independent Test**: Parser tests identify grouped top query fingerprints and
+render tests show them in the Processlist subview.
+
+- [x] T006 [US1] Extend `model/model.go` with observed query summary fields and deterministic helper functions.
+- [x] T007 [US1] Update `parse/processlist.go` to collect eligible active query sightings and emit grouped summaries.
+- [x] T008 [US1] Add render markup tests in `render/db_test.go`.
+- [x] T009 [US1] Update `render/templates/db.html.tmpl` and `render/assets/app.css` to show the bounded slowest-query table.
+
+---
+
+## Phase 4: User Story 2 - Preserve row-count and wait-state evidence (Priority: P2)
+
+**Goal**: Preserve peak row counters and context from the slowest sighting.
+
+**Independent Test**: Repeated sightings of the same fingerprint retain the
+highest row counters and state from the slowest sighting.
+
+- [x] T010 [P] [US2] Add merge tests for cross-snapshot query summaries in `render/concat_test.go`.
+- [x] T011 [US2] Update `render/concat.go` to merge observed query summaries across snapshots.
+- [x] T012 [US2] Update `render/payloads.go` and `render/render_test.go` to embed `slowQueries`.
+
+---
+
+## Phase 5: User Story 3 - Keep query text useful but controlled (Priority: P3)
+
+**Goal**: Bound text exposure while preserving useful identity.
+
+**Independent Test**: Long query text renders as a bounded snippet and repeated
+literal variants group by fingerprint.
+
+- [x] T013 [P] [US3] Add snippet and fingerprint tests in `model/processlist_query_test.go`.
+- [x] T014 [US3] Ensure `model/model.go` normalizes query text, computes stable fingerprints, and bounds snippets.
+- [x] T015 [US3] Add empty-state render coverage in `render/db_test.go`.
+
+---
+
+## Phase 6: Polish and Verification
+
+**Purpose**: Validate the full workflow against tests and a real incident
+capture.
+
+- [x] T016 Run `gofmt` on modified Go files.
+- [x] T017 Run `go test ./parse ./render ./model`.
+- [x] T018 Run `go test ./...`.
+- [x] T019 Generate `/tmp/report-CS0060148.html` from the motivating incident and validate the slowest observed queries appear.
+- [x] T020 Update `AGENTS.md` active feature block to `006-observed-slowest-queries`.
+
+## Dependencies & Execution Order
+
+- Phase 1 must complete first.
+- Phase 2 tests must be written before model/parser implementation.
+- US1 is the MVP and must complete before US2/US3 render polish.
+- US2 depends on the model fields from US1.
+- US3 depends on the fingerprint/snippet helpers from US1.
+- Phase 6 runs after all user stories are complete.

--- a/testdata/golden/db.example2.html
+++ b/testdata/golden/db.example2.html
@@ -233,8 +233,8 @@
             <tr data-query-text="select c from sbtest8 where id=? q_01e2bd8f360a932a" data-query-user="sysbench" data-query-db="test" data-query-state="statistics">
               <td class="rank">1</td>
               <td class="mono">0.5 s</td>
-              <td class="mono">13</td>
-              <td class="mono">2026-04-21T16:52:14Z</td>
+              <td class="mono">29</td>
+              <td class="mono">2026-04-21T16:51:45Z</td>
               <td class="mono">2026-04-21T16:52:42Z</td>
               <td>sysbench</td>
               <td>test</td>
@@ -247,8 +247,8 @@
             <tr data-query-text="update sbtest10 set k=k&#43;? where id=? q_5b3f6b87519c3deb" data-query-user="sysbench" data-query-db="test" data-query-state="updating">
               <td class="rank">2</td>
               <td class="mono">0.5 s</td>
-              <td class="mono">4</td>
-              <td class="mono">2026-04-21T16:52:19Z</td>
+              <td class="mono">7</td>
+              <td class="mono">2026-04-21T16:51:43Z</td>
               <td class="mono">2026-04-21T16:52:41Z</td>
               <td>sysbench</td>
               <td>test</td>
@@ -261,8 +261,8 @@
             <tr data-query-text="select c from sbtest10 where id=? q_0726a22f6a25ecf4" data-query-user="sysbench" data-query-db="test" data-query-state="statistics">
               <td class="rank">3</td>
               <td class="mono">0.5 s</td>
-              <td class="mono">11</td>
-              <td class="mono">2026-04-21T16:52:14Z</td>
+              <td class="mono">20</td>
+              <td class="mono">2026-04-21T16:51:48Z</td>
               <td class="mono">2026-04-21T16:52:39Z</td>
               <td>sysbench</td>
               <td>test</td>
@@ -275,8 +275,8 @@
             <tr data-query-text="select c from sbtest9 where id=? q_430ecda45b54ecdc" data-query-user="sysbench" data-query-db="test" data-query-state="statistics">
               <td class="rank">4</td>
               <td class="mono">0.5 s</td>
-              <td class="mono">13</td>
-              <td class="mono">2026-04-21T16:52:14Z</td>
+              <td class="mono">32</td>
+              <td class="mono">2026-04-21T16:51:44Z</td>
               <td class="mono">2026-04-21T16:52:39Z</td>
               <td>sysbench</td>
               <td>test</td>
@@ -303,8 +303,8 @@
             <tr data-query-text="select c from sbtest1 where id between ? and ? order by c q_7e42bb16254a9180" data-query-user="sysbench" data-query-db="test" data-query-state="statistics">
               <td class="rank">6</td>
               <td class="mono">0.5 s</td>
-              <td class="mono">3</td>
-              <td class="mono">2026-04-21T16:52:15Z</td>
+              <td class="mono">5</td>
+              <td class="mono">2026-04-21T16:51:53Z</td>
               <td class="mono">2026-04-21T16:52:19Z</td>
               <td>sysbench</td>
               <td>test</td>
@@ -317,8 +317,8 @@
             <tr data-query-text="select distinct c from sbtest4 where id between ? and ? order by c q_804e9698ae152b99" data-query-user="sysbench" data-query-db="test" data-query-state="statistics">
               <td class="rank">7</td>
               <td class="mono">0.5 s</td>
-              <td class="mono">5</td>
-              <td class="mono">2026-04-21T16:52:13Z</td>
+              <td class="mono">8</td>
+              <td class="mono">2026-04-21T16:51:54Z</td>
               <td class="mono">2026-04-21T16:52:26Z</td>
               <td>sysbench</td>
               <td>test</td>
@@ -345,8 +345,8 @@
             <tr data-query-text="delete from sbtest10 where id=? q_dcd856f12e9bb8f0" data-query-user="sysbench" data-query-db="test" data-query-state="updating">
               <td class="rank">9</td>
               <td class="mono">0.5 s</td>
-              <td class="mono">1</td>
-              <td class="mono">2026-04-21T16:52:19Z</td>
+              <td class="mono">6</td>
+              <td class="mono">2026-04-21T16:51:45Z</td>
               <td class="mono">2026-04-21T16:52:19Z</td>
               <td>sysbench</td>
               <td>test</td>

--- a/testdata/golden/db.example2.html
+++ b/testdata/golden/db.example2.html
@@ -189,6 +189,171 @@
     <div class="chart" id="chart-processlist" data-chart="processlist"
          aria-label="Count of threads per state over time"></div>
     <noscript><p class="banner">Charts require JavaScript. Raw processlist data is embedded in the page.</p></noscript>
+    <section class="slow-query-panel" aria-label="Slowest observed processlist queries">
+      <h4>Slowest observed queries</h4>
+      <div class="slow-query-table-wrap">
+        <table class="slow-query-table">
+          <thead>
+            <tr>
+              <th scope="col">Rank</th>
+              <th scope="col">Max age</th>
+              <th scope="col">Seen</th>
+              <th scope="col">First seen</th>
+              <th scope="col">Last seen</th>
+              <th scope="col">User</th>
+              <th scope="col">DB</th>
+              <th scope="col">State</th>
+              <th scope="col">Rows examined</th>
+              <th scope="col">Rows sent</th>
+              <th scope="col">Fingerprint</th>
+              <th scope="col">Query shape</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td class="rank">1</td>
+              <td class="mono">0.5 s</td>
+              <td class="mono">13</td>
+              <td class="mono">2026-04-21T16:52:14Z</td>
+              <td class="mono">2026-04-21T16:52:42Z</td>
+              <td>sysbench</td>
+              <td>test</td>
+              <td>statistics</td>
+              <td class="mono">1</td>
+              <td class="mono">1</td>
+              <td class="mono">q_01e2bd8f360a932a</td>
+              <td class="query-shape"><code>select c from sbtest8 where id=?</code></td>
+            </tr>
+            <tr>
+              <td class="rank">2</td>
+              <td class="mono">0.5 s</td>
+              <td class="mono">4</td>
+              <td class="mono">2026-04-21T16:52:19Z</td>
+              <td class="mono">2026-04-21T16:52:41Z</td>
+              <td>sysbench</td>
+              <td>test</td>
+              <td>updating</td>
+              <td class="mono">1</td>
+              <td class="mono">0</td>
+              <td class="mono">q_5b3f6b87519c3deb</td>
+              <td class="query-shape"><code>update sbtest10 set k=k&#43;? where id=?</code></td>
+            </tr>
+            <tr>
+              <td class="rank">3</td>
+              <td class="mono">0.5 s</td>
+              <td class="mono">11</td>
+              <td class="mono">2026-04-21T16:52:14Z</td>
+              <td class="mono">2026-04-21T16:52:39Z</td>
+              <td>sysbench</td>
+              <td>test</td>
+              <td>statistics</td>
+              <td class="mono">0</td>
+              <td class="mono">0</td>
+              <td class="mono">q_0726a22f6a25ecf4</td>
+              <td class="query-shape"><code>select c from sbtest10 where id=?</code></td>
+            </tr>
+            <tr>
+              <td class="rank">4</td>
+              <td class="mono">0.5 s</td>
+              <td class="mono">13</td>
+              <td class="mono">2026-04-21T16:52:14Z</td>
+              <td class="mono">2026-04-21T16:52:39Z</td>
+              <td>sysbench</td>
+              <td>test</td>
+              <td>statistics</td>
+              <td class="mono">0</td>
+              <td class="mono">0</td>
+              <td class="mono">q_430ecda45b54ecdc</td>
+              <td class="query-shape"><code>select c from sbtest9 where id=?</code></td>
+            </tr>
+            <tr>
+              <td class="rank">5</td>
+              <td class="mono">0.5 s</td>
+              <td class="mono">4</td>
+              <td class="mono">2026-04-21T16:52:17Z</td>
+              <td class="mono">2026-04-21T16:52:35Z</td>
+              <td>sysbench</td>
+              <td>test</td>
+              <td>statistics</td>
+              <td class="mono">0</td>
+              <td class="mono">0</td>
+              <td class="mono">q_6836d7b7af3c5bdc</td>
+              <td class="query-shape"><code>select distinct c from sbtest8 where id between ? and ? order by c</code></td>
+            </tr>
+            <tr>
+              <td class="rank">6</td>
+              <td class="mono">0.5 s</td>
+              <td class="mono">3</td>
+              <td class="mono">2026-04-21T16:52:15Z</td>
+              <td class="mono">2026-04-21T16:52:19Z</td>
+              <td>sysbench</td>
+              <td>test</td>
+              <td>statistics</td>
+              <td class="mono">0</td>
+              <td class="mono">0</td>
+              <td class="mono">q_7e42bb16254a9180</td>
+              <td class="query-shape"><code>select c from sbtest1 where id between ? and ? order by c</code></td>
+            </tr>
+            <tr>
+              <td class="rank">7</td>
+              <td class="mono">0.5 s</td>
+              <td class="mono">5</td>
+              <td class="mono">2026-04-21T16:52:13Z</td>
+              <td class="mono">2026-04-21T16:52:26Z</td>
+              <td>sysbench</td>
+              <td>test</td>
+              <td>statistics</td>
+              <td class="mono">0</td>
+              <td class="mono">0</td>
+              <td class="mono">q_804e9698ae152b99</td>
+              <td class="query-shape"><code>select distinct c from sbtest4 where id between ? and ? order by c</code></td>
+            </tr>
+            <tr>
+              <td class="rank">8</td>
+              <td class="mono">0.5 s</td>
+              <td class="mono">8</td>
+              <td class="mono">2026-04-21T16:51:46Z</td>
+              <td class="mono">2026-04-21T16:52:40Z</td>
+              <td>sysbench</td>
+              <td>test</td>
+              <td>updating</td>
+              <td class="mono">0</td>
+              <td class="mono">0</td>
+              <td class="mono">q_a93045c693d4d172</td>
+              <td class="query-shape"><code>update sbtest4 set k=k&#43;? where id=?</code></td>
+            </tr>
+            <tr>
+              <td class="rank">9</td>
+              <td class="mono">0.5 s</td>
+              <td class="mono">1</td>
+              <td class="mono">2026-04-21T16:52:19Z</td>
+              <td class="mono">2026-04-21T16:52:19Z</td>
+              <td>sysbench</td>
+              <td>test</td>
+              <td>updating</td>
+              <td class="mono">0</td>
+              <td class="mono">0</td>
+              <td class="mono">q_dcd856f12e9bb8f0</td>
+              <td class="query-shape"><code>delete from sbtest10 where id=?</code></td>
+            </tr>
+            <tr>
+              <td class="rank">10</td>
+              <td class="mono">0.5 s</td>
+              <td class="mono">3</td>
+              <td class="mono">2026-04-21T16:52:22Z</td>
+              <td class="mono">2026-04-21T16:52:37Z</td>
+              <td>sysbench</td>
+              <td>test</td>
+              <td>statistics</td>
+              <td class="mono">0</td>
+              <td class="mono">0</td>
+              <td class="mono">q_0f9d5cc9d50f9315</td>
+              <td class="query-shape"><code>select c from sbtest10 where id between ? and ? order by c</code></td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    </section>
   </div>
 </details>
 

--- a/testdata/golden/db.example2.html
+++ b/testdata/golden/db.example2.html
@@ -189,8 +189,28 @@
     <div class="chart" id="chart-processlist" data-chart="processlist"
          aria-label="Count of threads per state over time"></div>
     <noscript><p class="banner">Charts require JavaScript. Raw processlist data is embedded in the page.</p></noscript>
-    <section class="slow-query-panel" aria-label="Slowest observed processlist queries">
-      <h4>Slowest observed queries</h4>
+    <details class="slow-query-panel" aria-label="Slowest observed processlist queries" open>
+      <summary><span>Slowest observed queries</span><span class="badge">10 queries</span></summary>
+      <div class="slow-query-controls" role="search" aria-label="Slowest observed query filters">
+        <label>
+          <span>Query</span>
+          <input type="search" class="slow-query-search" data-filter-field="query" placeholder="Search query or fingerprint" autocomplete="off">
+        </label>
+        <label>
+          <span>User</span>
+          <input type="search" class="slow-query-filter" data-filter-field="user" placeholder="Filter user" autocomplete="off">
+        </label>
+        <label>
+          <span>DB</span>
+          <input type="search" class="slow-query-filter" data-filter-field="db" placeholder="Filter db" autocomplete="off">
+        </label>
+        <label>
+          <span>State</span>
+          <input type="search" class="slow-query-filter" data-filter-field="state" placeholder="Filter state" autocomplete="off">
+        </label>
+        <span class="slow-query-count" aria-live="polite">10 of 10 shown</span>
+      </div>
+      <p class="banner missing slow-query-filter-empty" data-slow-query-empty hidden>No slowest observed queries match the active filters.</p>
       <div class="slow-query-table-wrap">
         <table class="slow-query-table">
           <thead>
@@ -210,7 +230,7 @@
             </tr>
           </thead>
           <tbody>
-            <tr>
+            <tr data-query-text="select c from sbtest8 where id=? q_01e2bd8f360a932a" data-query-user="sysbench" data-query-db="test" data-query-state="statistics">
               <td class="rank">1</td>
               <td class="mono">0.5 s</td>
               <td class="mono">13</td>
@@ -224,7 +244,7 @@
               <td class="mono">q_01e2bd8f360a932a</td>
               <td class="query-shape"><code>select c from sbtest8 where id=?</code></td>
             </tr>
-            <tr>
+            <tr data-query-text="update sbtest10 set k=k&#43;? where id=? q_5b3f6b87519c3deb" data-query-user="sysbench" data-query-db="test" data-query-state="updating">
               <td class="rank">2</td>
               <td class="mono">0.5 s</td>
               <td class="mono">4</td>
@@ -238,7 +258,7 @@
               <td class="mono">q_5b3f6b87519c3deb</td>
               <td class="query-shape"><code>update sbtest10 set k=k&#43;? where id=?</code></td>
             </tr>
-            <tr>
+            <tr data-query-text="select c from sbtest10 where id=? q_0726a22f6a25ecf4" data-query-user="sysbench" data-query-db="test" data-query-state="statistics">
               <td class="rank">3</td>
               <td class="mono">0.5 s</td>
               <td class="mono">11</td>
@@ -252,7 +272,7 @@
               <td class="mono">q_0726a22f6a25ecf4</td>
               <td class="query-shape"><code>select c from sbtest10 where id=?</code></td>
             </tr>
-            <tr>
+            <tr data-query-text="select c from sbtest9 where id=? q_430ecda45b54ecdc" data-query-user="sysbench" data-query-db="test" data-query-state="statistics">
               <td class="rank">4</td>
               <td class="mono">0.5 s</td>
               <td class="mono">13</td>
@@ -266,7 +286,7 @@
               <td class="mono">q_430ecda45b54ecdc</td>
               <td class="query-shape"><code>select c from sbtest9 where id=?</code></td>
             </tr>
-            <tr>
+            <tr data-query-text="select distinct c from sbtest8 where id between ? and ? order by c q_6836d7b7af3c5bdc" data-query-user="sysbench" data-query-db="test" data-query-state="statistics">
               <td class="rank">5</td>
               <td class="mono">0.5 s</td>
               <td class="mono">4</td>
@@ -280,7 +300,7 @@
               <td class="mono">q_6836d7b7af3c5bdc</td>
               <td class="query-shape"><code>select distinct c from sbtest8 where id between ? and ? order by c</code></td>
             </tr>
-            <tr>
+            <tr data-query-text="select c from sbtest1 where id between ? and ? order by c q_7e42bb16254a9180" data-query-user="sysbench" data-query-db="test" data-query-state="statistics">
               <td class="rank">6</td>
               <td class="mono">0.5 s</td>
               <td class="mono">3</td>
@@ -294,7 +314,7 @@
               <td class="mono">q_7e42bb16254a9180</td>
               <td class="query-shape"><code>select c from sbtest1 where id between ? and ? order by c</code></td>
             </tr>
-            <tr>
+            <tr data-query-text="select distinct c from sbtest4 where id between ? and ? order by c q_804e9698ae152b99" data-query-user="sysbench" data-query-db="test" data-query-state="statistics">
               <td class="rank">7</td>
               <td class="mono">0.5 s</td>
               <td class="mono">5</td>
@@ -308,7 +328,7 @@
               <td class="mono">q_804e9698ae152b99</td>
               <td class="query-shape"><code>select distinct c from sbtest4 where id between ? and ? order by c</code></td>
             </tr>
-            <tr>
+            <tr data-query-text="update sbtest4 set k=k&#43;? where id=? q_a93045c693d4d172" data-query-user="sysbench" data-query-db="test" data-query-state="updating">
               <td class="rank">8</td>
               <td class="mono">0.5 s</td>
               <td class="mono">8</td>
@@ -322,7 +342,7 @@
               <td class="mono">q_a93045c693d4d172</td>
               <td class="query-shape"><code>update sbtest4 set k=k&#43;? where id=?</code></td>
             </tr>
-            <tr>
+            <tr data-query-text="delete from sbtest10 where id=? q_dcd856f12e9bb8f0" data-query-user="sysbench" data-query-db="test" data-query-state="updating">
               <td class="rank">9</td>
               <td class="mono">0.5 s</td>
               <td class="mono">1</td>
@@ -336,7 +356,7 @@
               <td class="mono">q_dcd856f12e9bb8f0</td>
               <td class="query-shape"><code>delete from sbtest10 where id=?</code></td>
             </tr>
-            <tr>
+            <tr data-query-text="select c from sbtest10 where id between ? and ? order by c q_0f9d5cc9d50f9315" data-query-user="sysbench" data-query-db="test" data-query-state="statistics">
               <td class="rank">10</td>
               <td class="mono">0.5 s</td>
               <td class="mono">3</td>
@@ -353,7 +373,7 @@
           </tbody>
         </table>
       </div>
-    </section>
+    </details>
   </div>
 </details>
 


### PR DESCRIPTION
## Summary
- add spec-driven feature 006 for observed slowest processlist query detection
- parse and group active processlist query shapes with bounded snippets, fingerprints, seen counts, age, row metrics, and context from the slowest sighting
- render a Slowest observed queries table in the Processlist report and expose the same data in the embedded report payload

## Validation
- go test ./...
- git diff --check
- make build
- generated /tmp/report-CS0060148.html from the CS0060148 pt-stalk data and verified the new section appears with metadata-lock query rows

## Notes
This reports in-flight queries observed in pt-stalk processlist captures. It does not claim completed slow-query-log events unless those are present as active processlist rows during collection.