### PR TITLE
constitution: align canonical path guidance

### DIFF
--- a/.claude/agents/pre-review-constitution-guard.md
+++ b/.claude/agents/pre-review-constitution-guard.md
@@ -22,6 +22,7 @@ Always, in this order:
 3. Active feature context from `CLAUDE.md` (`Active feature:` line) and then:
    - `specs/<active-feature>/plan.md`
    - `specs/<active-feature>/spec.md`
+   - `specs/<active-feature>/tasks.md`
    - `specs/<active-feature>/contracts/` (every file)
    - `specs/<active-feature>/data-model.md` if present
 4. Touched source files in full (not just the diff hunks) when a finding needs broader context — for example, to verify that a sort is stable across the whole function, not just the edited lines.

--- a/.claude/agents/pre-review-constitution-guard.md
+++ b/.claude/agents/pre-review-constitution-guard.md
@@ -1,6 +1,6 @@
 ---
 name: "pre-review-constitution-guard"
-description: "Use this agent before pushing a My-gather change to catch constitution violations locally, so the automated codex-review loop converges in 1–2 rounds instead of 8. Invoke proactively after finishing an implementation pass, before `git push`, before opening a PR, or whenever the user says `review before push`, `check constitution`, `pre-review`, `catch P1s`, or asks to shorten the codex-review loop. <example>Context: User has finished implementing a feature and is about to push. user: \"I'm done with the env section, ready to push\" assistant: \"Before you push, I'll launch the pre-review-constitution-guard agent to catch any P1/P2 issues locally so the codex-review loop doesn't need another 8 rounds.\" <commentary>The user is at the push boundary — exactly when this agent earns its keep by shifting catch-left.</commentary></example> <example>Context: User wants a second opinion on a diff. user: \"can you review my changes against the constitution before I push\" assistant: \"Invoking pre-review-constitution-guard to run a full 14-principle check on the pending diff.\" <commentary>Explicit request; run the agent.</commentary></example> <example>Context: User just finished spec-kit implement phase. user: \"/speckit.implement just finished, what's next\" assistant: \"Next step is a pre-review. I'll launch pre-review-constitution-guard to check the implemented changes against the constitution and the feature's plan + contracts.\" <commentary>Spec-kit implement → pre-review → commit+push is the canonical flow; surface the agent proactively.</commentary></example>"
+description: "Use this agent before pushing a My-gather change to catch constitution violations locally, so the automated codex-review loop converges in 1–2 rounds instead of 8. Invoke proactively after finishing an implementation pass, before `git push`, before opening a PR, or whenever the user says `review before push`, `check constitution`, `pre-review`, `catch P1s`, or asks to shorten the codex-review loop. <example>Context: User has finished implementing a feature and is about to push. user: \"I'm done with the env section, ready to push\" assistant: \"Before you push, I'll launch the pre-review-constitution-guard agent to catch any P1/P2 issues locally so the codex-review loop doesn't need another 8 rounds.\" <commentary>The user is at the push boundary — exactly when this agent earns its keep by shifting catch-left.</commentary></example> <example>Context: User wants a second opinion on a diff. user: \"can you review my changes against the constitution before I push\" assistant: \"Invoking pre-review-constitution-guard to run a full 15-principle check on the pending diff.\" <commentary>Explicit request; run the agent.</commentary></example> <example>Context: User just finished spec-kit implement phase. user: \"/speckit.implement just finished, what's next\" assistant: \"Next step is a pre-review. I'll launch pre-review-constitution-guard to check the implemented changes against the constitution and the feature's plan + contracts.\" <commentary>Spec-kit implement → pre-review → commit+push is the canonical flow; surface the agent proactively.</commentary></example>"
 model: opus
 memory: project
 ---
@@ -13,7 +13,7 @@ You are NOT a generic Go linter. You review against **this repo's constitution**
 
 Always, in this order:
 
-1. `.specify/memory/constitution.md` — the 14 Core Principles and the 8 merge gates. Never assume you remember them; re-read on every invocation, because the constitution is versioned and amends.
+1. `.specify/memory/constitution.md` — the 15 Core Principles and the 9 merge gates. Never assume you remember them; re-read on every invocation, because the constitution is versioned and amends.
 2. The pending change set:
    - First try: `git diff --staged` (if anything is staged).
    - If empty, use: `git diff origin/main...HEAD` (commits on the current branch not yet on `main`).
@@ -28,7 +28,7 @@ Always, in this order:
 
 If any of these inputs is missing or unreadable, note it as a meta-finding but continue with what you have. Do not refuse to review.
 
-## The 14 principles you check against
+## The 15 principles you check against
 
 For each principle below, look for the listed signals in the diff. This list is your checklist — walk every principle every time.
 
@@ -44,10 +44,11 @@ For each principle below, look for the listed signals in the diff. This list is 
 - **X. Minimal Dependencies** — new entry in `go.mod` `require` block without a matching justification line in the active `plan.md`; swap of a stdlib capability for a third-party one; transitive dependency expansion not noted.
 - **XI. Reports Optimized for Humans Under Pressure** — new top-level report section that does not justify its placement against the "80% signal" rule; exhaustive dumps promoted above summaries; removal of the "what triggered collection / state at trigger / deltas" spine.
 - **XII. Pinned Go Version** — change to the `go` directive in `go.mod`; new platform-divergent build tag outside `path/filepath` use; Go upgrade bundled with a feature commit.
-- **XIII. Canonical Code Path (NON-NEGOTIABLE)** — new function that duplicates an existing one with a trivial variation; an `if useNew { ... } else { ... }` internal feature flag; an old function left alongside a replacement; a silent fallback (`try A, on err try B`) without attaching a diagnostic or returning a typed error; a rename that leaves a re-export or alias behind; two helpers that model the same concept in different packages.
+- **XIII. Canonical Code Path (NON-NEGOTIABLE)** — new function, helper, workflow, API, worker route, UI behaviour, review skill, or automation path that duplicates an existing one with a trivial variation; an `if useNew { ... } else { ... }` internal feature flag; an old path left alongside a replacement; a hidden internal fallback (`try A, on err try B`) without attaching a diagnostic or returning a typed error; a rename that leaves a re-export or alias behind; two helpers that model the same concept in different packages. External degradation is allowed only when observable, tested or explicitly reviewed, and routed through the canonical owner.
 - **XIV. English-Only Durable Artifacts** — non-ASCII alphabetic characters in added lines outside `testdata/` and `_references/` (the carve-out for raw pt-stalk input); Spanish, Portuguese, or other non-English words in Go identifiers, comments, godoc, struct tags, commit subject/body, branch names, or anything under `specs/`, `.specify/`, `docs/`, `.claude/` (agent and skill files and their example trigger phrases), `scripts/`, `README.md`, `CHANGELOG.md`. Out-of-band chat with the user is exempt because it is not a checked-in artifact.
+- **XV. Bounded Source File Size** — any governed first-party source-code file over 1000 lines; any split that leaves a maintained source part over the limit; any new source-code exemption without a constitution amendment naming the exception and removal plan.
 
-## The 8 merge gates (also check each explicitly)
+## The 9 merge gates (also check each explicitly)
 
 1. `go vet ./...` and `go test ./...` — run them if you can (`bash` with a short timeout); at minimum confirm the diff doesn't obviously break compilation.
 2. New/modified parser has fixture + golden (Principle VIII).
@@ -57,6 +58,7 @@ For each principle below, look for the listed signals in the diff. This list is 
 6. No CGO, no runtime network, no writes under the input tree (Principles I, IX, II).
 7. No duplicated or fallback implementation left behind; no post-rename shim (Principle XIII).
 8. No non-English content introduced outside `testdata/` and `_references/` (Principle XIV).
+9. No governed first-party source-code file exceeds 1000 lines (Principle XV).
 
 ## Output format (mandatory)
 
@@ -90,6 +92,7 @@ Produce exactly one report in this shape. Match the taxonomy used in recent comm
 6. no CGO / network / input writes: <ok | violation: ...>
 7. canonical code path (no duplication/fallback): <ok | violation: ...>
 8. English-only artifacts outside testdata/_references: <ok | violation: ...>
+9. source file size limit: <ok | violation: ...>
 
 ## Verdict
 <one of: READY TO PUSH | FIX P1s FIRST | FIX P1s + REVIEW P2s>

--- a/.claude/skills/pr-review-fix-my-gather/SKILL.md
+++ b/.claude/skills/pr-review-fix-my-gather/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: pr-review-fix-my-gather
-description: "Triage Codex / Copilot findings on the current My-gather PR, verify each one, apply fixes that respect the 14-principle constitution in .specify/memory/constitution.md, mark resolved threads as resolved on GitHub, clean stale trigger comments, and optionally re-trigger the review cycle. Use in the My-gather repo whenever the user says `/pr-review-fix-my-gather`, `address review findings`, `fix codex comments`, `fix copilot comments`, `resolve PR review`, or is cycling through a codex-review round on the current branch. Prefer this over the generic `/pr-review-fix` when working in this repo — only this variant walks the 14 principles and uses Go-native validation. <example>Context: Codex has posted findings on the current PR. user: \"address the codex findings\" assistant: \"Invoking /pr-review-fix-my-gather to triage each finding, walk the constitution, apply valid fixes, mark the threads resolved, and commit.\"</example> <example>Context: User wants to clear an iteration. user: \"fix review comments and resolve them\" assistant: \"Launching /pr-review-fix-my-gather — will verify each comment against the code, apply only principle-compliant fixes, resolve the threads on GitHub, and push.\"</example> <example>Context: After a fresh codex round lands. user: \"process the codex round and push the fixes\" assistant: \"Running /pr-review-fix-my-gather: verify, principle-walk, fix, resolve threads, push.\"</example>"
+description: "Triage Codex / Copilot findings on the current My-gather PR, verify each one, apply fixes that respect the 15-principle constitution in .specify/memory/constitution.md, mark resolved threads as resolved on GitHub, clean stale trigger comments, and optionally re-trigger the review cycle. Use in the My-gather repo whenever the user says `/pr-review-fix-my-gather`, `address review findings`, `fix codex comments`, `fix copilot comments`, `resolve PR review`, or is cycling through a codex-review round on the current branch. Prefer this over the generic `/pr-review-fix` when working in this repo — only this variant walks the 15 principles and uses Go-native validation. <example>Context: Codex has posted findings on the current PR. user: \"address the codex findings\" assistant: \"Invoking /pr-review-fix-my-gather to triage each finding, walk the constitution, apply valid fixes, mark the threads resolved, and commit.\"</example> <example>Context: User wants to clear an iteration. user: \"fix review comments and resolve them\" assistant: \"Launching /pr-review-fix-my-gather — will verify each comment against the code, apply only principle-compliant fixes, resolve the threads on GitHub, and push.\"</example> <example>Context: After a fresh codex round lands. user: \"process the codex round and push the fixes\" assistant: \"Running /pr-review-fix-my-gather: verify, principle-walk, fix, resolve threads, push.\"</example>"
 ---
 
 # PR Review Fix (My-gather)
 
-Read Codex / Copilot findings on the current PR, verify each against the code, apply only fixes that satisfy the 14-principle constitution, mark fixed review threads resolved on GitHub, clean stale trigger comments, and optionally re-trigger the review cycle.
+Read Codex / Copilot findings on the current PR, verify each against the code, apply only fixes that satisfy the 15-principle constitution, mark fixed review threads resolved on GitHub, clean stale trigger comments, and optionally re-trigger the review cycle.
 
 This skill is one half of the review loop:
 
@@ -96,8 +96,9 @@ Re-read `.specify/memory/constitution.md` at the start of each run; the version 
 | X. Minimal Dependencies | Does the fix add a `go.mod require` entry without a justification line in the active feature's `plan.md`? |
 | XI. Reports Optimized for Humans Under Pressure | Does the fix promote an exhaustive dump above the "what triggered / state at trigger / deltas" spine? |
 | XII. Pinned Go Version | Does the fix change `go.mod`'s `go` directive as a side effect of another change? |
-| **XIII. Canonical Code Path (NON-NEGOTIABLE)** | Does the fix leave an old function, type, or code path alongside a replacement? Add a fallback (`try A, on error silently try B`)? Introduce an `if useNew { ... } else { ... }` internal flag? Keep a re-export or alias after a rename? Preserve a compat shim for internal callers? |
+| **XIII. Canonical Code Path (NON-NEGOTIABLE)** | Does the fix leave an old function, type, workflow, API, helper, worker route, UI behaviour, review skill, or automation path alongside a replacement? Add a hidden internal fallback (`try A, on error silently try B`)? Introduce an `if useNew { ... } else { ... }` internal flag? Keep a re-export or alias after a rename? Preserve a compat shim for internal callers? Add external degradation that is not observable, tested or explicitly reviewed, and routed through the canonical owner? |
 | XIV. English-Only Durable Artifacts | Does the fix add non-English content (identifiers, comments, godoc, commit message, docs, skill/agent/hook text) anywhere outside `testdata/` and `_references/`? Rewrite in English, keeping the fix intact. |
+| XV. Bounded Source File Size | Does the fix leave any governed first-party source-code file over 1000 lines or add a maintained source-code exemption without a constitution amendment naming the exception and removal plan? |
 
 Any yes means: **do not apply this fix as proposed**. Your options are:
 
@@ -129,7 +130,7 @@ For each `FIX` and `ALT`:
 
 ### Step 6 — Full local validation
 
-Match the CI gates and the 7 merge gates from `Development Workflow & Quality Gates`:
+Match the CI gates and the 9 merge gates from `Development Workflow & Quality Gates`:
 
 ```bash
 go vet ./...
@@ -249,6 +250,7 @@ Dismiss these when codex / copilot proposes them. Cite the principle in the dism
 11. **"Bump Go to the latest tip as part of this fix."** → Dismiss. Principle XII — Go upgrades are their own reviewed commit.
 12. **"Add a pre-existing-pattern refactor."** → Dismiss. Out of scope for a review-fix cycle; propose it as a separate issue if worth doing.
 13. **"Localize this comment / message / identifier to Spanish (or any non-English language)."** → Dismiss. Principle XIV — checked-in artifacts are English-only.
+14. **"Allow this source file to exceed 1000 lines for now."** → Dismiss. Principle XV — split governed first-party source code before merge or amend the constitution with a named exception and removal plan.
 
 ## Convergence metric
 

--- a/.claude/skills/pr-review-loop-my-gather/SKILL.md
+++ b/.claude/skills/pr-review-loop-my-gather/SKILL.md
@@ -22,7 +22,7 @@ Operationally, after running `/pr-review-fix-my-gather` and `/pr-review-trigger-
 ## Scope and non-negotiables
 
 - **Composes, never duplicates.** This skill calls the other two via their slugs — it does not reimplement the fix or trigger logic. Any change to fix or trigger semantics happens in those files (Principle XIII: canonical code path, no duplicated implementations).
-- **Every applied fix inherits the full 14-principle walk** from `/pr-review-fix-my-gather`. That walk is **not** bypassed, shortened, or softened inside this loop. If a proposed fix would violate a principle, the fix skill dismisses it or applies an alternative remedy — same as a single-shot run.
+- **Every applied fix inherits the full 15-principle walk** from `/pr-review-fix-my-gather`. That walk is **not** bypassed, shortened, or softened inside this loop. If a proposed fix would violate a principle, the fix skill dismisses it or applies an alternative remedy — same as a single-shot run.
 - **No fix ever introduces a duplicated or fallback implementation** (Principle XIII). If the fix skill returns without applying a change for a given finding because the only remedy would violate XIII, that finding is dismissed with a reply citing XIII — the loop does not retry it with a looser remedy.
 - **English-only** (Principle XIV) across every artifact this skill touches: commit messages, review replies, thread-resolution notes, and log lines.
 - **Commit + push is the default flow** — inherited from `/pr-review-fix-my-gather`'s Step 7. This skill never modifies code directly; code changes only come through the fix skill.
@@ -97,7 +97,7 @@ Call the fix skill:
 
 > `/pr-review-fix-my-gather`
 
-The fix skill runs its full procedure: verify each finding, walk all 14 principles, apply fixes (or alternative remedies, or dismissals), run `go vet ./...` and `go test ./...`, invoke `@agent-pre-review-constitution-guard`, commit, push, and resolve each processed thread via GraphQL.
+The fix skill runs its full procedure: verify each finding, walk all 15 principles, apply fixes (or alternative remedies, or dismissals), run `go vet ./...` and `go test ./...`, invoke `@agent-pre-review-constitution-guard`, commit, push, and resolve each processed thread via GraphQL.
 
 **Critical contract for this loop**: if the fix skill dismisses a finding because the only remedy would violate a principle (most commonly XIII — duplicated code / silent fallback — or XIV — non-English content), that dismissal is **final**. The loop MUST NOT retry that finding on the next iteration. Because the fix skill resolves the thread on dismissal, Codex's next review will not re-raise a thread it already resolved — but if Codex does raise it again anyway, the fix skill will dismiss it again with the same XIII/XIV citation. That is correct behaviour; not a bug to work around.
 

--- a/.claude/skills/pr-review-trigger-my-gather/SKILL.md
+++ b/.claude/skills/pr-review-trigger-my-gather/SKILL.md
@@ -125,8 +125,9 @@ Code review requested on `${BRANCH}` — ${COMMIT_COUNT} commits, ${DIFF_STAT}, 
 
 - **Principle IV (Deterministic Output)**: output MUST be byte-identical across runs. No map iteration without sorted keys, no unstable sort, no `time.Now()` reaching the render path, no locale-dependent float formatting, no random IDs.
 - **Principle VIII (Reference Fixtures & Golden Tests)**: new parsers MUST ship with a fixture under `testdata/` and a golden under `testdata/golden/` in the same change.
-- **Principle XIII (Canonical Code Path, NON-NEGOTIABLE)**: exactly one implementation per behaviour. No duplicated code, no silent fallbacks (`try A, on error try B`), no post-rename compatibility shims, no `if useNew { ... } else { ... }` internal flags. When a function is replaced, the old one is deleted in the same change.
+- **Principle XIII (Canonical Code Path, NON-NEGOTIABLE)**: exactly one canonical implementation path per behaviour, workflow, API, helper, worker route, UI behaviour, review skill, or automation path. No duplicated code, no hidden internal fallbacks (`try A, on error try B`), no post-rename compatibility shims, no `if useNew { ... } else { ... }` internal flags. When a path is replaced, the old one is deleted in the same change. External degradation must be observable, tested or explicitly reviewed, and routed through the canonical owner.
 - **Principle XIV (English-Only Durable Artifacts)**: all checked-in code, comments, commit messages, docs, and configuration MUST be English. The only exempt content is under `testdata/` and `_references/` (raw pt-stalk input).
+- **Principle XV (Bounded Source File Size)**: governed first-party source-code files MUST stay at or below 1000 lines. Specs, docs, fixtures, goldens, lockfiles, and vendored/minified third-party assets are outside this source-code rule.
 
 **Focus:** real bugs, correctness, determinism regressions, exception handling, behavioural drift from deleted code, principle violations.
 
@@ -134,6 +135,7 @@ Code review requested on `${BRANCH}` — ${COMMIT_COUNT} commits, ${DIFF_STAT}, 
 
 - Keeping legacy/fallback code or dual implementations (Principle XIII).
 - Re-exports or compatibility aliases after a rename (Principle XIII).
+- External degradation that is hidden, untested, or routed around the canonical owner (Principle XIII).
 - Goroutines, parallelism, or concurrent parsing anywhere in `parse/`, `model/`, or `render/` (Principle IV).
 - External fetches, CDN links, or runtime network I/O (Principles V + IX).
 - Silent fallback parsers — always attach a structured diagnostic instead (Principle III).
@@ -143,6 +145,7 @@ Code review requested on `${BRANCH}` — ${COMMIT_COUNT} commits, ${DIFF_STAT}, 
 - `fmt.Errorf` for branchable conditions — use typed errors with `%w` (Principle VII).
 - Bumping the Go directive in `go.mod` as a side effect (Principle XII).
 - Non-English content in code, comments, commit messages, docs, or configuration outside `testdata/` and `_references/` (Principle XIV).
+- Letting a governed first-party source-code file exceed 1000 lines (Principle XV).
 - Style, formatting, or import ordering — CI and `gofmt` already enforce those.
 
 **Do NOT implement or push changes.** Review-only. Findings as inline comments, please.

--- a/.specify/memory/constitution.md
+++ b/.specify/memory/constitution.md
@@ -1,6 +1,52 @@
 <!--
 Sync Impact Report
 ==================
+Version change: 1.5.0 → 1.6.0
+Bump rationale: MINOR-level material expansion of existing Principle
+  XIII. The canonical-code-path rule already forbade duplicated
+  implementations, silent fallbacks, and internal compatibility shims;
+  this amendment broadens the wording to match the full project
+  surface (features, workflows, APIs, helpers, contracts, worker
+  routes, UI behaviours, and review skills) and adds explicit
+  external-degradation criteria so legitimate graceful degradation
+  cannot be confused with forbidden internal fallback paths. No new
+  principle is added.
+
+Added principles: none.
+
+Modified principles:
+  - XIII. Canonical Code Path (NON-NEGOTIABLE) → broadened from
+    function/type/code-path wording to every maintained behaviour,
+    workflow, API, helper, parser, validator, renderer path, worker
+    route, UI behaviour, and review skill; added observable/tested
+    external-degradation criteria and a requirement that specs/plans/
+    tasks identify the canonical path for touched behaviour.
+
+Modified sections:
+  - Development Workflow & Quality Gates → gate 7 now names the
+    expanded canonical-path audit expectations for specs, plans, tasks,
+    and review.
+
+Templates requiring updates:
+  - .specify/templates/plan-template.md             updated
+  - .specify/templates/tasks-template.md            updated
+  - .specify/templates/spec-template.md             updated
+  - .specify/templates/checklist-template.md        compatible
+  - .claude/agents/pre-review-constitution-guard.md updated
+  - .claude/skills/pr-review-*-my-gather/           updated
+  - AGENTS.md                                      compatible
+  - CLAUDE.md                                      updated
+  - README.md                                      updated
+
+Deferred items / follow-up TODOs:
+  - Existing source-code canonical-path smells identified during the
+    audit (for example render-side helper duplication and legacy
+    fallback/migration comments) are intentionally not changed in this
+    documentation-only amendment. They should be handled in a separate
+    source refactor.
+
+Prior Sync Impact Report (1.5.0) follows for history:
+-----------------------------------------------------
 Version change: 1.4.0 → 1.5.0
 Bump rationale: MINOR-level addition of a new Core Principle — XV.
   Bounded Source File Size — plus a companion mechanical quality gate.
@@ -468,18 +514,37 @@ of another commit.
 
 ### XIII. Canonical Code Path (NON-NEGOTIABLE)
 
-Every behaviour in My-gather MUST have exactly one implementation. When a
-function, type, or code path is replaced, the old one MUST be deleted in
-the same change — not left behind, not guarded by an internal flag, not
-retained "for safety". Silent fallbacks (try A, on failure silently try B)
-are prohibited; recoverable failures MUST surface as typed errors
-(Principle VII) or structured diagnostics in the report (Principle III),
-never as a second hidden attempt. Re-exports and compatibility shims for
-internal identifiers after a rename are prohibited; all call sites MUST
-be updated in the same commit. This principle does not forbid branching
-driven by genuine input variation (e.g., distinct pt-stalk file format
-versions) or platform primitives (`path/filepath`), provided the branches
-converge into a single typed model as early as possible.
+Every behaviour, feature, workflow, API, helper, parser, validator,
+renderer path, worker route, UI behaviour, review skill, and automation
+entry point in My-gather MUST have exactly one canonical implementation
+path. New code MUST reuse, move, or improve that canonical path instead
+of creating a parallel helper, wrapper, duplicate API, compatibility shim,
+internal feature flag, or competing implementation. When a function, type,
+contract, file layout, or code path is replaced, the old path MUST be
+deleted in the same change — not left behind, not guarded by an internal
+flag, not retained "for safety". Re-exports and compatibility shims for
+internal identifiers after a rename are prohibited; all call sites MUST be
+updated in the same commit.
+
+Silent internal fallbacks (try A, on failure silently try B) are prohibited.
+Recoverable failures MUST surface as typed errors (Principle VII) or
+structured diagnostics in the report (Principle III), never as a second
+hidden attempt. External degradation paths are allowed only for genuine
+runtime boundaries outside the canonical implementation's control, such as
+missing or malformed pt-stalk inputs, unavailable browser capabilities,
+network or upstream-service failure on the named feedback exception, or
+platform primitives (`path/filepath`). Such degradation MUST be observable
+to the user or caller, covered by tests or explicit review evidence, and
+routed through the canonical owner rather than a preserved old
+implementation.
+
+This principle does not forbid branching driven by genuine input variation
+(e.g., distinct pt-stalk file format versions), provided the branches
+converge into a single typed model as early as possible. Specs, plans, and
+tasks that touch existing behaviour MUST identify the canonical owner/path,
+state whether an old path is removed or unchanged, and include a review
+step that verifies no duplicate implementation, hidden fallback, or
+compatibility shim remains.
 
 ### XIV. English-Only Durable Artifacts
 
@@ -572,11 +637,17 @@ is the only line of defence:
    `ioutil.WriteFile` lands in `parse/` or `cmd/` (Principle II,
    pre-push hook greps the diff). All three halves now block the
    push without human action.
-7. **[REVIEW]** No change leaves a duplicated or fallback implementation
-   of an existing behaviour in place (Principle XIII). Replaced
-   functions, types, and code paths MUST be deleted in the same change;
-   internal re-exports and compatibility shims after a rename are
-   prohibited. Reviewers verify on the diff; no mechanical check today.
+7. **[REVIEW]** No change leaves a duplicated, competing, or fallback
+   implementation of an existing behaviour in place (Principle XIII).
+   Replaced functions, types, contracts, file layouts, workflows, APIs,
+   helpers, worker routes, UI behaviours, review skills, and automation
+   paths MUST delete the old path in the same change unless a separate
+   constitution amendment names a temporary exception and removal plan.
+   Specs, plans, tasks, and review notes MUST identify the canonical
+   owner/path for touched behaviour and verify that any external
+   degradation path is observable, tested or explicitly reviewed, and
+   routed through that owner. Reviewers verify on the diff; no mechanical
+   check today.
 8. **[MECHANICAL]** No change introduces non-English content into any
    checked-in artifact outside `testdata/` and `_references/`
    (Principle XIV). Enforced by a byte-level grep in
@@ -639,4 +710,4 @@ invocation via the Constitution Check gate. Runtime development guidance
 and feature-local `plan.md` / `quickstart.md` files and MUST defer to this
 constitution when conflicts arise.
 
-**Version**: 1.5.0 | **Ratified**: 2026-04-21 | **Last Amended**: 2026-05-01
+**Version**: 1.6.0 | **Ratified**: 2026-04-21 | **Last Amended**: 2026-05-04

--- a/.specify/templates/plan-template.md
+++ b/.specify/templates/plan-template.md
@@ -36,8 +36,8 @@
 **Canonical Path Audit (Principle XIII)**:
 - Canonical owner/path for touched behaviour: [package/file/workflow/API]
 - Replaced or retired paths: [deleted in this change | unchanged | N/A]
-- External degradation paths, if any: [observable/tested route through the
-  canonical owner | N/A]
+- External degradation paths, if any: [observable/tested or explicitly reviewed
+  route through the canonical owner | N/A]
 - Review check: [how reviewers verify no duplicate implementation, hidden
   fallback, compatibility shim, or competing helper remains]
 

--- a/.specify/templates/plan-template.md
+++ b/.specify/templates/plan-template.md
@@ -33,6 +33,14 @@
 
 [Gates determined based on constitution file]
 
+**Canonical Path Audit (Principle XIII)**:
+- Canonical owner/path for touched behaviour: [package/file/workflow/API]
+- Replaced or retired paths: [deleted in this change | unchanged | N/A]
+- External degradation paths, if any: [observable/tested route through the
+  canonical owner | N/A]
+- Review check: [how reviewers verify no duplicate implementation, hidden
+  fallback, compatibility shim, or competing helper remains]
+
 ## Project Structure
 
 ### Documentation (this feature)

--- a/.specify/templates/spec-template.md
+++ b/.specify/templates/spec-template.md
@@ -90,6 +90,15 @@
 - **FR-004**: System MUST [data requirement, e.g., "persist user preferences"]
 - **FR-005**: System MUST [behavior, e.g., "log all security events"]
 
+### Canonical Path Expectations *(include when changing existing behavior)*
+
+- **Canonical owner/path**: [Name the existing feature, workflow, API, helper,
+  UI behavior, worker route, or automation path this change updates]
+- **Old path treatment**: [deleted in this feature | unchanged because not
+  replaced | N/A]
+- **External degradation**: [observable user/caller outcome and test/review
+  evidence | N/A]
+
 *Example of marking unclear requirements:*
 
 - **FR-006**: System MUST authenticate users via [NEEDS CLARIFICATION: auth method not specified - email/password, SSO, OAuth?]

--- a/.specify/templates/spec-template.md
+++ b/.specify/templates/spec-template.md
@@ -98,6 +98,8 @@
   replaced | N/A]
 - **External degradation**: [observable user/caller outcome and test/review
   evidence | N/A]
+- **Review check**: [how review verifies no duplicate implementation, hidden
+  fallback, compatibility shim, or competing path remains]
 
 *Example of marking unclear requirements:*
 

--- a/.specify/templates/tasks-template.md
+++ b/.specify/templates/tasks-template.md
@@ -12,6 +12,12 @@ description: "Task list template for feature implementation"
 
 **Organization**: Tasks are grouped by user story to enable independent implementation and testing of each story.
 
+## Canonical Path Metadata *(Principle XIII; include when changing existing behavior)*
+
+- **Canonical owner/path**: [package/file/workflow/API from plan.md]
+- **Old path treatment**: [deleted by task IDs | unchanged because not replaced | N/A]
+- **External degradation evidence**: [test task IDs or explicit review task | N/A]
+
 ## Format: `[ID] [P?] [Story] Description`
 
 - **[P]**: Can run in parallel (different files, no dependencies)
@@ -152,9 +158,10 @@ Examples of foundational tasks (adjust based on your project):
 
 - [ ] TXXX [P] Documentation updates in docs/
 - [ ] TXXX Code cleanup and refactoring
-- [ ] TXXX Canonical-path audit: verify the plan's Principle XIII owner/path is
-      the only implementation, replaced paths are deleted, external degradation
-      paths are observable/tested, and no compatibility shim or hidden fallback
+- [ ] TXXX Canonical-path audit: verify the Principle XIII metadata above
+      identifies the canonical owner/path and old-path treatment, replaced
+      paths are deleted, external degradation paths are observable and covered
+      by tests or explicit review, and no compatibility shim or hidden fallback
       remains.
 - [ ] TXXX Performance optimization across all stories
 - [ ] TXXX [P] Additional unit tests (if requested) in tests/unit/

--- a/.specify/templates/tasks-template.md
+++ b/.specify/templates/tasks-template.md
@@ -152,6 +152,10 @@ Examples of foundational tasks (adjust based on your project):
 
 - [ ] TXXX [P] Documentation updates in docs/
 - [ ] TXXX Code cleanup and refactoring
+- [ ] TXXX Canonical-path audit: verify the plan's Principle XIII owner/path is
+      the only implementation, replaced paths are deleted, external degradation
+      paths are observable/tested, and no compatibility shim or hidden fallback
+      remains.
 - [ ] TXXX Performance optimization across all stories
 - [ ] TXXX [P] Additional unit tests (if requested) in tests/unit/
 - [ ] TXXX Security hardening

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,7 +57,7 @@ signals must name the same feature before running `/speckit-*` workflows.
   list the My-gather-specific anti-patterns so bots can self-filter.
   **Use this in this repo, not the global `/pr-review-trigger`.**
 - `/pr-review-fix-my-gather` (skill at `.claude/skills/pr-review-fix-my-gather/`)
-  — the My-gather variant of the PR review-fix workflow. Walks the 14
+  — the My-gather variant of the PR review-fix workflow. Walks the 15
   principles in `.specify/memory/constitution.md`, uses Go-native
   validation, and marks review threads resolved on GitHub. **Use this
   in this repo, not the global `/pr-review-fix`** — the global one
@@ -76,4 +76,5 @@ signals must name the same feature before running `/speckit-*` workflows.
   before you push.
 - Pre-push hook (`scripts/hooks/pre-push-constitution-guard.sh`) wired
   via `.claude/settings.json` — mechanical checks that block pushes
-  violating Principles I, VIII, or X.
+  violating the mechanically enforced constitution gates, including
+  Principles I, II, VI, VIII, IX, X, XIV, and XV.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -76,5 +76,6 @@ signals must name the same feature before running `/speckit-*` workflows.
   before you push.
 - Pre-push hook (`scripts/hooks/pre-push-constitution-guard.sh`) wired
   via `.claude/settings.json` — mechanical checks that block pushes
-  violating the mechanically enforced constitution gates, including
-  Principles I, II, VI, VIII, IX, X, XIV, and XV.
+  violating the diff-scoped mechanical gates, including Principles I,
+  II, VI, VIII, IX, X, and XIV. Principle XV is enforced by
+  `tests/coverage/file_size_test.go` in the Go test suite.

--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ If the backend is unreachable the dialog degrades gracefully to GitHub's new-iss
 
 ## Design principles
 
-The project's [constitution](.specify/memory/constitution.md) locks in fourteen non-negotiables:
+The project's [constitution](.specify/memory/constitution.md) locks in fifteen non-negotiables:
 
 1. **Single static binary.** No CGO, no libc version negotiation, no runtime install step.
 2. **Read-only inputs.** Never modify the pt-stalk tree.
@@ -130,8 +130,9 @@ The project's [constitution](.specify/memory/constitution.md) locks in fourteen 
 10. **Minimal dependencies.** Stdlib-first; every third-party module justifies itself in the active feature's plan.
 11. **Reports optimised for humans under pressure.** Primary narrative (trigger + state at trigger + deltas) takes precedence over exhaustive metric dumps.
 12. **Pinned Go version.** Upgrades are their own reviewed commit.
-13. **Canonical code path** *(NON-NEGOTIABLE)*. One implementation per behaviour — no silent fallbacks, no post-rename shims.
+13. **Canonical code path** *(NON-NEGOTIABLE)*. One canonical implementation path per behaviour, workflow, API, helper, UI path, worker route, and review skill — no duplicate implementations, hidden internal fallbacks, or post-rename shims.
 14. **English-only durable artifacts.** Code, comments, commit messages, specs, docs — all English. Exempt: `testdata/` and `_references/` (raw pt-stalk input).
+15. **Bounded source file size.** First-party source-code files stay at or below 1000 lines; specs, docs, fixtures, goldens, lockfiles, and vendored/minified third-party assets are outside this source-code rule.
 
 ## Repository layout
 
@@ -189,7 +190,7 @@ A dedicated test renders the same fixture twice and asserts byte-identical outpu
 
 ## Contributing
 
-1. Read the [constitution](.specify/memory/constitution.md). Every contribution gates on those fourteen principles.
+1. Read the [constitution](.specify/memory/constitution.md). Every contribution gates on those fifteen principles.
 2. New features go through the spec-driven pipeline — see `specs/` for prior examples (spec → plan → research → data-model → contracts → tasks → implement).
 3. Local pre-push enforces the constitution via `scripts/hooks/pre-push-constitution-guard.sh` (wired through `.claude/settings.json`); CI runs the same checks on every PR.
 4. Issues + discussions: the in-report "Report feedback" button is the preferred path; manual filing is also welcome at [github.com/matias-sanchez/My-gather/issues](https://github.com/matias-sanchez/My-gather/issues).


### PR DESCRIPTION
## Summary
- bump the constitution to v1.6.0 by strengthening Principle XIII across workflows, APIs, helpers, UI behavior, worker routes, review skills, and automation paths
- clarify allowed external degradation as observable, tested or explicitly reviewed, and routed through the canonical owner
- update Spec Kit templates, README, CLAUDE context, and My-gather review guidance from the stale 14/8 model to the current 15-principle / 9-gate model

## Validation
- go test ./tests/coverage -count=1
- go test ./... -count=1
- go vet ./...
- make lint
- scripts/hooks/pre-push-constitution-guard.sh </dev/null
- .specify/scripts/bash/check-prerequisites.sh --json --require-tasks --include-tasks

## Notes
- This is a documentation/template/review-guidance-only stacked PR on top of #44.
- Source-code canonical-path follow-ups identified during audit are intentionally left for a separate source refactor.