### PR TITLE
chore: reconcile spec state and archive input coverage

### DIFF
--- a/.specify/feature.json
+++ b/.specify/feature.json
@@ -1,3 +1,3 @@
 {
-  "feature_directory": "specs/008-archive-input"
+  "feature_directory": "specs/009-spec-code-reconciliation"
 }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,19 +1,20 @@
 <!-- SPECKIT START -->
-Active feature: **008-archive-input**
+Active feature: **009-spec-code-reconciliation**
 
 For technologies, project structure, constitution gates, data model,
-CLI contracts, and shell commands, read the current plan:
+contracts, and shell commands, read the current plan:
 
-- Plan: `specs/008-archive-input/plan.md`
-- Spec: `specs/008-archive-input/spec.md`
-- Research: `specs/008-archive-input/research.md`
-- Data model: `specs/008-archive-input/data-model.md`
-- Contracts: `specs/008-archive-input/contracts/cli.md`
-- Quickstart: `specs/008-archive-input/quickstart.md`
-- Tasks: `specs/008-archive-input/tasks.md`
+- Plan: `specs/009-spec-code-reconciliation/plan.md`
+- Spec: `specs/009-spec-code-reconciliation/spec.md`
+- Research: `specs/009-spec-code-reconciliation/research.md`
+- Data model: `specs/009-spec-code-reconciliation/data-model.md`
+- Contracts: `specs/009-spec-code-reconciliation/contracts/reconciliation.md`
+- Quickstart: `specs/009-spec-code-reconciliation/quickstart.md`
+- Tasks: `specs/009-spec-code-reconciliation/tasks.md`
 - Constitution: `.specify/memory/constitution.md`
 
 Prior features:
+- **008-archive-input** - `specs/008-archive-input/plan.md`
 - **007-advisor-intelligence** - `specs/007-advisor-intelligence/plan.md`
 - **006-observed-slowest-queries** - `specs/006-observed-slowest-queries/plan.md`
 - **005-richer-processlist-metrics** - `specs/005-richer-processlist-metrics/plan.md`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,19 +1,20 @@
 <!-- SPECKIT START -->
-Active feature: **008-archive-input**
+Active feature: **009-spec-code-reconciliation**
 
 For technologies, project structure, constitution gates, data model,
-CLI contracts, and shell commands, read the current plan:
+contracts, and shell commands, read the current plan:
 
-- Plan: `specs/008-archive-input/plan.md`
-- Spec: `specs/008-archive-input/spec.md`
-- Research: `specs/008-archive-input/research.md`
-- Data model: `specs/008-archive-input/data-model.md`
-- Contracts: `specs/008-archive-input/contracts/cli.md`
-- Quickstart: `specs/008-archive-input/quickstart.md`
-- Tasks: `specs/008-archive-input/tasks.md`
+- Plan: `specs/009-spec-code-reconciliation/plan.md`
+- Spec: `specs/009-spec-code-reconciliation/spec.md`
+- Research: `specs/009-spec-code-reconciliation/research.md`
+- Data model: `specs/009-spec-code-reconciliation/data-model.md`
+- Contracts: `specs/009-spec-code-reconciliation/contracts/reconciliation.md`
+- Quickstart: `specs/009-spec-code-reconciliation/quickstart.md`
+- Tasks: `specs/009-spec-code-reconciliation/tasks.md`
 - Constitution: `.specify/memory/constitution.md`
 
 Prior features:
+- **008-archive-input** - `specs/008-archive-input/plan.md`
 - **007-advisor-intelligence** - `specs/007-advisor-intelligence/plan.md`
 - **006-observed-slowest-queries** - `specs/006-observed-slowest-queries/plan.md`
 - **005-richer-processlist-metrics** - `specs/005-richer-processlist-metrics/plan.md`

--- a/cmd/my-gather/main_test.go
+++ b/cmd/my-gather/main_test.go
@@ -227,6 +227,61 @@ func TestRunMapsCorruptGzipPayloadToInputPathError(t *testing.T) {
 	}
 }
 
+func TestRunRejectsArchiveWithNoPtStalkRoot(t *testing.T) {
+	dir := t.TempDir()
+	archivePath := filepath.Join(dir, "unrelated.zip")
+	file, err := os.Create(archivePath)
+	if err != nil {
+		t.Fatalf("create archive: %v", err)
+	}
+	zw := zip.NewWriter(file)
+	entry, err := zw.Create("notes/readme.txt")
+	if err != nil {
+		t.Fatalf("create zip entry: %v", err)
+	}
+	if _, err := entry.Write([]byte("not a pt-stalk collection")); err != nil {
+		t.Fatalf("write zip entry: %v", err)
+	}
+	if err := zw.Close(); err != nil {
+		t.Fatalf("close zip: %v", err)
+	}
+	if err := file.Close(); err != nil {
+		t.Fatalf("close archive: %v", err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	code := run([]string{"--overwrite", "-o", filepath.Join(dir, "report.html"), archivePath}, &stdout, &stderr)
+	if code != exitNotAPtStalkDir {
+		t.Fatalf("run exit = %d, want %d\nstderr:\n%s", code, exitNotAPtStalkDir, stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "not recognised as a pt-stalk output directory") {
+		t.Fatalf("stderr = %q, want no-root pt-stalk message", stderr.String())
+	}
+}
+
+func TestRunRejectsUnsupportedRegularInputFile(t *testing.T) {
+	dir := t.TempDir()
+	inputPath := filepath.Join(dir, "capture.txt")
+	if err := os.WriteFile(inputPath, []byte("not an archive"), 0o600); err != nil {
+		t.Fatalf("write input: %v", err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	code := run([]string{"--overwrite", "-o", filepath.Join(dir, "report.html"), inputPath}, &stdout, &stderr)
+	if code != exitInputPath {
+		t.Fatalf("run exit = %d, want %d\nstderr:\n%s", code, exitInputPath, stderr.String())
+	}
+	got := stderr.String()
+	if !strings.Contains(got, "not a supported input archive") {
+		t.Fatalf("stderr = %q, want unsupported archive message", got)
+	}
+	for _, format := range []string{".zip", ".tar", ".tar.gz", ".tgz", ".gz"} {
+		if !strings.Contains(got, format) {
+			t.Fatalf("stderr = %q, want supported format %s", got, format)
+		}
+	}
+}
+
 func TestWriteExtractedFileEnforcesPerFileLimit(t *testing.T) {
 	dir := t.TempDir()
 	target := filepath.Join(dir, "large")

--- a/specs/001-ptstalk-report-mvp/checklists/ux-quality.md
+++ b/specs/001-ptstalk-report-mvp/checklists/ux-quality.md
@@ -272,14 +272,14 @@ File path: `specs/001-ptstalk-report-mvp/ux-audits/<YYYY-MM-DD>-<label>.md`
 | G-1 | PASS | — |
 | G-2 | PASS | — |
 | …   | …    | … |
-| OS-3 | DEFERRED → T??? | vmstat legend overlaps at 1280 px |
+| OS-3 | DEFERRED -> T110 | vmstat legend overlaps at 1280 px |
 | …   | …    | … |
 
 ## Deferred items
 
 | ID | Follow-up task | Owner | Target |
 |---|---|---|---|
-| OS-3 | T??? | @matias-sanchez | next cut |
+| OS-3 | T110 | @matias-sanchez | next cut |
 
 ## Summary
 

--- a/specs/002-report-feedback-button/tasks.md
+++ b/specs/002-report-feedback-button/tasks.md
@@ -8,6 +8,14 @@ description: "Task list for Report Feedback Button implementation"
 **Input**: Design documents from `/specs/002-report-feedback-button/`
 **Prerequisites**: plan.md, spec.md, research.md, data-model.md, contracts/ui.md, quickstart.md
 
+**Historical state**: This task file preserves the original 2026-04-24
+implementation plan for feature 002. The shipped feedback flow was later
+reconciled and superseded by feature 003's Worker-backed submit path; do not
+read the unchecked boxes below as live remaining work for the current product.
+Use `specs/002-report-feedback-button/spec.md` for the still-authoritative
+dialog and attachment behavior, and `specs/003-feedback-backend-worker/` for
+the authoritative submit path.
+
 **Tests**: Test tasks are included — this feature touches render-layer code, which Principle VIII (Reference Fixtures & Golden Tests) and the constitution's Quality Gate #3 (determinism byte-diff) hard-require tests for.
 
 **Organization**: One phase per user story in priority order (US1 P1 → US2 P2 → US3/4/5 P3). Every story is independently testable per its spec acceptance criteria and its quickstart scenario.

--- a/specs/003-feedback-backend-worker/spec.md
+++ b/specs/003-feedback-backend-worker/spec.md
@@ -2,7 +2,7 @@
 
 **Feature Branch**: `003-feedback-backend-worker`
 **Created**: 2026-04-24
-**Status**: Draft
+**Status**: Complete
 **Input**: User description: "Cuando el user hace Submit en el report-feedback dialog, la discussion se tiene que registrar sola en GitHub Discussions del repo matias-sanchez/My-gather (categoría Ideas), sin que el user tenga que pegar nada ni clickear más. El user ve un success inline y listo. Image y voice tienen que quedar también en la discussion. No se puede shipping un token de GitHub en el HTML (cualquier lector lo extrae)." *(Verbatim user input. Pivoted to Issues during 2026-04-26 clarification — see below.)*
 
 ## Clarifications (2026-04-24)

--- a/specs/003-feedback-backend-worker/tasks.md
+++ b/specs/003-feedback-backend-worker/tasks.md
@@ -102,7 +102,7 @@ description: "Task list for Feedback Backend Worker implementation"
 - [x] T039 Reconcile `contracts/ui.md` against deployed reality (commit `fb0aba8`).
 - [x] T040 Reconcile `research.md`, `plan.md`, `quickstart.md`, `tasks.md`, `checklists/requirements.md` against deployed reality (this commit).
 - [x] T041 (commit `b168a71`) Add `AbortController` 10 000 ms timeout to all GitHub fetches in `feedback-worker/src/github-app.ts` via a `fetchWithTimeout` helper. On timeout throw `GitHubTimeoutError` (sibling — not subclass — of `GitHubError`); `feedback-worker/src/index.ts` catches it and returns HTTP 504 with `error: "github_timeout"` per FR-014 + contracts/api.md §504. Tests: `feedback-worker/test/github-app.test.ts` +2 cases (signal-passed-through + AbortError → GitHubTimeoutError conversion). `npm test` 43/43 PASS.
-- [ ] T042 PR #30 review cycle via `/pr-review-trigger-my-gather` and `/pr-review-fix-my-gather` until clean; merge.
+- [x] T042 PR #30 review cycle via `/pr-review-trigger-my-gather` and `/pr-review-fix-my-gather` until clean; merged as PR #30 on 2026-04-27.
 
 ---
 

--- a/specs/006-observed-slowest-queries/spec.md
+++ b/specs/006-observed-slowest-queries/spec.md
@@ -2,7 +2,7 @@
 
 **Feature Branch**: `006-observed-slowest-queries`  
 **Created**: 2026-04-28  
-**Status**: Draft  
+**Status**: Complete
 **Input**: User description: "Detect the slowest queries obtained or reported in pt-stalk captures and add this to the report using the spec-driven workflow."
 
 ## User Scenarios & Testing *(mandatory)*

--- a/specs/007-advisor-intelligence/spec.md
+++ b/specs/007-advisor-intelligence/spec.md
@@ -2,7 +2,7 @@
 
 **Feature Branch**: `007-advisor-intelligence`  
 **Created**: 2026-04-29  
-**Status**: Draft  
+**Status**: Complete
 **Input**: User description: "Create a spec to enhance Advisor intelligence using the expert insights from `MySQL Rosetta Stone.txt` in the Downloads folder so analysts can understand database problems with highest-quality diagnosis."
 
 ## User Scenarios & Testing *(mandatory)*

--- a/specs/008-archive-input/spec.md
+++ b/specs/008-archive-input/spec.md
@@ -2,7 +2,7 @@
 
 **Feature Branch**: `008-archive-input`  
 **Created**: 2026-04-29  
-**Status**: Draft  
+**Status**: Complete
 **Input**: User description: "Search `/Users/matias/Documents/Incidents/` for folders containing pt-stalk data and compressed files, then adapt the tool so it can accept either a folder or compressed file. Compressed files must extract into a temporary folder and open through the tool as well."
 
 ## User Scenarios & Testing *(mandatory)*

--- a/specs/009-spec-code-reconciliation/contracts/reconciliation.md
+++ b/specs/009-spec-code-reconciliation/contracts/reconciliation.md
@@ -1,0 +1,37 @@
+# Reconciliation Contract
+
+## Active Feature Contract
+
+On branch `009-spec-code-reconciliation`:
+
+- `.specify/feature.json` contains
+  `{"feature_directory": "specs/009-spec-code-reconciliation"}`.
+- `AGENTS.md` and `CLAUDE.md` active feature blocks name
+  `009-spec-code-reconciliation`.
+- Both context files list the same artifact paths for the active feature.
+
+## Status Contract
+
+- `006-observed-slowest-queries`, `007-advisor-intelligence`, and
+  `008-archive-input` are marked `Complete`.
+- `001-ptstalk-report-mvp` remains `Draft` because it still tracks open and
+  deferred historical quality work.
+- `002-report-feedback-button` remains `Shipped (v1)` with an explicit note
+  that its unchecked task list is historical.
+
+## Archive CLI Test Contract
+
+`go test ./cmd/my-gather` must include coverage for:
+
+- supported archive with no pt-stalk root returns `exitNotAPtStalkDir`
+- unsupported regular input file returns `exitInputPath`
+- unsupported regular input stderr includes supported archive formats
+
+## Validation Contract
+
+Before opening the PR:
+
+```bash
+go test ./cmd/my-gather
+go test ./...
+```

--- a/specs/009-spec-code-reconciliation/data-model.md
+++ b/specs/009-spec-code-reconciliation/data-model.md
@@ -1,0 +1,54 @@
+# Data Model: Spec And Code Reconciliation
+
+## Reconciliation Finding
+
+A concrete inconsistency between checked-in specs, task files, active pointers,
+or code coverage.
+
+Fields:
+
+- `id`: stable analysis identifier
+- `category`: workflow drift, status drift, task tracking drift, coverage gap,
+  or stale placeholder
+- `affected_paths`: checked-in files that need reconciliation
+- `resolution`: documentation update, test addition, or status update
+
+Rules:
+
+- Findings must resolve without weakening the constitution.
+- Historical context may be preserved when clearly labelled.
+- Code behavior changes are avoided unless a documented contract currently
+  fails.
+
+## Active Feature Pointer
+
+The durable repository state that tells agents which feature is current.
+
+Fields:
+
+- `feature_directory`: `.specify/feature.json` value
+- `agent_context`: active block in `AGENTS.md`
+- `claude_context`: active block in `CLAUDE.md`
+
+Rules:
+
+- All three pointers must name the same feature while a feature branch is
+  active.
+- On `main`, the pointer may name the latest shipped feature only when the
+  agent context files say there is no active feature.
+
+## Archive Error Test
+
+A focused CLI test that validates one documented input failure mode.
+
+Fields:
+
+- `fixture`: temporary archive or regular file
+- `expected_exit_code`: documented CLI exit category
+- `expected_message`: stable stderr substring proving clear user feedback
+
+Rules:
+
+- Fixtures are created under `t.TempDir`.
+- Tests must not depend on local incident data.
+- Tests must not write inside source input trees.

--- a/specs/009-spec-code-reconciliation/plan.md
+++ b/specs/009-spec-code-reconciliation/plan.md
@@ -1,0 +1,79 @@
+# Implementation Plan: Spec And Code Reconciliation
+
+**Branch**: `009-spec-code-reconciliation` | **Date**: 2026-05-01 | **Spec**: [spec.md](./spec.md)
+**Input**: Feature specification from `specs/009-spec-code-reconciliation/spec.md`
+
+## Summary
+
+Reconcile Spec Kit state with the shipped repository by aligning active feature
+pointers, correcting completed feature statuses, clarifying historical task
+tracking, removing stale placeholders, and adding the missing archive-input CLI
+tests. No runtime behavior change is intended except any correction required to
+make the documented archive-input contract pass.
+
+## Technical Context
+
+**Language/Version**: Go version per current `go.mod` declaration
+**Primary Dependencies**: Go standard library only
+**Storage**: Checked-in Markdown spec artifacts plus Go tests
+**Testing**: `go test ./cmd/my-gather`, then `go test ./...`
+**Target Platform**: Static CLI binary for Linux and macOS targets
+**Project Type**: CLI/report generator with Spec Kit documentation
+**Performance Goals**: No production performance impact; test additions remain
+small and deterministic
+**Constraints**: English-only durable artifacts, no new dependencies, no
+network access in shipped Go code, no duplicate archive-input path
+**Scale/Scope**: One reconciliation feature, two targeted CLI tests, and
+documentation-only status/task alignment across existing feature specs
+
+## Constitution Check
+
+| Principle | Status | Notes |
+|-----------|--------|-------|
+| I. Single Static Binary | PASS | Test/docs only; no binary dependency change. |
+| II. Read-Only Inputs | PASS | Archive tests use temporary test directories only. |
+| III. Graceful Degradation | PASS | Tests pin documented non-panic input failures. |
+| IV. Deterministic Output | PASS | No output generation changes planned. |
+| V. Self-Contained HTML Reports | PASS | Report assets unchanged. |
+| VI. Library-First Architecture | PASS | No package boundary change. |
+| VII. Typed Errors | PASS | Existing archive error mapping is reused. |
+| VIII. Reference Fixtures & Golden Tests | PASS | No collector parser or golden behavior change. |
+| IX. Zero Network at Runtime | PASS | No runtime network code added. |
+| X. Minimal Dependencies | PASS | No new dependencies. |
+| XI. Reports Optimized for Humans Under Pressure | PASS | No report UX change. |
+| XII. Pinned Go Version | PASS | No Go version change. |
+| XIII. Canonical Code Path | PASS | Tests exercise the existing archive path. |
+| XIV. English-Only Durable Artifacts | PASS | New durable text is English. |
+
+## Project Structure
+
+```text
+AGENTS.md
+CLAUDE.md
+.specify/feature.json
+cmd/my-gather/main_test.go
+specs/001-ptstalk-report-mvp/
+specs/002-report-feedback-button/
+specs/003-feedback-backend-worker/
+specs/006-observed-slowest-queries/
+specs/007-advisor-intelligence/
+specs/008-archive-input/
+specs/009-spec-code-reconciliation/
+```
+
+## Design Decisions
+
+- Treat the branch as an active Spec Kit reconciliation feature so automated
+  agents have one unambiguous current target.
+- Keep feature 001 as historical/in-progress because its task file explicitly
+  tracks deferred quality work.
+- Treat feature 002 tasks as historical because feature 003 superseded the
+  submit path and later reconciliations document the shipped behavior.
+- Mark features 006, 007, and 008 complete because their task files are fully
+  checked and their implementation is already merged to `main`.
+- Add focused tests in `cmd/my-gather/main_test.go` rather than introducing a
+  separate archive test package, matching the existing CLI coverage pattern.
+
+## Post-Design Constitution Check
+
+No constitution violations were introduced.

--- a/specs/009-spec-code-reconciliation/quickstart.md
+++ b/specs/009-spec-code-reconciliation/quickstart.md
@@ -1,0 +1,41 @@
+# Quickstart: Spec And Code Reconciliation
+
+## Validate Focused Archive Tests
+
+```bash
+go test ./cmd/my-gather
+```
+
+## Validate Full Repository
+
+```bash
+go test ./...
+```
+
+## Check Active Feature Pointers
+
+```bash
+cat .specify/feature.json
+sed -n '1,24p' AGENTS.md
+sed -n '1,24p' CLAUDE.md
+```
+
+Expected active feature:
+
+```text
+009-spec-code-reconciliation
+```
+
+## Check Feature Status Lines
+
+```bash
+rg -n '^\*\*Status\*\*:' specs/*/spec.md
+```
+
+Expected highlights:
+
+- `005-richer-processlist-metrics`: Complete
+- `006-observed-slowest-queries`: Complete
+- `007-advisor-intelligence`: Complete
+- `008-archive-input`: Complete
+- `009-spec-code-reconciliation`: Complete after validation passes

--- a/specs/009-spec-code-reconciliation/research.md
+++ b/specs/009-spec-code-reconciliation/research.md
@@ -1,0 +1,45 @@
+# Research: Spec And Code Reconciliation
+
+## Finding: Active Feature Drift
+
+The repository is on a new reconciliation branch, but prior context on `main`
+still identified `008-archive-input` as active. Spec Kit branch validation
+expects a numbered feature branch, so this branch uses
+`009-spec-code-reconciliation` and updates all active pointers together.
+
+## Finding: Completed Specs Still Marked Draft
+
+Features `006-observed-slowest-queries`, `007-advisor-intelligence`, and
+`008-archive-input` have task files with every listed task checked. Keeping
+their specs as `Draft` makes the documentation disagree with the shipped
+implementation.
+
+Decision: mark those specs `Complete`.
+
+## Finding: Feature 002 Task State Is Historical
+
+Feature `002-report-feedback-button` is documented as shipped and partially
+superseded by feature 003, but its task list still shows 40 unchecked tasks.
+The task file is useful as original planning history, but it is misleading if
+read as a live implementation checklist.
+
+Decision: add a clear historical-state note instead of pretending the original
+task list maps cleanly to the later reconciled implementation.
+
+## Finding: Archive-Input Test Gaps
+
+Feature `008-archive-input` documents failures for zero-root archives and
+unsupported regular files. Existing tests cover supported archive success,
+unsafe paths, corrupt archives, extracted size limits, and multiple roots, but
+not those two documented branches.
+
+Decision: add two CLI tests in `cmd/my-gather/main_test.go`.
+
+## Finding: UX Checklist Placeholder
+
+Feature 001's UX checklist included a deferred sample row with a placeholder
+task ID. That is fine as an example in a template, but in a checked-in feature
+checklist it reads like unresolved tracking.
+
+Decision: replace it with an existing concrete task reference from the same
+feature's UX audit phase.

--- a/specs/009-spec-code-reconciliation/spec.md
+++ b/specs/009-spec-code-reconciliation/spec.md
@@ -1,0 +1,147 @@
+# Feature Specification: Spec And Code Reconciliation
+
+**Feature Branch**: `009-spec-code-reconciliation`
+**Created**: 2026-05-01
+**Status**: Complete
+**Input**: User description: "Create a new branch and PR that fixes all spec/code drift found by the deep analysis so the repository is working and spec/code are correct."
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Trust Spec Status At A Glance (Priority: P1)
+
+A maintainer opens the repository on `main` or a reconciliation branch and needs
+the active feature pointer, agent context files, and feature status lines to
+match the actual implementation state.
+
+**Why this priority**: Stale feature pointers and `Draft` statuses cause Spec
+Kit commands to fail or send future work to the wrong feature.
+
+**Independent Test**: Inspect `.specify/feature.json`, `AGENTS.md`,
+`CLAUDE.md`, and every `specs/*/spec.md` status line. Completed features with
+fully checked task lists are not left as `Draft`, and the active feature points
+to this reconciliation work while the branch is active.
+
+**Acceptance Scenarios**:
+
+1. **Given** the current branch is `009-spec-code-reconciliation`, **When** an
+   agent reads the active feature block, **Then** it names
+   `009-spec-code-reconciliation`.
+2. **Given** a feature task list is fully checked, **When** the spec status is
+   reviewed, **Then** the status says `Complete` unless the spec is explicitly
+   historical or superseded.
+3. **Given** a shipped or superseded historical feature has stale task tracking,
+   **When** a maintainer opens its task file, **Then** the file clearly states
+   whether it is authoritative or historical.
+
+---
+
+### User Story 2 - Archive Input Contracts Are Tested (Priority: P1)
+
+A maintainer changes archive input behavior and needs tests for every
+documented archive error branch.
+
+**Why this priority**: The active feature `008-archive-input` added untrusted
+archive handling. Missing tests for zero-root archives and unsupported regular
+files leave documented CLI contracts underprotected.
+
+**Independent Test**: Run `go test ./cmd/my-gather` and verify coverage exists
+for archive input success, unsafe archive rejection, corrupt archive rejection,
+multiple-root rejection, zero-root rejection, and unsupported regular input
+files.
+
+**Acceptance Scenarios**:
+
+1. **Given** a supported archive contains no pt-stalk root, **When** the CLI is
+   run against it, **Then** it exits with the documented not-a-pt-stalk code and
+   a clear message.
+2. **Given** a regular file uses an unsupported extension, **When** the CLI is
+   run against it, **Then** it exits with the documented input-path code and
+   names the supported archive formats.
+
+---
+
+### User Story 3 - Open Historical Gaps Are Explicit (Priority: P2)
+
+A maintainer reviews older feature specs and needs to know which remaining
+items are live release blockers, deferred follow-up, or historical context.
+
+**Why this priority**: The project uses specs as operational memory. Ambiguous
+open tasks can cause agents to reopen old work or claim an incomplete release.
+
+**Independent Test**: Inspect the noted historical files for unresolved
+placeholders, misleading stale task states, and release-gate wording that no
+longer reflects current project flow.
+
+**Acceptance Scenarios**:
+
+1. **Given** feature 001 has a UX audit checklist sample row, **When** it is
+   reviewed as a durable artifact, **Then** it does not contain an unresolved
+   placeholder task ID.
+2. **Given** feature 002 is superseded by feature 003, **When** its task file is
+   reviewed, **Then** it does not imply 40 live unchecked tasks remain for the
+   shipped product.
+
+### Edge Cases
+
+- Historical specifications may intentionally preserve original user wording;
+  reconciliation must not rewrite exempt verbatim input or raw test fixtures.
+- Active feature pointers must remain synchronized across `AGENTS.md`,
+  `CLAUDE.md`, and `.specify/feature.json`.
+- Code changes must avoid creating a second implementation path for archive
+  input behavior.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: The repository MUST contain a reconciliation feature under
+  `specs/009-spec-code-reconciliation/` with spec, plan, research, data model,
+  quickstart, contracts, and tasks artifacts.
+- **FR-002**: `AGENTS.md`, `CLAUDE.md`, and `.specify/feature.json` MUST point
+  to the same active feature while this branch is active.
+- **FR-003**: Specs for completed fully checked features MUST not remain marked
+  `Draft`.
+- **FR-004**: Historical or superseded task files MUST explicitly state that
+  their checklist state is historical when it no longer maps one-to-one to the
+  shipped implementation.
+- **FR-005**: Archive input tests MUST cover supported archives with zero
+  pt-stalk roots.
+- **FR-006**: Archive input tests MUST cover unsupported regular files and
+  assert the documented exit-code category plus supported-format guidance.
+- **FR-007**: Reconciliation edits MUST preserve English-only durable artifacts
+  and must not alter raw fixture or reference data.
+- **FR-008**: Validation MUST include focused archive-input tests and the full Go
+  test suite before the PR is opened.
+
+### Key Entities
+
+- **Feature Status Line**: The `**Status**` field in a feature specification.
+- **Active Feature Pointer**: The synchronized references in `AGENTS.md`,
+  `CLAUDE.md`, and `.specify/feature.json`.
+- **Historical Task File**: A task list retained for traceability after the
+  shipped behavior has been superseded or reconciled elsewhere.
+- **Archive Error Test**: A focused CLI test that pins one documented archive
+  error branch.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: `go test ./cmd/my-gather` passes with tests for the two previously
+  missing archive-input error branches.
+- **SC-002**: `go test ./...` passes.
+- **SC-003**: All active feature pointers name `009-spec-code-reconciliation`
+  on the branch.
+- **SC-004**: No feature with all tasks checked remains marked `Draft`.
+- **SC-005**: No unresolved placeholder task ID remains in checked-in spec
+  artifacts outside historical examples.
+
+## Assumptions
+
+- Feature 001 remains a broad historical MVP tracker with known deferred and
+  open quality tasks, not a fully complete feature.
+- Feature 002's unchecked task list is historical because its shipped feedback
+  behavior was reconciled and superseded by feature 003.
+- The archive-input implementation behavior is mostly correct; this feature
+  adds missing test coverage and spec/task clarity rather than redesigning
+  archive extraction.

--- a/specs/009-spec-code-reconciliation/tasks.md
+++ b/specs/009-spec-code-reconciliation/tasks.md
@@ -1,0 +1,33 @@
+# Tasks: Spec And Code Reconciliation
+
+**Input**: Design documents from `specs/009-spec-code-reconciliation/`
+**Prerequisites**: spec.md, plan.md, research.md, data-model.md, contracts/reconciliation.md, quickstart.md
+
+**Tests**: Included because this feature closes missing CLI coverage for
+documented archive-input behavior.
+
+## Phase 1: Setup
+
+- [x] T001 Create feature branch `009-spec-code-reconciliation`.
+- [x] T002 Create reconciliation Spec Kit artifacts under `specs/009-spec-code-reconciliation/`.
+- [x] T003 Update `.specify/feature.json`, `AGENTS.md`, and `CLAUDE.md` to the active reconciliation feature.
+
+## Phase 2: Spec And Task Reconciliation
+
+- [x] T004 Mark fully completed features `006`, `007`, and `008` as `Complete` in their `spec.md` files.
+- [x] T005 Add a historical-state note to `specs/002-report-feedback-button/tasks.md`.
+- [x] T006 Replace the unresolved placeholder task ID in `specs/001-ptstalk-report-mvp/checklists/ux-quality.md`.
+- [x] T007 Update feature index blocks in `AGENTS.md` and `CLAUDE.md` so prior features include `008-archive-input`.
+
+## Phase 3: Archive Input Test Coverage
+
+- [x] T008 Add a CLI test for supported archive files with zero pt-stalk roots in `cmd/my-gather/main_test.go`.
+- [x] T009 Add a CLI test for unsupported regular input files in `cmd/my-gather/main_test.go`.
+- [x] T010 Run `gofmt` on modified Go files.
+
+## Phase 4: Validation And PR
+
+- [x] T011 Run `go test ./cmd/my-gather`.
+- [x] T012 Run `go test ./...`.
+- [x] T013 Review the final diff for constitution alignment and update this task file to checked state.
+- [x] T014 Push the branch and open a PR.


### PR DESCRIPTION
## Summary

- add feature 009 as the Spec Kit reconciliation feature and align AGENTS.md, CLAUDE.md, and .specify/feature.json
- mark completed feature specs as Complete and clarify historical/superseded task tracking
- add missing archive-input CLI coverage for zero-root archives and unsupported regular files

## Validation

- go test ./cmd/my-gather
- go test -count=1 ./...
- git diff --cached --check before commit
