### PR TITLE
Add archive input support

### DIFF
--- a/.specify/feature.json
+++ b/.specify/feature.json
@@ -1,3 +1,3 @@
 {
-  "feature_directory": "specs/007-advisor-intelligence"
+  "feature_directory": "specs/008-archive-input"
 }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,20 +1,20 @@
 <!-- SPECKIT START -->
-Active feature: **007-advisor-intelligence**
+Active feature: **008-archive-input**
 
 For technologies, project structure, constitution gates, data model,
-package/UI contracts, and shell commands, read the current plan:
+CLI contracts, and shell commands, read the current plan:
 
-- Plan: `specs/007-advisor-intelligence/plan.md`
-- Spec: `specs/007-advisor-intelligence/spec.md`
-- Research: `specs/007-advisor-intelligence/research.md`
-- Data model: `specs/007-advisor-intelligence/data-model.md`
-- Contracts: `specs/007-advisor-intelligence/contracts/packages.md`,
-  `specs/007-advisor-intelligence/contracts/ui.md`
-- Quickstart: `specs/007-advisor-intelligence/quickstart.md`
-- Tasks: `specs/007-advisor-intelligence/tasks.md`
+- Plan: `specs/008-archive-input/plan.md`
+- Spec: `specs/008-archive-input/spec.md`
+- Research: `specs/008-archive-input/research.md`
+- Data model: `specs/008-archive-input/data-model.md`
+- Contracts: `specs/008-archive-input/contracts/cli.md`
+- Quickstart: `specs/008-archive-input/quickstart.md`
+- Tasks: `specs/008-archive-input/tasks.md`
 - Constitution: `.specify/memory/constitution.md`
 
 Prior features:
+- **007-advisor-intelligence** - `specs/007-advisor-intelligence/plan.md`
 - **006-observed-slowest-queries** - `specs/006-observed-slowest-queries/plan.md`
 - **005-richer-processlist-metrics** - `specs/005-richer-processlist-metrics/plan.md`
 - **003-feedback-backend-worker** - `specs/003-feedback-backend-worker/plan.md`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,20 +1,20 @@
 <!-- SPECKIT START -->
-Active feature: **007-advisor-intelligence**
+Active feature: **008-archive-input**
 
 For technologies, project structure, constitution gates, data model,
-package/UI contracts, and shell commands, read the current plan:
+CLI contracts, and shell commands, read the current plan:
 
-- Plan: `specs/007-advisor-intelligence/plan.md`
-- Spec: `specs/007-advisor-intelligence/spec.md`
-- Research: `specs/007-advisor-intelligence/research.md`
-- Data model: `specs/007-advisor-intelligence/data-model.md`
-- Contracts: `specs/007-advisor-intelligence/contracts/packages.md`,
-  `specs/007-advisor-intelligence/contracts/ui.md`
-- Quickstart: `specs/007-advisor-intelligence/quickstart.md`
-- Tasks: `specs/007-advisor-intelligence/tasks.md`
+- Plan: `specs/008-archive-input/plan.md`
+- Spec: `specs/008-archive-input/spec.md`
+- Research: `specs/008-archive-input/research.md`
+- Data model: `specs/008-archive-input/data-model.md`
+- Contracts: `specs/008-archive-input/contracts/cli.md`
+- Quickstart: `specs/008-archive-input/quickstart.md`
+- Tasks: `specs/008-archive-input/tasks.md`
 - Constitution: `.specify/memory/constitution.md`
 
 Prior features:
+- **007-advisor-intelligence** - `specs/007-advisor-intelligence/plan.md`
 - **006-observed-slowest-queries** - `specs/006-observed-slowest-queries/plan.md`
 - **005-richer-processlist-metrics** - `specs/005-richer-processlist-metrics/plan.md`
 - **003-feedback-backend-worker** - `specs/003-feedback-backend-worker/plan.md`

--- a/cmd/my-gather/archive_input.go
+++ b/cmd/my-gather/archive_input.go
@@ -19,6 +19,7 @@ import (
 )
 
 const maxArchiveExtractedBytes = parse.DefaultMaxCollectionBytes
+const maxArchiveFileBytes = parse.DefaultMaxFileBytes
 
 var errUnsupportedArchive = errors.New("unsupported archive format")
 
@@ -43,6 +44,25 @@ type unsafeArchivePathError struct {
 
 func (e *unsafeArchivePathError) Error() string {
 	return fmt.Sprintf("archive entry %q would extract outside the temporary directory", e.entry)
+}
+
+type archiveInputError struct {
+	path  string
+	entry string
+	err   error
+}
+
+func (e *archiveInputError) Error() string {
+	if e.entry != "" {
+		return fmt.Sprintf("archive %s entry %q: %v", e.path, e.entry, e.err)
+	}
+	return fmt.Sprintf("archive %s: %v", e.path, e.err)
+}
+
+func (e *archiveInputError) Unwrap() error { return e.err }
+
+func newArchiveInputError(path, entry string, err error) error {
+	return &archiveInputError{path: path, entry: entry, err: err}
 }
 
 type archiveFormat int
@@ -129,7 +149,7 @@ func extractArchive(archivePath, destDir string) error {
 		defer file.Close()
 		gz, err := gzip.NewReader(file)
 		if err != nil {
-			return fmt.Errorf("read gzip archive %s: %w", archivePath, err)
+			return newArchiveInputError(archivePath, "", err)
 		}
 		defer gz.Close()
 		return extractTarReader(tar.NewReader(gz), archivePath, destDir, &written)
@@ -143,16 +163,19 @@ func extractArchive(archivePath, destDir string) error {
 func extractZipArchive(archivePath, destDir string, written *int64) error {
 	reader, err := zip.OpenReader(archivePath)
 	if err != nil {
-		return fmt.Errorf("open zip archive %s: %w", archivePath, err)
+		return newArchiveInputError(archivePath, "", err)
 	}
 	defer reader.Close()
 
 	for _, entry := range reader.File {
-		target, err := safeArchiveTarget(destDir, entry.Name)
+		target, isRoot, err := safeArchiveTarget(destDir, entry.Name)
 		if err != nil {
 			return err
 		}
 		mode := entry.FileInfo().Mode()
+		if isRoot && !entry.FileInfo().IsDir() {
+			return newArchiveInputError(archivePath, entry.Name, errors.New("root archive entry must be a directory"))
+		}
 		if entry.FileInfo().IsDir() {
 			if err := os.MkdirAll(target, 0o755); err != nil {
 				return fmt.Errorf("create archive directory %s: %w", target, err)
@@ -160,21 +183,21 @@ func extractZipArchive(archivePath, destDir string, written *int64) error {
 			continue
 		}
 		if !mode.IsRegular() {
-			return fmt.Errorf("zip archive %s: unsupported non-regular entry %q", archivePath, entry.Name)
+			return newArchiveInputError(archivePath, entry.Name, errors.New("unsupported non-regular entry"))
 		}
 		if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
 			return fmt.Errorf("create archive parent %s: %w", filepath.Dir(target), err)
 		}
 		src, err := entry.Open()
 		if err != nil {
-			return fmt.Errorf("open zip entry %q: %w", entry.Name, err)
+			return newArchiveInputError(archivePath, entry.Name, err)
 		}
 		if err := writeExtractedFile(target, mode.Perm(), src, written); err != nil {
 			_ = src.Close()
 			return err
 		}
 		if err := src.Close(); err != nil {
-			return fmt.Errorf("close zip entry %q: %w", entry.Name, err)
+			return newArchiveInputError(archivePath, entry.Name, err)
 		}
 	}
 	return nil
@@ -187,9 +210,9 @@ func extractTarReader(reader *tar.Reader, archivePath, destDir string, written *
 			return nil
 		}
 		if err != nil {
-			return fmt.Errorf("read tar archive %s: %w", archivePath, err)
+			return newArchiveInputError(archivePath, "", err)
 		}
-		target, err := safeArchiveTarget(destDir, header.Name)
+		target, isRoot, err := safeArchiveTarget(destDir, header.Name)
 		if err != nil {
 			return err
 		}
@@ -199,6 +222,9 @@ func extractTarReader(reader *tar.Reader, archivePath, destDir string, written *
 				return fmt.Errorf("create archive directory %s: %w", target, err)
 			}
 		case tar.TypeReg, tar.TypeRegA:
+			if isRoot {
+				return newArchiveInputError(archivePath, header.Name, errors.New("root archive entry must be a directory"))
+			}
 			if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
 				return fmt.Errorf("create archive parent %s: %w", filepath.Dir(target), err)
 			}
@@ -208,7 +234,7 @@ func extractTarReader(reader *tar.Reader, archivePath, destDir string, written *
 		case tar.TypeXGlobalHeader, tar.TypeXHeader:
 			continue
 		default:
-			return fmt.Errorf("tar archive %s: unsupported non-regular entry %q", archivePath, header.Name)
+			return newArchiveInputError(archivePath, header.Name, errors.New("unsupported non-regular entry"))
 		}
 	}
 }
@@ -222,7 +248,7 @@ func extractGzipArchive(archivePath, destDir string, written *int64) error {
 
 	gz, err := gzip.NewReader(file)
 	if err != nil {
-		return fmt.Errorf("read gzip archive %s: %w", archivePath, err)
+		return newArchiveInputError(archivePath, "", err)
 	}
 	defer gz.Close()
 
@@ -235,7 +261,7 @@ func extractGzipArchive(archivePath, destDir string, written *int64) error {
 	if name == "" || name == "." {
 		name = "decompressed"
 	}
-	target, err := safeArchiveTarget(destDir, name)
+	target, _, err := safeArchiveTarget(destDir, name)
 	if err != nil {
 		return err
 	}
@@ -252,21 +278,31 @@ func looksLikeTarHeader(block []byte) bool {
 	return bytes.HasPrefix(block[257:], []byte("ustar"))
 }
 
-func safeArchiveTarget(destDir, entryName string) (string, error) {
+func safeArchiveTarget(destDir, entryName string) (string, bool, error) {
 	entryName = strings.ReplaceAll(entryName, "\\", "/")
+	if entryName == "" {
+		return "", false, &unsafeArchivePathError{entry: entryName}
+	}
 	clean := filepath.Clean(filepath.FromSlash(entryName))
-	if clean == "." || clean == "" || filepath.IsAbs(clean) || clean == ".." || strings.HasPrefix(clean, ".."+string(filepath.Separator)) {
-		return "", &unsafeArchivePathError{entry: entryName}
+	if clean == "." {
+		return destDir, true, nil
+	}
+	if filepath.IsAbs(clean) || clean == ".." || strings.HasPrefix(clean, ".."+string(filepath.Separator)) {
+		return "", false, &unsafeArchivePathError{entry: entryName}
 	}
 	target := filepath.Join(destDir, clean)
 	rel, err := filepath.Rel(destDir, target)
 	if err != nil || filepath.IsAbs(rel) || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
-		return "", &unsafeArchivePathError{entry: entryName}
+		return "", false, &unsafeArchivePathError{entry: entryName}
 	}
-	return target, nil
+	return target, false, nil
 }
 
 func writeExtractedFile(target string, mode os.FileMode, src io.Reader, written *int64) error {
+	return writeExtractedFileWithLimits(target, mode, src, written, maxArchiveExtractedBytes, maxArchiveFileBytes)
+}
+
+func writeExtractedFileWithLimits(target string, mode os.FileMode, src io.Reader, written *int64, maxTotal, maxFile int64) error {
 	perm := mode.Perm()
 	if perm == 0 {
 		perm = 0o600
@@ -277,18 +313,30 @@ func writeExtractedFile(target string, mode os.FileMode, src io.Reader, written 
 	}
 	defer file.Close()
 
-	remaining := maxArchiveExtractedBytes - *written
+	remaining := maxTotal - *written
 	if remaining < 0 {
 		remaining = 0
 	}
-	n, err := io.Copy(file, io.LimitReader(src, remaining+1))
+	limit := maxFile
+	if remaining < limit {
+		limit = remaining
+	}
+	n, err := io.Copy(file, io.LimitReader(src, limit+1))
 	*written += n
-	if *written > maxArchiveExtractedBytes {
+	if n > maxFile {
+		return &parse.SizeError{
+			Kind:  parse.SizeErrorFile,
+			Path:  target,
+			Bytes: n,
+			Limit: maxFile,
+		}
+	}
+	if *written > maxTotal {
 		return &parse.SizeError{
 			Kind:  parse.SizeErrorTotal,
 			Path:  target,
 			Bytes: *written,
-			Limit: maxArchiveExtractedBytes,
+			Limit: maxTotal,
 		}
 	}
 	if err != nil {

--- a/cmd/my-gather/archive_input.go
+++ b/cmd/my-gather/archive_input.go
@@ -268,7 +268,14 @@ func extractGzipArchive(archivePath, destDir string, written *int64) error {
 	if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
 		return fmt.Errorf("create archive parent %s: %w", filepath.Dir(target), err)
 	}
-	return writeExtractedFile(target, 0o600, buffered, written)
+	if err := writeExtractedFile(target, 0o600, buffered, written); err != nil {
+		var sizeErr *parse.SizeError
+		if errors.As(err, &sizeErr) {
+			return err
+		}
+		return newArchiveInputError(archivePath, name, err)
+	}
+	return nil
 }
 
 func looksLikeTarHeader(block []byte) bool {

--- a/cmd/my-gather/archive_input.go
+++ b/cmd/my-gather/archive_input.go
@@ -1,0 +1,332 @@
+package main
+
+import (
+	"archive/tar"
+	"archive/zip"
+	"bufio"
+	"bytes"
+	"compress/gzip"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/matias-sanchez/My-gather/parse"
+)
+
+const maxArchiveExtractedBytes = parse.DefaultMaxCollectionBytes
+
+var errUnsupportedArchive = errors.New("unsupported archive format")
+
+type preparedInput struct {
+	parseDir  string
+	tempDir   string
+	isArchive bool
+	cleanup   func()
+}
+
+type multiplePtStalkRootsError struct {
+	roots []string
+}
+
+func (e *multiplePtStalkRootsError) Error() string {
+	return fmt.Sprintf("archive contains multiple pt-stalk collections: %s", strings.Join(e.roots, ", "))
+}
+
+type unsafeArchivePathError struct {
+	entry string
+}
+
+func (e *unsafeArchivePathError) Error() string {
+	return fmt.Sprintf("archive entry %q would extract outside the temporary directory", e.entry)
+}
+
+type archiveFormat int
+
+const (
+	archiveUnsupported archiveFormat = iota
+	archiveZip
+	archiveTar
+	archiveTarGzip
+	archiveGzip
+)
+
+func prepareInput(ctx context.Context, inputPath string) (*preparedInput, error) {
+	info, err := os.Stat(inputPath)
+	if err != nil {
+		return nil, &parse.PathError{Op: "stat", Path: inputPath, Err: err}
+	}
+	if info.IsDir() {
+		return &preparedInput{parseDir: inputPath, cleanup: func() {}}, nil
+	}
+	if !info.Mode().IsRegular() {
+		return nil, &parse.PathError{Op: "stat", Path: inputPath, Err: errors.New("not a directory or regular archive file")}
+	}
+	if archiveKind(inputPath) == archiveUnsupported {
+		return nil, fmt.Errorf("%w: %s", errUnsupportedArchive, inputPath)
+	}
+
+	tempDir, err := os.MkdirTemp("", "my-gather-input-*")
+	if err != nil {
+		return nil, fmt.Errorf("create extraction temp dir: %w", err)
+	}
+	cleanup := func() { _ = os.RemoveAll(tempDir) }
+
+	if err := extractArchive(inputPath, tempDir); err != nil {
+		cleanup()
+		return nil, err
+	}
+	root, err := findExtractedPtStalkRoot(ctx, tempDir)
+	if err != nil {
+		cleanup()
+		return nil, err
+	}
+	return &preparedInput{
+		parseDir:  root,
+		tempDir:   tempDir,
+		isArchive: true,
+		cleanup:   cleanup,
+	}, nil
+}
+
+func archiveKind(path string) archiveFormat {
+	lower := strings.ToLower(path)
+	switch {
+	case strings.HasSuffix(lower, ".zip"):
+		return archiveZip
+	case strings.HasSuffix(lower, ".tar"):
+		return archiveTar
+	case strings.HasSuffix(lower, ".tar.gz"), strings.HasSuffix(lower, ".tgz"):
+		return archiveTarGzip
+	case strings.HasSuffix(lower, ".gz"):
+		return archiveGzip
+	default:
+		return archiveUnsupported
+	}
+}
+
+func extractArchive(archivePath, destDir string) error {
+	var written int64
+	switch archiveKind(archivePath) {
+	case archiveZip:
+		return extractZipArchive(archivePath, destDir, &written)
+	case archiveTar:
+		file, err := os.Open(archivePath)
+		if err != nil {
+			return &parse.PathError{Op: "open", Path: archivePath, Err: err}
+		}
+		defer file.Close()
+		return extractTarReader(tar.NewReader(file), archivePath, destDir, &written)
+	case archiveTarGzip:
+		file, err := os.Open(archivePath)
+		if err != nil {
+			return &parse.PathError{Op: "open", Path: archivePath, Err: err}
+		}
+		defer file.Close()
+		gz, err := gzip.NewReader(file)
+		if err != nil {
+			return fmt.Errorf("read gzip archive %s: %w", archivePath, err)
+		}
+		defer gz.Close()
+		return extractTarReader(tar.NewReader(gz), archivePath, destDir, &written)
+	case archiveGzip:
+		return extractGzipArchive(archivePath, destDir, &written)
+	default:
+		return fmt.Errorf("%w: %s", errUnsupportedArchive, archivePath)
+	}
+}
+
+func extractZipArchive(archivePath, destDir string, written *int64) error {
+	reader, err := zip.OpenReader(archivePath)
+	if err != nil {
+		return fmt.Errorf("open zip archive %s: %w", archivePath, err)
+	}
+	defer reader.Close()
+
+	for _, entry := range reader.File {
+		target, err := safeArchiveTarget(destDir, entry.Name)
+		if err != nil {
+			return err
+		}
+		mode := entry.FileInfo().Mode()
+		if entry.FileInfo().IsDir() {
+			if err := os.MkdirAll(target, 0o755); err != nil {
+				return fmt.Errorf("create archive directory %s: %w", target, err)
+			}
+			continue
+		}
+		if !mode.IsRegular() {
+			return fmt.Errorf("zip archive %s: unsupported non-regular entry %q", archivePath, entry.Name)
+		}
+		if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
+			return fmt.Errorf("create archive parent %s: %w", filepath.Dir(target), err)
+		}
+		src, err := entry.Open()
+		if err != nil {
+			return fmt.Errorf("open zip entry %q: %w", entry.Name, err)
+		}
+		if err := writeExtractedFile(target, mode.Perm(), src, written); err != nil {
+			_ = src.Close()
+			return err
+		}
+		if err := src.Close(); err != nil {
+			return fmt.Errorf("close zip entry %q: %w", entry.Name, err)
+		}
+	}
+	return nil
+}
+
+func extractTarReader(reader *tar.Reader, archivePath, destDir string, written *int64) error {
+	for {
+		header, err := reader.Next()
+		if errors.Is(err, io.EOF) {
+			return nil
+		}
+		if err != nil {
+			return fmt.Errorf("read tar archive %s: %w", archivePath, err)
+		}
+		target, err := safeArchiveTarget(destDir, header.Name)
+		if err != nil {
+			return err
+		}
+		switch header.Typeflag {
+		case tar.TypeDir:
+			if err := os.MkdirAll(target, 0o755); err != nil {
+				return fmt.Errorf("create archive directory %s: %w", target, err)
+			}
+		case tar.TypeReg, tar.TypeRegA:
+			if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
+				return fmt.Errorf("create archive parent %s: %w", filepath.Dir(target), err)
+			}
+			if err := writeExtractedFile(target, os.FileMode(header.Mode).Perm(), reader, written); err != nil {
+				return err
+			}
+		case tar.TypeXGlobalHeader, tar.TypeXHeader:
+			continue
+		default:
+			return fmt.Errorf("tar archive %s: unsupported non-regular entry %q", archivePath, header.Name)
+		}
+	}
+}
+
+func extractGzipArchive(archivePath, destDir string, written *int64) error {
+	file, err := os.Open(archivePath)
+	if err != nil {
+		return &parse.PathError{Op: "open", Path: archivePath, Err: err}
+	}
+	defer file.Close()
+
+	gz, err := gzip.NewReader(file)
+	if err != nil {
+		return fmt.Errorf("read gzip archive %s: %w", archivePath, err)
+	}
+	defer gz.Close()
+
+	buffered := bufio.NewReader(gz)
+	if block, err := buffered.Peek(512); err == nil && looksLikeTarHeader(block) {
+		return extractTarReader(tar.NewReader(buffered), archivePath, destDir, written)
+	}
+
+	name := strings.TrimSuffix(filepath.Base(archivePath), filepath.Ext(archivePath))
+	if name == "" || name == "." {
+		name = "decompressed"
+	}
+	target, err := safeArchiveTarget(destDir, name)
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
+		return fmt.Errorf("create archive parent %s: %w", filepath.Dir(target), err)
+	}
+	return writeExtractedFile(target, 0o600, buffered, written)
+}
+
+func looksLikeTarHeader(block []byte) bool {
+	if len(block) < 265 {
+		return false
+	}
+	return bytes.HasPrefix(block[257:], []byte("ustar"))
+}
+
+func safeArchiveTarget(destDir, entryName string) (string, error) {
+	entryName = strings.ReplaceAll(entryName, "\\", "/")
+	clean := filepath.Clean(filepath.FromSlash(entryName))
+	if clean == "." || clean == "" || filepath.IsAbs(clean) || clean == ".." || strings.HasPrefix(clean, ".."+string(filepath.Separator)) {
+		return "", &unsafeArchivePathError{entry: entryName}
+	}
+	target := filepath.Join(destDir, clean)
+	rel, err := filepath.Rel(destDir, target)
+	if err != nil || filepath.IsAbs(rel) || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+		return "", &unsafeArchivePathError{entry: entryName}
+	}
+	return target, nil
+}
+
+func writeExtractedFile(target string, mode os.FileMode, src io.Reader, written *int64) error {
+	perm := mode.Perm()
+	if perm == 0 {
+		perm = 0o600
+	}
+	file, err := os.OpenFile(target, os.O_WRONLY|os.O_CREATE|os.O_EXCL, perm)
+	if err != nil {
+		return fmt.Errorf("create extracted file %s: %w", target, err)
+	}
+	defer file.Close()
+
+	remaining := maxArchiveExtractedBytes - *written
+	if remaining < 0 {
+		remaining = 0
+	}
+	n, err := io.Copy(file, io.LimitReader(src, remaining+1))
+	*written += n
+	if *written > maxArchiveExtractedBytes {
+		return &parse.SizeError{
+			Kind:  parse.SizeErrorTotal,
+			Path:  target,
+			Bytes: *written,
+			Limit: maxArchiveExtractedBytes,
+		}
+	}
+	if err != nil {
+		return fmt.Errorf("write extracted file %s: %w", target, err)
+	}
+	return nil
+}
+
+func findExtractedPtStalkRoot(ctx context.Context, tempDir string) (string, error) {
+	var roots []string
+	err := filepath.WalkDir(tempDir, func(path string, entry os.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		if !entry.IsDir() {
+			return nil
+		}
+		ok, err := parse.LooksLikePtStalkRoot(path)
+		if err != nil {
+			return err
+		}
+		if ok {
+			roots = append(roots, path)
+		}
+		return nil
+	})
+	if err != nil {
+		return "", err
+	}
+	if len(roots) == 0 {
+		return "", parse.ErrNotAPtStalkDir
+	}
+	sort.Strings(roots)
+	if len(roots) > 1 {
+		return "", &multiplePtStalkRootsError{roots: roots}
+	}
+	return roots[0], nil
+}

--- a/cmd/my-gather/main.go
+++ b/cmd/my-gather/main.go
@@ -195,6 +195,11 @@ func mapInputPreparationError(err error, inputPath string, stderr io.Writer) int
 		fmt.Fprintf(stderr, "my-gather: unsafe archive %s: %v\n", inputPath, unsafe)
 		return exitInputPath
 	}
+	var archiveInput *archiveInputError
+	if errors.As(err, &archiveInput) {
+		fmt.Fprintf(stderr, "my-gather: invalid archive input: %v\n", archiveInput)
+		return exitInputPath
+	}
 	var multiple *multiplePtStalkRootsError
 	if errors.As(err, &multiple) {
 		fmt.Fprintf(stderr, "my-gather: %s is not a single pt-stalk collection: %v\n", inputPath, multiple)

--- a/cmd/my-gather/main.go
+++ b/cmd/my-gather/main.go
@@ -88,15 +88,15 @@ func run(args []string, stdout, stderr io.Writer) int {
 
 	rest := fs.Args()
 	if len(rest) == 0 {
-		fmt.Fprintln(stderr, "my-gather: missing required <input-dir>")
+		fmt.Fprintln(stderr, "my-gather: missing required <input>")
 		fmt.Fprint(stderr, "See 'my-gather --help'.\n")
 		return exitUsage
 	}
 	if len(rest) > 1 {
-		fmt.Fprintf(stderr, "my-gather: expected exactly one <input-dir>, got %d\n", len(rest))
+		fmt.Fprintf(stderr, "my-gather: expected exactly one <input>, got %d\n", len(rest))
 		return exitUsage
 	}
-	inputDir := rest[0]
+	inputPath := rest[0]
 	if outPath == "" {
 		cwd, err := os.Getwd()
 		if err != nil {
@@ -106,7 +106,7 @@ func run(args []string, stdout, stderr io.Writer) int {
 		outPath = filepath.Join(cwd, "report.html")
 	}
 
-	absInput, err := filepath.Abs(inputDir)
+	absInput, err := filepath.Abs(inputPath)
 	if err != nil {
 		fmt.Fprintf(stderr, "my-gather: input path: %v\n", err)
 		return exitInputPath
@@ -145,10 +145,18 @@ func run(args []string, stdout, stderr io.Writer) int {
 	sink := &stderrSink{w: stderr}
 
 	ctx := context.Background()
-	if verbose {
-		fmt.Fprintf(stderr, "[parse] reading %s\n", absInput)
+	prepared, err := prepareInput(ctx, absInput)
+	if err != nil {
+		return mapInputPreparationError(err, absInput, stderr)
 	}
-	collection, err := parse.Discover(ctx, absInput, parse.DiscoverOptions{Sink: sink})
+	defer prepared.cleanup()
+	if verbose && prepared.isArchive {
+		fmt.Fprintf(stderr, "[input] extracted %s to %s; using %s\n", absInput, prepared.tempDir, prepared.parseDir)
+	}
+	if verbose {
+		fmt.Fprintf(stderr, "[parse] reading %s\n", prepared.parseDir)
+	}
+	collection, err := parse.Discover(ctx, prepared.parseDir, parse.DiscoverOptions{Sink: sink})
 	if err != nil {
 		return mapDiscoverError(err, absInput, stderr)
 	}
@@ -175,6 +183,24 @@ func run(args []string, stdout, stderr io.Writer) int {
 		}
 	}
 	return exitOK
+}
+
+func mapInputPreparationError(err error, inputPath string, stderr io.Writer) int {
+	if errors.Is(err, errUnsupportedArchive) {
+		fmt.Fprintf(stderr, "my-gather: %s is not a supported input archive; supported archives: .zip, .tar, .tar.gz, .tgz, .gz\n", inputPath)
+		return exitInputPath
+	}
+	var unsafe *unsafeArchivePathError
+	if errors.As(err, &unsafe) {
+		fmt.Fprintf(stderr, "my-gather: unsafe archive %s: %v\n", inputPath, unsafe)
+		return exitInputPath
+	}
+	var multiple *multiplePtStalkRootsError
+	if errors.As(err, &multiple) {
+		fmt.Fprintf(stderr, "my-gather: %s is not a single pt-stalk collection: %v\n", inputPath, multiple)
+		return exitNotAPtStalkDir
+	}
+	return mapDiscoverError(err, inputPath, stderr)
 }
 
 // mapDiscoverError converts a parse.Discover error into the correct
@@ -325,10 +351,11 @@ func pathIsUnder(child, parent string) bool {
 const usageText = `my-gather — self-contained HTML reports for pt-stalk collections
 
 USAGE
-  my-gather [flags] <input-dir>
+  my-gather [flags] <input>
 
 ARGUMENTS
-  <input-dir>    Path to a pt-stalk output directory (required).
+  <input>    Path to a pt-stalk output directory or supported archive
+             (.zip, .tar, .tar.gz, .tgz, .gz).
 
 FLAGS
   -o, --out <path>    Output HTML file path (default: ./report.html).

--- a/cmd/my-gather/main_test.go
+++ b/cmd/my-gather/main_test.go
@@ -212,6 +212,21 @@ func TestRunMapsInvalidZipToInputPathError(t *testing.T) {
 	}
 }
 
+func TestRunMapsCorruptGzipPayloadToInputPathError(t *testing.T) {
+	dir := t.TempDir()
+	archivePath := filepath.Join(dir, "broken.gz")
+	writeTruncatedGzip(t, archivePath)
+
+	var stdout, stderr bytes.Buffer
+	code := run([]string{"--overwrite", "-o", filepath.Join(dir, "report.html"), archivePath}, &stdout, &stderr)
+	if code != exitInputPath {
+		t.Fatalf("run exit = %d, want %d\nstderr:\n%s", code, exitInputPath, stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "invalid archive input") {
+		t.Fatalf("stderr = %q, want invalid archive input message", stderr.String())
+	}
+}
+
 func TestWriteExtractedFileEnforcesPerFileLimit(t *testing.T) {
 	dir := t.TempDir()
 	target := filepath.Join(dir, "large")
@@ -371,5 +386,24 @@ func copyFileToWriter(t *testing.T, srcPath string, writer io.Writer) {
 	defer src.Close()
 	if _, err := io.Copy(writer, src); err != nil {
 		t.Fatalf("copy fixture %s: %v", srcPath, err)
+	}
+}
+
+func writeTruncatedGzip(t *testing.T, path string) {
+	t.Helper()
+	var buf bytes.Buffer
+	gz := gzip.NewWriter(&buf)
+	if _, err := gz.Write([]byte("truncated payload")); err != nil {
+		t.Fatalf("write gzip payload: %v", err)
+	}
+	if err := gz.Close(); err != nil {
+		t.Fatalf("close gzip: %v", err)
+	}
+	data := buf.Bytes()
+	if len(data) < 8 {
+		t.Fatalf("gzip fixture too small: %d bytes", len(data))
+	}
+	if err := os.WriteFile(path, data[:len(data)-4], 0o600); err != nil {
+		t.Fatalf("write truncated gzip: %v", err)
 	}
 }

--- a/cmd/my-gather/main_test.go
+++ b/cmd/my-gather/main_test.go
@@ -1,9 +1,15 @@
 package main
 
 import (
+	"archive/tar"
+	"archive/zip"
+	"bytes"
+	"compress/gzip"
 	"errors"
+	"io"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -83,5 +89,225 @@ func TestInstallRenderedFileOverwritesWhenRequested(t *testing.T) {
 	}
 	if string(got) != "new report" {
 		t.Fatalf("output content = %q, want new report", got)
+	}
+}
+
+func TestRunAcceptsZipArchiveInput(t *testing.T) {
+	dir := t.TempDir()
+	archivePath := filepath.Join(dir, "capture.zip")
+	writeZipFixture(t, archivePath, "nested/pt-stalk")
+	outPath := filepath.Join(dir, "report.html")
+
+	var stdout, stderr bytes.Buffer
+	code := run([]string{"--overwrite", "-o", outPath, archivePath}, &stdout, &stderr)
+	if code != exitOK {
+		t.Fatalf("run exit = %d, want %d\nstderr:\n%s", code, exitOK, stderr.String())
+	}
+	if st, err := os.Stat(outPath); err != nil || st.Size() == 0 {
+		t.Fatalf("output stat = (%v, %v), want non-empty report", st, err)
+	}
+}
+
+func TestRunAcceptsTarGzipArchiveInput(t *testing.T) {
+	dir := t.TempDir()
+	archivePath := filepath.Join(dir, "capture.tar.gz")
+	writeTarGzipFixture(t, archivePath, "pt-stalk")
+	outPath := filepath.Join(dir, "report.html")
+
+	var stdout, stderr bytes.Buffer
+	code := run([]string{"--overwrite", "-o", outPath, archivePath}, &stdout, &stderr)
+	if code != exitOK {
+		t.Fatalf("run exit = %d, want %d\nstderr:\n%s", code, exitOK, stderr.String())
+	}
+	if st, err := os.Stat(outPath); err != nil || st.Size() == 0 {
+		t.Fatalf("output stat = (%v, %v), want non-empty report", st, err)
+	}
+}
+
+func TestRunAcceptsGzipArchiveContainingTarStream(t *testing.T) {
+	dir := t.TempDir()
+	archivePath := filepath.Join(dir, "capture.tar_abc123.gz")
+	writeTarGzipFixture(t, archivePath, "pt-stalk")
+	outPath := filepath.Join(dir, "report.html")
+
+	var stdout, stderr bytes.Buffer
+	code := run([]string{"--overwrite", "-o", outPath, archivePath}, &stdout, &stderr)
+	if code != exitOK {
+		t.Fatalf("run exit = %d, want %d\nstderr:\n%s", code, exitOK, stderr.String())
+	}
+	if st, err := os.Stat(outPath); err != nil || st.Size() == 0 {
+		t.Fatalf("output stat = (%v, %v), want non-empty report", st, err)
+	}
+}
+
+func TestRunRejectsArchivePathTraversal(t *testing.T) {
+	dir := t.TempDir()
+	archivePath := filepath.Join(dir, "bad.zip")
+	file, err := os.Create(archivePath)
+	if err != nil {
+		t.Fatalf("create archive: %v", err)
+	}
+	zw := zip.NewWriter(file)
+	entry, err := zw.Create("../escape")
+	if err != nil {
+		t.Fatalf("create zip entry: %v", err)
+	}
+	if _, err := entry.Write([]byte("bad")); err != nil {
+		t.Fatalf("write zip entry: %v", err)
+	}
+	if err := zw.Close(); err != nil {
+		t.Fatalf("close zip: %v", err)
+	}
+	if err := file.Close(); err != nil {
+		t.Fatalf("close archive: %v", err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	code := run([]string{"--overwrite", "-o", filepath.Join(dir, "report.html"), archivePath}, &stdout, &stderr)
+	if code != exitInputPath {
+		t.Fatalf("run exit = %d, want %d\nstderr:\n%s", code, exitInputPath, stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "unsafe archive") {
+		t.Fatalf("stderr = %q, want unsafe archive message", stderr.String())
+	}
+	if _, err := os.Stat(filepath.Join(dir, "escape")); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("path traversal created file, stat err = %v", err)
+	}
+}
+
+func TestRunRejectsArchiveWithMultiplePtStalkRoots(t *testing.T) {
+	dir := t.TempDir()
+	archivePath := filepath.Join(dir, "multi.zip")
+	file, err := os.Create(archivePath)
+	if err != nil {
+		t.Fatalf("create archive: %v", err)
+	}
+	zw := zip.NewWriter(file)
+	for _, name := range []string{
+		"a/2026_04_21_16_51_41-top",
+		"b/2026_04_21_16_51_41-top",
+	} {
+		entry, err := zw.Create(name)
+		if err != nil {
+			t.Fatalf("create zip entry %s: %v", name, err)
+		}
+		if _, err := entry.Write([]byte("TS 1776790303.009325313 2026-04-21 16:51:43\n")); err != nil {
+			t.Fatalf("write zip entry %s: %v", name, err)
+		}
+	}
+	if err := zw.Close(); err != nil {
+		t.Fatalf("close zip: %v", err)
+	}
+	if err := file.Close(); err != nil {
+		t.Fatalf("close archive: %v", err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	code := run([]string{"--overwrite", "-o", filepath.Join(dir, "report.html"), archivePath}, &stdout, &stderr)
+	if code != exitNotAPtStalkDir {
+		t.Fatalf("run exit = %d, want %d\nstderr:\n%s", code, exitNotAPtStalkDir, stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "multiple pt-stalk collections") {
+		t.Fatalf("stderr = %q, want multiple-root message", stderr.String())
+	}
+}
+
+func writeZipFixture(t *testing.T, archivePath, prefix string) {
+	t.Helper()
+	file, err := os.Create(archivePath)
+	if err != nil {
+		t.Fatalf("create zip: %v", err)
+	}
+	defer file.Close()
+
+	zw := zip.NewWriter(file)
+	defer func() {
+		if err := zw.Close(); err != nil {
+			t.Fatalf("close zip: %v", err)
+		}
+	}()
+	walkFixture(t, func(srcPath, rel string, info os.FileInfo) {
+		if info.IsDir() {
+			return
+		}
+		header, err := zip.FileInfoHeader(info)
+		if err != nil {
+			t.Fatalf("zip header %s: %v", rel, err)
+		}
+		header.Name = filepath.ToSlash(filepath.Join(prefix, rel))
+		writer, err := zw.CreateHeader(header)
+		if err != nil {
+			t.Fatalf("zip create %s: %v", rel, err)
+		}
+		copyFileToWriter(t, srcPath, writer)
+	})
+}
+
+func writeTarGzipFixture(t *testing.T, archivePath, prefix string) {
+	t.Helper()
+	file, err := os.Create(archivePath)
+	if err != nil {
+		t.Fatalf("create tar.gz: %v", err)
+	}
+	defer file.Close()
+	gz := gzip.NewWriter(file)
+	defer func() {
+		if err := gz.Close(); err != nil {
+			t.Fatalf("close gzip: %v", err)
+		}
+	}()
+	tw := tar.NewWriter(gz)
+	defer func() {
+		if err := tw.Close(); err != nil {
+			t.Fatalf("close tar: %v", err)
+		}
+	}()
+	walkFixture(t, func(srcPath, rel string, info os.FileInfo) {
+		if info.IsDir() {
+			return
+		}
+		header, err := tar.FileInfoHeader(info, "")
+		if err != nil {
+			t.Fatalf("tar header %s: %v", rel, err)
+		}
+		header.Name = filepath.ToSlash(filepath.Join(prefix, rel))
+		if err := tw.WriteHeader(header); err != nil {
+			t.Fatalf("tar write header %s: %v", rel, err)
+		}
+		copyFileToWriter(t, srcPath, tw)
+	})
+}
+
+func walkFixture(t *testing.T, visit func(srcPath, rel string, info os.FileInfo)) {
+	t.Helper()
+	root := filepath.Join("..", "..", "testdata", "example2")
+	err := filepath.Walk(root, func(path string, info os.FileInfo, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		rel, err := filepath.Rel(root, path)
+		if err != nil {
+			return err
+		}
+		if rel == "." {
+			return nil
+		}
+		visit(path, rel, info)
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walk fixture: %v", err)
+	}
+}
+
+func copyFileToWriter(t *testing.T, srcPath string, writer io.Writer) {
+	t.Helper()
+	src, err := os.Open(srcPath)
+	if err != nil {
+		t.Fatalf("open fixture %s: %v", srcPath, err)
+	}
+	defer src.Close()
+	if _, err := io.Copy(writer, src); err != nil {
+		t.Fatalf("copy fixture %s: %v", srcPath, err)
 	}
 }

--- a/cmd/my-gather/main_test.go
+++ b/cmd/my-gather/main_test.go
@@ -11,6 +11,8 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/matias-sanchez/My-gather/parse"
 )
 
 func TestInstallRenderedFileDoesNotOverwriteExistingOutput(t *testing.T) {
@@ -142,6 +144,8 @@ func TestRunAcceptsGzipArchiveContainingTarStream(t *testing.T) {
 
 func TestRunRejectsArchivePathTraversal(t *testing.T) {
 	dir := t.TempDir()
+	t.Setenv("TMPDIR", dir)
+	t.Setenv("TEMP", dir)
 	archivePath := filepath.Join(dir, "bad.zip")
 	file, err := os.Create(archivePath)
 	if err != nil {
@@ -172,6 +176,54 @@ func TestRunRejectsArchivePathTraversal(t *testing.T) {
 	}
 	if _, err := os.Stat(filepath.Join(dir, "escape")); !errors.Is(err, os.ErrNotExist) {
 		t.Fatalf("path traversal created file, stat err = %v", err)
+	}
+}
+
+func TestRunAcceptsTarArchiveWithRootDirectoryEntry(t *testing.T) {
+	dir := t.TempDir()
+	archivePath := filepath.Join(dir, "capture.tar.gz")
+	writeTarGzipFixtureWithOptions(t, archivePath, "pt-stalk", true)
+	outPath := filepath.Join(dir, "report.html")
+
+	var stdout, stderr bytes.Buffer
+	code := run([]string{"--overwrite", "-o", outPath, archivePath}, &stdout, &stderr)
+	if code != exitOK {
+		t.Fatalf("run exit = %d, want %d\nstderr:\n%s", code, exitOK, stderr.String())
+	}
+	if st, err := os.Stat(outPath); err != nil || st.Size() == 0 {
+		t.Fatalf("output stat = (%v, %v), want non-empty report", st, err)
+	}
+}
+
+func TestRunMapsInvalidZipToInputPathError(t *testing.T) {
+	dir := t.TempDir()
+	archivePath := filepath.Join(dir, "broken.zip")
+	if err := os.WriteFile(archivePath, []byte("not a zip"), 0o600); err != nil {
+		t.Fatalf("write broken zip: %v", err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	code := run([]string{"--overwrite", "-o", filepath.Join(dir, "report.html"), archivePath}, &stdout, &stderr)
+	if code != exitInputPath {
+		t.Fatalf("run exit = %d, want %d\nstderr:\n%s", code, exitInputPath, stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "invalid archive input") {
+		t.Fatalf("stderr = %q, want invalid archive input message", stderr.String())
+	}
+}
+
+func TestWriteExtractedFileEnforcesPerFileLimit(t *testing.T) {
+	dir := t.TempDir()
+	target := filepath.Join(dir, "large")
+	var written int64
+
+	err := writeExtractedFileWithLimits(target, 0o600, strings.NewReader("abcdef"), &written, 100, 5)
+	var sizeErr *parse.SizeError
+	if !errors.As(err, &sizeErr) {
+		t.Fatalf("error = %v, want parse.SizeError", err)
+	}
+	if sizeErr.Kind != parse.SizeErrorFile {
+		t.Fatalf("size error kind = %v, want %v", sizeErr.Kind, parse.SizeErrorFile)
 	}
 }
 
@@ -245,6 +297,11 @@ func writeZipFixture(t *testing.T, archivePath, prefix string) {
 
 func writeTarGzipFixture(t *testing.T, archivePath, prefix string) {
 	t.Helper()
+	writeTarGzipFixtureWithOptions(t, archivePath, prefix, false)
+}
+
+func writeTarGzipFixtureWithOptions(t *testing.T, archivePath, prefix string, includeRootDir bool) {
+	t.Helper()
 	file, err := os.Create(archivePath)
 	if err != nil {
 		t.Fatalf("create tar.gz: %v", err)
@@ -262,6 +319,11 @@ func writeTarGzipFixture(t *testing.T, archivePath, prefix string) {
 			t.Fatalf("close tar: %v", err)
 		}
 	}()
+	if includeRootDir {
+		if err := tw.WriteHeader(&tar.Header{Name: "./", Mode: 0o755, Typeflag: tar.TypeDir}); err != nil {
+			t.Fatalf("tar write root header: %v", err)
+		}
+	}
 	walkFixture(t, func(srcPath, rel string, info os.FileInfo) {
 		if info.IsDir() {
 			return

--- a/parse/parse.go
+++ b/parse/parse.go
@@ -81,6 +81,49 @@ var snapshotPrefix = regexp.MustCompile(`^(\d{4}_\d{2}_\d{2}_\d{2}_\d{2}_\d{2})-
 // signal per research R5.
 var summaryFiles = []string{"pt-summary.out", "pt-mysql-summary.out"}
 
+// LooksLikePtStalkRoot reports whether rootDir contains the top-level
+// signals Discover uses to recognize a pt-stalk collection. It does
+// not parse source files or enforce size limits; callers use it only
+// for cheap root selection before the canonical Discover pass.
+func LooksLikePtStalkRoot(rootDir string) (bool, error) {
+	absRoot, err := filepath.Abs(rootDir)
+	if err != nil {
+		return false, &PathError{Op: "abs", Path: rootDir, Err: err}
+	}
+	info, err := os.Stat(absRoot)
+	if err != nil {
+		return false, &PathError{Op: "stat", Path: absRoot, Err: err}
+	}
+	if !info.IsDir() {
+		return false, &PathError{Op: "stat", Path: absRoot, Err: errors.New("not a directory")}
+	}
+	entries, err := os.ReadDir(absRoot)
+	if err != nil {
+		return false, &PathError{Op: "readdir", Path: absRoot, Err: err}
+	}
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+		if isPtStalkRootSignal(entry.Name()) {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+func isPtStalkRootSignal(name string) bool {
+	if snapshotPrefix.FindStringSubmatch(name) != nil {
+		return true
+	}
+	for _, s := range summaryFiles {
+		if name == s {
+			return true
+		}
+	}
+	return false
+}
+
 // Discover walks rootDir, recognises pt-stalk snapshots, and returns
 // a fully-populated model.Collection. Behaviour:
 //

--- a/specs/001-ptstalk-report-mvp/contracts/cli.md
+++ b/specs/001-ptstalk-report-mvp/contracts/cli.md
@@ -6,12 +6,13 @@ change to this contract requires a spec amendment.
 ## Invocation
 
 ```text
-my-gather [flags] <input-dir>
+my-gather [flags] <input>
 ```
 
-- `<input-dir>` — **Required positional argument.** Path to a pt-stalk
-  output directory. Relative paths are resolved against the CWD before
-  any further processing.
+- `<input>` — **Required positional argument.** Path to a pt-stalk
+  output directory or supported archive file (`.zip`, `.tar`,
+  `.tar.gz`, `.tgz`, `.gz`). Relative paths are resolved against the
+  CWD before any further processing.
 
 Exactly one positional argument is accepted. Zero positional arguments
 or two or more positional arguments is a usage error (exit code 2).
@@ -39,8 +40,8 @@ an explicit flag.
 |------|---------|----------------|
 | `0` | Success. HTML file written. | Empty on success (unless `-v`); parser diagnostics mirrored as they occur. |
 | `2` | Usage error (missing positional, unknown flag, bad flag value). | One line describing the usage error + usage summary. |
-| `3` | Input path does not exist, is unreadable, or is not a directory. | One line naming the path and the condition. |
-| `4` | Input directory is not recognised as a pt-stalk output directory (no timestamped collectors and no `pt-summary.out`). | One line. |
+| `3` | Input path does not exist, is unreadable, is neither a directory nor supported archive, or archive extraction is unsafe. | One line naming the path and the condition. |
+| `4` | Input is not recognised as a single pt-stalk collection (no timestamped collectors and no `pt-summary.out`, or an archive contains multiple candidate roots). | One line. |
 | `5` | Input size bound exceeded (> 1 GB total or > 200 MB for any single source file). | One line naming the violated bound and the offending path. |
 | `6` | Output path already exists and `--overwrite` was not set. | One line naming the output path. |
 | `7` | Output path resolves to a location inside the input directory tree (would violate read-only-inputs principle). | One line naming both the input path and the offending output path. |
@@ -110,8 +111,11 @@ log call so partial outputs survive a SIGKILL.
 
 ## File I/O contract
 
-- The tool MUST NOT write, rename, or delete anything inside
-  `<input-dir>` or any subdirectory of it (Principle II, FR-003).
+- The tool MUST NOT write, rename, or delete anything inside directory
+  input, archive input, or any subdirectory of a directory input
+  (Principle II, FR-003). Archive input may be extracted only into a
+  process-owned temporary directory outside the input tree, and that
+  temporary directory MUST be removed before exit.
 - The tool MUST write exactly one file to the `--out` path. No
   temporary side-car files under the output's parent dir, no lock
   files, no `.bak` files. If atomic-replace behaviour is needed the
@@ -127,10 +131,11 @@ log call so partial outputs survive a SIGKILL.
 my-gather — self-contained HTML reports for pt-stalk collections
 
 USAGE
-  my-gather [flags] <input-dir>
+  my-gather [flags] <input>
 
 ARGUMENTS
-  <input-dir>    Path to a pt-stalk output directory (required).
+  <input>    Path to a pt-stalk output directory or supported archive
+             (.zip, .tar, .tar.gz, .tgz, .gz).
 
 FLAGS
   -o, --out <path>    Output HTML file path (default: ./report.html).
@@ -156,7 +161,7 @@ Help output goes to stdout, never stderr.
 
 Before calling into `parse.Discover`, `cmd/my-gather` MUST:
 
-1. Resolve `<input-dir>` to an absolute path with symlinks expanded
+1. Resolve `<input>` to an absolute path with symlinks expanded
    (`filepath.EvalSymlinks` after `filepath.Abs`).
 2. Resolve `--out` to an absolute path with symlinks expanded on the
    parent directory (the output file itself does not exist yet).
@@ -166,6 +171,11 @@ Before calling into `parse.Discover`, `cmd/my-gather` MUST:
 This check is what enforces spec FR-029 and closes the Principle II
 foot-gun where a naive `-o ./report.html` from inside the input tree
 would land a write inside the pt-stalk dump.
+
+For archive input, `cmd/my-gather` MUST safely extract the archive into
+a temporary directory, discover exactly one pt-stalk root, and pass that
+root directory to `parse.Discover`. Unsafe archive paths, unsupported
+special entries, and multiple extracted pt-stalk roots are rejected.
 
 ## Backwards-compatibility policy
 

--- a/specs/008-archive-input/contracts/cli.md
+++ b/specs/008-archive-input/contracts/cli.md
@@ -1,0 +1,47 @@
+# CLI Contract: Archive Input
+
+This contract amends the v1 CLI contract for feature `008-archive-input`.
+
+## Invocation
+
+```text
+my-gather [flags] <input>
+```
+
+- `<input>` is required.
+- `<input>` may be either:
+  - a pt-stalk output directory
+  - a supported archive file: `.zip`, `.tar`, `.tar.gz`, `.tgz`, `.gz`
+
+Exactly one positional input is accepted. Zero or multiple positional inputs
+remain usage errors.
+
+## Archive Behavior
+
+For directory input, behavior is unchanged.
+
+For archive input, the CLI must:
+
+1. Create a private temporary extraction directory.
+2. Safely extract regular files and directories only.
+3. Reject entries that would escape the temporary directory.
+4. Reject links and other special entries.
+5. Locate exactly one extracted pt-stalk root.
+6. Call the existing parser with that extracted root.
+7. Remove temporary extraction files before exit.
+
+## Exit Code Mapping
+
+| Code | Archive-specific meaning |
+|------|--------------------------|
+| `3` | Regular file uses an unsupported archive format, archive cannot be opened, or archive path is unsafe. |
+| `4` | Supported archive contains zero pt-stalk roots or multiple pt-stalk roots. |
+| `5` | Extracted content exceeds the supported total input bound. |
+| `70` | Unexpected temporary directory or write failure. |
+
+Existing directory-input exit code meanings remain unchanged.
+
+## Help Text
+
+Help output must describe `<input>` as a pt-stalk directory or supported
+archive, not as a directory-only argument.

--- a/specs/008-archive-input/data-model.md
+++ b/specs/008-archive-input/data-model.md
@@ -1,0 +1,68 @@
+# Data Model: Archive Input
+
+## Input Path
+
+The positional argument provided to `my-gather`.
+
+Fields:
+
+- `path`: absolute path after CLI resolution
+- `kind`: directory, supported archive, or unsupported regular file
+- `display_path`: original absolute path used for user-facing errors
+
+Rules:
+
+- Directories pass through to `parse.Discover`.
+- Regular files must match a supported archive format.
+- Other file types fail as input-path errors.
+
+## Temporary Extraction Directory
+
+A private directory created for one archive run.
+
+Fields:
+
+- `path`: absolute temporary directory path
+- `owner`: the current `my-gather` process
+- `lifetime`: from successful archive classification until command exit
+
+Rules:
+
+- Created outside the input tree.
+- Removed on success and failure.
+- Never used for directory input.
+
+## Archive Entry
+
+One member inside a compressed archive.
+
+Fields:
+
+- `name`: archive-provided path
+- `type`: directory, regular file, metadata, or unsupported special entry
+- `target`: safe resolved path under the temporary extraction directory
+- `bytes_written`: uncompressed bytes written
+
+Rules:
+
+- Regular files and directories are allowed.
+- Symlinks, hardlinks, devices, and traversal paths are rejected.
+- Total extracted bytes are bounded by the existing collection-size limit.
+
+## Extracted pt-stalk Root
+
+The single extracted directory that contains pt-stalk recognition signals.
+
+Recognition signals:
+
+- A top-level timestamped pt-stalk collector filename:
+  `YYYY_MM_DD_HH_MM_SS-<suffix>`
+- `pt-summary.out`
+- `pt-mysql-summary.out`
+
+Rules:
+
+- Exactly one extracted root is required.
+- Zero roots map to "not a pt-stalk directory".
+- Multiple roots map to an ambiguous input error because the current CLI
+  renders one collection per invocation.

--- a/specs/008-archive-input/plan.md
+++ b/specs/008-archive-input/plan.md
@@ -1,0 +1,86 @@
+# Implementation Plan: Archive Input
+
+**Branch**: `008-archive-input` | **Date**: 2026-04-29 | **Spec**: [spec.md](./spec.md)  
+**Input**: Feature specification from `specs/008-archive-input/spec.md`
+
+## Summary
+
+Allow `my-gather` to accept either a pt-stalk directory or a supported
+compressed archive as its single positional input. Archive handling stays in
+the CLI boundary: resolve the input, extract supported archives into a private
+temporary directory, identify the single extracted pt-stalk root, then pass that
+directory into the existing `parse.Discover` pipeline. Directory input remains
+unchanged.
+
+## Technical Context
+
+**Language/Version**: Go version per current `go.mod` declaration  
+**Primary Dependencies**: Go standard library only (`archive/tar`,
+`archive/zip`, `compress/gzip`) plus existing packages  
+**Storage**: Reads one input directory or archive and writes one HTML file  
+**Testing**: `go test ./cmd/my-gather ./parse`, then `go test ./...`  
+**Target Platform**: Static CLI binary for Linux and macOS targets  
+**Performance Goals**: Avoid manual extraction for common archive formats;
+enforce bounded extraction before parsing; keep directory input cost unchanged  
+**Constraints**: Read-only input tree, deterministic root selection, temporary
+files removed on exit, self-contained HTML, zero runtime network, no new
+third-party dependency  
+**Scale/Scope**: One collection per command; multi-host archive selection is
+explicitly rejected until a multi-report workflow exists
+
+## Constitution Check
+
+| Principle | Status | Notes |
+|-----------|--------|-------|
+| I. Single Static Binary | PASS | Standard library archive readers only. |
+| II. Read-Only Inputs | PASS | Archive extraction writes only to private temp directories and never mutates input paths. |
+| III. Graceful Degradation | PASS | Unsupported or invalid archives fail with existing documented exit codes and clear stderr. |
+| IV. Deterministic Output | PASS | Extracted roots are sorted; multiple roots are rejected instead of selected arbitrarily. |
+| V. Self-Contained HTML Reports | PASS | Report rendering path is unchanged. |
+| VI. Library-First Architecture | PASS | `parse` exposes a small root-recognition helper; CLI remains the archive boundary. |
+| VII. Typed Errors | PASS | Existing parse errors plus typed archive path/multiple-root errors drive exit mapping. |
+| VIII. Reference Fixtures & Golden Tests | PASS | Tests package archive fixture data from `testdata/example2`. |
+| IX. Zero Network at Runtime | PASS | No network code. |
+| X. Minimal Dependencies | PASS | No new module dependency. |
+| XI. Reports Optimized for Humans Under Pressure | PASS | Eliminates manual extraction and fails clearly on ambiguous archives. |
+| XII. Pinned Go Version | PASS | No Go version change. |
+| XIII. Canonical Code Path | PASS | Archive input resolves to a directory before the single canonical parser/render path. |
+| XIV. English-Only Durable Artifacts | PASS | All durable artifacts are English. |
+
+## Project Structure
+
+```text
+cmd/my-gather/
+├── archive_input.go       # archive detection, safe extraction, root selection
+├── main.go                # positional wording and input-preparation mapping
+└── main_test.go           # archive-input CLI coverage
+
+parse/
+└── parse.go               # exported root-recognition helper
+
+specs/008-archive-input/
+├── spec.md
+├── plan.md
+├── research.md
+├── data-model.md
+├── quickstart.md
+├── contracts/
+│   └── cli.md
+└── tasks.md
+```
+
+## Design Decisions
+
+- Keep archive support out of `parse.Discover` so the parser remains a
+  read-only directory parser.
+- Add `parse.LooksLikePtStalkRoot` so archive root discovery uses the same
+  recognition signals as `Discover` without parsing files twice for every
+  directory.
+- Reject multiple extracted pt-stalk roots because the current CLI renders one
+  collection per invocation and silent root choice could hide the relevant host.
+- Support `.gz` both as a single compressed file and, by content detection, as
+  a tar stream with a non-standard filename.
+
+## Post-Design Constitution Check
+
+No constitution violations were introduced.

--- a/specs/008-archive-input/quickstart.md
+++ b/specs/008-archive-input/quickstart.md
@@ -1,0 +1,67 @@
+# Quickstart: Archive Input
+
+## Validate Focused Tests
+
+```bash
+go test ./cmd/my-gather ./parse
+```
+
+## Validate Full Repository
+
+```bash
+go test ./...
+```
+
+## Generate From Directory
+
+```bash
+my-gather --overwrite \
+  -o /tmp/report-CS0060148.html \
+  /Users/matias/Documents/Incidents/CS0060148/eu-hrznp-d003/pt-stalk
+```
+
+## Generate From Archive
+
+```bash
+my-gather --overwrite \
+  -o /tmp/report-CS0061180.html \
+  /Users/matias/Documents/Incidents/CS0061180/evidence/raw/CS0061180_pt-stalk.zip
+```
+
+## Local Inventory Commands
+
+```bash
+find /Users/matias/Documents/Incidents \
+  -path '*/code/*' -prune -o \
+  -path '*/mysql-server/*' -prune -o \
+  -type f -print |
+awk '
+function dirname(p){ sub("/[^/]+$", "", p); return p }
+{
+  n=$0; sub(".*/", "", n)
+  if (n == "pt-summary.out" || n == "pt-mysql-summary.out" ||
+      n ~ /^[0-9]{4}_[0-9]{2}_[0-9]{2}_[0-9]{2}_[0-9]{2}_[0-9]{2}-(iostat|top|variables|vmstat|meminfo|innodbstatus1|mysqladmin|processlist|netstat|netstat_s)$/)
+    print dirname($0)
+}' | sort -u > /tmp/my-gather-pt-stalk-candidate-dirs.txt
+
+find /Users/matias/Documents/Incidents \
+  -path '*/code/*' -prune -o \
+  -path '*/mysql-server/*' -prune -o \
+  -type f \( -iname '*.zip' -o -iname '*.tar' -o -iname '*.tar.gz' \
+  -o -iname '*.tgz' -o -iname '*.gz' \) -print |
+sort > /tmp/my-gather-archives.txt
+```
+
+Expected local inventory at feature creation:
+
+- 171 pt-stalk candidate directories
+- 560 archives
+
+## Manual Validation
+
+- Directory input still renders the known CS0060148 report.
+- Archive input renders without manual extraction.
+- `--verbose` shows extraction before parsing for archive inputs.
+- Temporary extraction directories named `my-gather-input-*` are removed after
+  the command exits.
+- Unsupported archive extensions fail before parsing.

--- a/specs/008-archive-input/research.md
+++ b/specs/008-archive-input/research.md
@@ -1,0 +1,92 @@
+# Research: Archive Input
+
+## Incident Inventory
+
+Local scan target:
+
+```text
+/Users/matias/Documents/Incidents/
+```
+
+The scan excluded source-code attachments under `code/` and `mysql-server/`
+because those folders contain unrelated compressed repository artifacts.
+
+Results:
+
+- Parse-compatible pt-stalk candidate directories: 171
+- Archive files: 560
+- Archive formats observed:
+  - `.tar.gz`: 200
+  - `.zip`: 188
+  - `.gz`: 144
+  - `.tar`: 18
+  - `.tgz`: 10
+- Archive filenames containing `stalk`: 3
+
+Inventory files were written outside the repository for local review:
+
+```text
+/tmp/my-gather-pt-stalk-candidate-dirs.txt
+/tmp/my-gather-archives.txt
+/tmp/my-gather-likely-stalk-archives.txt
+```
+
+Conclusion: archive support cannot depend on filenames. It must inspect
+extracted content and discover pt-stalk roots by the same signals used for
+directory input.
+
+## Decision: Supported Formats
+
+Support `.zip`, `.tar`, `.tar.gz`, `.tgz`, and `.gz`.
+
+Rationale:
+
+- These are the only formats observed in the refined incident inventory.
+- They are covered by Go standard-library readers.
+- `.gz` appears frequently and can wrap either one file or a tar stream with a
+  non-standard filename, so content detection is useful.
+
+Rejected for this feature:
+
+- `.bz2`, `.xz`, `.7z`, `.rar`: not observed in the refined inventory and would
+  require either new dependencies or partial platform-specific tooling.
+
+## Decision: Temporary Extraction
+
+Archives extract into a private directory created with `os.MkdirTemp` and
+removed with `os.RemoveAll` on every exit path.
+
+Rationale:
+
+- Preserves the read-only input-tree principle.
+- Avoids leaving partially extracted customer data in the working directory.
+- Keeps archive handling transparent to the existing parser and renderer.
+
+## Decision: Safe Archive Paths
+
+Extraction rejects:
+
+- Absolute paths
+- Parent-directory traversal
+- Symlinks
+- Hardlinks
+- Devices and other non-regular entries
+
+Rationale:
+
+- Customer archives are untrusted input.
+- The tool must never write outside its temporary extraction directory.
+- Following links would violate deterministic and read-only behavior.
+
+## Decision: Root Selection
+
+After extraction, the CLI walks extracted directories and calls
+`parse.LooksLikePtStalkRoot`. Exactly one matching root is required.
+
+Rationale:
+
+- Existing `parse.Discover` intentionally parses one root directory.
+- Multiple extracted roots usually mean multi-host or multi-capture archives.
+  Silent selection would risk rendering the wrong host.
+- Reusing parse recognition signals avoids a second, divergent definition of
+  "pt-stalk root".

--- a/specs/008-archive-input/spec.md
+++ b/specs/008-archive-input/spec.md
@@ -1,0 +1,171 @@
+# Feature Specification: Archive Input
+
+**Feature Branch**: `008-archive-input`  
+**Created**: 2026-04-29  
+**Status**: Draft  
+**Input**: User description: "Search `/Users/matias/Documents/Incidents/` for folders containing pt-stalk data and compressed files, then adapt the tool so it can accept either a folder or compressed file. Compressed files must extract into a temporary folder and open through the tool as well."
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Run Reports Directly From Archives (Priority: P1)
+
+A support engineer receives a compressed pt-stalk capture and wants to generate
+the same HTML report without manually extracting the archive first.
+
+**Why this priority**: Many incident attachments arrive as `.zip`, `.tar`,
+`.tar.gz`, `.tgz`, or `.gz` files. Requiring manual extraction slows triage and
+creates inconsistent local folder layouts.
+
+**Independent Test**: Run `my-gather --overwrite -o /tmp/report.html
+capture.zip` and `my-gather --overwrite -o /tmp/report.html capture.tar.gz`
+against archives that contain a nested pt-stalk directory. Each command exits
+0 and writes a non-empty self-contained report.
+
+**Acceptance Scenarios**:
+
+1. **Given** a supported archive that contains exactly one pt-stalk collection,
+   **When** the user passes the archive as the positional input, **Then** the
+   tool extracts it to a temporary directory, discovers the pt-stalk root, and
+   renders the report.
+2. **Given** the same collection as an extracted directory or as an archive,
+   **When** the user generates a report, **Then** the report uses the same
+   parser, model, renderer, and Advisor paths.
+3. **Given** archive processing completes or fails, **When** the command exits,
+   **Then** temporary extraction files are removed and the original archive is
+   not modified.
+
+---
+
+### User Story 2 - Preserve Directory Input Compatibility (Priority: P1)
+
+A support engineer already has an extracted pt-stalk directory and expects the
+existing command and exit codes to continue working.
+
+**Why this priority**: Directory input is the current primary workflow and must
+remain stable.
+
+**Independent Test**: Run the existing directory quickstart command against
+`testdata/example2` and a real incident pt-stalk directory. Both commands keep
+their prior behavior.
+
+**Acceptance Scenarios**:
+
+1. **Given** an existing pt-stalk directory, **When** it is passed as input,
+   **Then** no archive extraction occurs and the existing parse flow runs.
+2. **Given** `--out` points inside a directory input tree, **When** the command
+   starts, **Then** the existing output-inside-input guard still rejects the
+   run with exit code 7.
+3. **Given** no input or more than one input is passed, **When** flags are
+   parsed, **Then** usage errors still use exit code 2.
+
+---
+
+### User Story 3 - Reject Unsafe Or Ambiguous Archives (Priority: P2)
+
+A support engineer needs archive handling to be safe under untrusted customer
+attachments and clear when an archive is not a single report input.
+
+**Why this priority**: Archives can contain path traversal entries, symlinks,
+multiple host captures, or unrelated compressed logs. The tool must not write
+outside its temporary workspace or silently choose the wrong collection.
+
+**Independent Test**: Run focused tests with a traversal zip entry, an
+unsupported file type, an archive with no pt-stalk root, and an archive with
+multiple pt-stalk roots. Each case exits with the documented non-zero code and
+does not create unexpected files.
+
+**Acceptance Scenarios**:
+
+1. **Given** an archive contains `../` or absolute extraction paths, **When**
+   the tool processes it, **Then** extraction is rejected before any outside
+   path can be written.
+2. **Given** an archive contains multiple pt-stalk roots, **When** the tool
+   processes it, **Then** the command fails clearly instead of selecting one
+   silently.
+3. **Given** a regular file with an unsupported extension is passed, **When**
+   the command starts, **Then** it exits with an input-path error naming the
+   supported archive formats.
+
+### Edge Cases
+
+- Archives may wrap the pt-stalk root in one or more parent directories.
+- `.gz` files may contain a single decompressed file or a tar stream with a
+  non-standard filename; tar streams are detected by content.
+- Archives may contain hidden metadata files or directories that are unrelated
+  to pt-stalk data.
+- Archives may contain symlinks, hardlinks, devices, or other non-regular
+  entries; these are rejected.
+- Archives may expand beyond the supported total input size and must fail
+  before unbounded extraction.
+- Incident trees may contain many unrelated compressed logs; names alone are
+  not sufficient to identify pt-stalk archives.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: The CLI MUST accept one positional `<input>` that can be either
+  a pt-stalk directory or a supported archive file.
+- **FR-002**: Supported archive formats MUST include `.zip`, `.tar`,
+  `.tar.gz`, `.tgz`, and `.gz`.
+- **FR-003**: Directory input MUST continue using the existing
+  `parse.Discover` code path without temporary extraction.
+- **FR-004**: Archive input MUST extract only into a newly-created temporary
+  directory outside the input tree.
+- **FR-005**: Archive extraction MUST remove the temporary directory on both
+  success and failure.
+- **FR-006**: Archive extraction MUST reject absolute paths, parent-directory
+  traversal, symlinks, hardlinks, devices, and other non-regular entries.
+- **FR-007**: Archive extraction MUST enforce the existing 1 GB total
+  collection bound while writing extracted content.
+- **FR-008**: After archive extraction, the tool MUST discover exactly one
+  pt-stalk root by using the same top-level recognition signals as
+  `parse.Discover`: timestamped collector files or summary files.
+- **FR-009**: If an archive contains no pt-stalk root, the CLI MUST fail with
+  exit code 4.
+- **FR-010**: If an archive contains multiple pt-stalk roots, the CLI MUST
+  fail clearly instead of selecting one silently.
+- **FR-011**: Unsupported regular input files MUST fail with exit code 3 and
+  list the supported archive formats.
+- **FR-012**: The rendered report for archive input MUST be produced through
+  the existing parser, model, findings, and renderer pipeline.
+- **FR-013**: Archive handling MUST add no runtime network access and no new
+  third-party dependencies.
+- **FR-014**: Help text and CLI contracts MUST describe `<input>` as directory
+  or supported archive, replacing directory-only wording.
+
+### Key Entities
+
+- **Input Path**: The user-provided positional argument. It resolves to either
+  a directory or a regular archive file.
+- **Temporary Extraction Directory**: A private workspace created for one
+  archive run and removed before process exit.
+- **Extracted pt-stalk Root**: The single extracted directory that contains
+  timestamped pt-stalk collector files or recognized summary files.
+- **Incident Inventory**: Local scan evidence from
+  `/Users/matias/Documents/Incidents/` used to validate that both directory
+  and archive workflows are common.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: The local incident inventory identifies parse-compatible
+  pt-stalk candidate directories and archive files under the incident tree.
+- **SC-002**: `go test ./cmd/my-gather ./parse` covers directory recognition,
+  zip archive input, tar-gzip archive input, and unsafe archive rejection.
+- **SC-003**: A report can be generated from an archive containing a nested
+  pt-stalk directory without manual extraction.
+- **SC-004**: Unsafe archive entries do not create files outside the temporary
+  extraction directory.
+- **SC-005**: Existing directory-input behavior remains compatible with the
+  current quickstart commands and exit codes.
+
+## Assumptions
+
+- A single `my-gather` invocation renders one pt-stalk collection. Multi-host
+  archives remain out of scope until the product supports multi-report or
+  collection selection.
+- Standard-library archive support is preferred over new dependencies.
+- The incident inventory is local evidence and is not committed verbatim
+  because customer paths can contain sensitive identifiers.

--- a/specs/008-archive-input/tasks.md
+++ b/specs/008-archive-input/tasks.md
@@ -1,0 +1,41 @@
+# Tasks: Archive Input
+
+**Input**: Design documents from `specs/008-archive-input/`  
+**Prerequisites**: spec.md, plan.md, research.md, data-model.md, contracts/cli.md, quickstart.md
+
+**Tests**: Included because archive input changes CLI behavior and untrusted
+input handling.
+
+## Phase 1: Setup
+
+- [x] T001 Create feature branch and Spec Kit directory for archive input.
+- [x] T002 Record incident inventory counts and evidence paths in `research.md`.
+- [x] T003 Define archive input CLI contract in `contracts/cli.md`.
+
+## Phase 2: Foundation
+
+- [x] T004 Add cheap pt-stalk root recognition helper in `parse/parse.go`.
+- [x] T005 Add CLI archive input resolver in `cmd/my-gather/archive_input.go`.
+- [x] T006 Map archive input errors to existing exit codes in `cmd/my-gather/main.go`.
+- [x] T007 Update help and positional wording from `<input-dir>` to `<input>`.
+
+## Phase 3: Safe Archive Extraction
+
+- [x] T008 Support `.zip` extraction with traversal and special-entry rejection.
+- [x] T009 Support `.tar`, `.tar.gz`, and `.tgz` extraction.
+- [x] T010 Support `.gz` extraction, including content detection for tar streams.
+- [x] T011 Enforce extracted-byte bounds during extraction.
+- [x] T012 Remove temporary extraction directories on success and failure.
+
+## Phase 4: Tests
+
+- [x] T013 Add CLI test for nested zip archive input in `cmd/my-gather/main_test.go`.
+- [x] T014 Add CLI test for nested tar-gzip archive input in `cmd/my-gather/main_test.go`.
+- [x] T015 Add CLI test for archive path traversal rejection in `cmd/my-gather/main_test.go`.
+- [x] T016 Run focused validation from `quickstart.md`.
+
+## Phase 5: Documentation And Final Validation
+
+- [x] T017 Update feature docs and active Spec Kit pointers.
+- [x] T018 Run full repository validation with `go test ./...`.
+- [x] T019 Generate a real report from a local incident archive and verify output.


### PR DESCRIPTION
## Summary
- accept pt-stalk input as either a directory or supported archive (.zip, .tar, .tar.gz, .tgz, .gz)
- safely extract archives to a temporary directory, discover exactly one pt-stalk root, and keep the canonical parser/render path
- update Spec Kit artifacts and Codex/Claude active feature pointers for 008-archive-input

## Validation
- go test ./cmd/my-gather ./parse
- go test ./...
- git diff --check
- my-gather --overwrite -o /tmp/report-CS0061180-archive-installed.html /Users/matias/Documents/Incidents/CS0061180/evidence/raw/CS0061180_pt-stalk.zip
