### PR TITLE
InnoDB redo-log sizing panel (#55)

### DIFF
--- a/.specify/feature.json
+++ b/.specify/feature.json
@@ -1,3 +1,3 @@
 {
-  "feature_directory": "specs/015-compliance-closure"
+  "feature_directory": "specs/019-redo-log-sizing-panel"
 }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,18 +1,19 @@
 <!-- SPECKIT START -->
-Active feature: **015-compliance-closure**
+Active feature: **019-redo-log-sizing-panel**
 
 For technologies, project structure, constitution gates, data model,
 contracts, and shell commands, read the current plan:
 
-- Plan: `specs/015-compliance-closure/plan.md`
-- Spec: `specs/015-compliance-closure/spec.md`
-- Research: `specs/015-compliance-closure/research.md`
-- Contracts: `specs/015-compliance-closure/contracts/audit.md`
-- Quickstart: `specs/015-compliance-closure/quickstart.md`
-- Tasks: `specs/015-compliance-closure/tasks.md`
+- Plan: `specs/019-redo-log-sizing-panel/plan.md`
+- Spec: `specs/019-redo-log-sizing-panel/spec.md`
+- Research: `specs/019-redo-log-sizing-panel/research.md`
+- Contracts: `specs/019-redo-log-sizing-panel/contracts/redo-sizing-panel.md`
+- Quickstart: `specs/019-redo-log-sizing-panel/quickstart.md`
+- Tasks: `specs/019-redo-log-sizing-panel/tasks.md`
 - Constitution: `.specify/memory/constitution.md`
 
 Prior features:
+- **015-compliance-closure** - `specs/015-compliance-closure/plan.md`
 - **014-reconciliation-cleanup** - `specs/014-reconciliation-cleanup/plan.md`
 - **013-full-compliance-fixes** - `specs/013-full-compliance-fixes/plan.md`
 - **012-repo-alignment-audit** - `specs/012-repo-alignment-audit/plan.md`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,18 +1,19 @@
 <!-- SPECKIT START -->
-Active feature: **015-compliance-closure**
+Active feature: **019-redo-log-sizing-panel**
 
 For technologies, project structure, constitution gates, data model,
 contracts, and shell commands, read the current plan:
 
-- Plan: `specs/015-compliance-closure/plan.md`
-- Spec: `specs/015-compliance-closure/spec.md`
-- Research: `specs/015-compliance-closure/research.md`
-- Contracts: `specs/015-compliance-closure/contracts/audit.md`
-- Quickstart: `specs/015-compliance-closure/quickstart.md`
-- Tasks: `specs/015-compliance-closure/tasks.md`
+- Plan: `specs/019-redo-log-sizing-panel/plan.md`
+- Spec: `specs/019-redo-log-sizing-panel/spec.md`
+- Research: `specs/019-redo-log-sizing-panel/research.md`
+- Contracts: `specs/019-redo-log-sizing-panel/contracts/redo-sizing-panel.md`
+- Quickstart: `specs/019-redo-log-sizing-panel/quickstart.md`
+- Tasks: `specs/019-redo-log-sizing-panel/tasks.md`
 - Constitution: `.specify/memory/constitution.md`
 
 Prior features:
+- **015-compliance-closure** - `specs/015-compliance-closure/plan.md`
 - **014-reconciliation-cleanup** - `specs/014-reconciliation-cleanup/plan.md`
 - **013-full-compliance-fixes** - `specs/013-full-compliance-fixes/plan.md`
 - **012-repo-alignment-audit** - `specs/012-repo-alignment-audit/plan.md`

--- a/render/build_view.go
+++ b/render/build_view.go
@@ -189,6 +189,7 @@ func buildView(r *model.Report, c *model.Collection, sigs []string) (*reportView
 	if r.DBSection != nil {
 		v.InnoDBMetrics = aggregateInnoDBMetrics(r.DBSection.InnoDBPerSnapshot)
 		v.HasInnoDB = len(v.InnoDBMetrics) > 0
+		v.RedoSizing = computeRedoSizing(r)
 		v.HasMysqladmin = r.DBSection.Mysqladmin != nil
 		v.HasProcesslist = r.DBSection.Processlist != nil
 		if v.HasProcesslist {

--- a/render/redo_sizing.go
+++ b/render/redo_sizing.go
@@ -224,16 +224,43 @@ func readConfiguredRedoSpace(r *model.Report) (float64, string) {
 // peak walk treats each block independently so a single peak window
 // never spans a cross-snapshot gap.
 //
-// SkipFirst is true only for the very first block of the merged series.
-// pt-mext stores the cold-start tally at index 0 of the first snapshot,
-// which is not a real per-interval delta. model.MergeMysqladminData
-// drops this raw tally for every snapshot after the first (it inserts a
-// NaN at the boundary and appends src[1:]), so post-boundary blocks'
-// first finite samples ARE genuine deltas and must be included.
+// SkipFirst is true only for a block that begins at the very first
+// global timestamp (startIdx == 0). pt-mext stores the cold-start tally
+// at index 0 of the first snapshot, which is not a real per-interval
+// delta; that tally only ever lives at global index 0. Every other
+// block — including the first FINITE block after a leading NaN gap
+// (e.g. when Innodb_os_log_written is absent in early snapshots and
+// appears later) and every post-boundary block — has its raw tally
+// already stripped by model.MergeMysqladminData (it inserts a NaN at
+// the boundary and appends src[1:]), so its first finite sample IS a
+// genuine per-interval delta and must be included. Tying SkipFirst to
+// the global index, not to block ordinal, is the canonical predicate
+// (Principle XIII).
 type redoSampleBlock struct {
 	startIdx  int
 	endIdx    int
 	SkipFirst bool
+}
+
+// hasUsableDelta reports whether a block carries at least one
+// per-interval delta after applying the SkipFirst rule. A block with
+// zero finite samples is unusable. A SkipFirst block (startIdx == 0)
+// with only the cold-start tally is also unusable: the single sample
+// at index 0 is the raw tally, not a per-interval delta, and the
+// observed-seconds accumulator and the rolling-peak walk both skip it.
+// Every other block — including a single-delta post-boundary block —
+// has at least one usable delta covering a real interval bounded on
+// the left by timestamps[blockLeftBoundIdx(b)]. This is the canonical
+// "block carries at least one usable delta" predicate (Principle XIII).
+func (b redoSampleBlock) hasUsableDelta() bool {
+	n := b.endIdx - b.startIdx
+	if n < 1 {
+		return false
+	}
+	if b.SkipFirst && n < 2 {
+		return false
+	}
+	return true
 }
 
 // blockLeftBoundIdx returns the timestamp index that anchors the left
@@ -303,14 +330,19 @@ func readObservedRedoRate(m *model.MysqladminData) (
 
 	// Build contiguous blocks separated by NaN slots. Each block is a
 	// half-open index range [start, end) of indices i such that
-	// deltas[i] is finite. Only the FIRST block carries the raw
-	// initial tally at its start index (pt-mext writes the cold-start
-	// counter value there, the same convention used by
-	// findings.counterTotal); model.MergeMysqladminData strips that
-	// raw tally from every snapshot after the first by appending
-	// src[1:] after the NaN boundary slot, so post-boundary blocks'
-	// first finite samples are genuine per-interval deltas and MUST
-	// be included in both the average and the rolling-window peak.
+	// deltas[i] is finite. Only a block starting at global index 0
+	// carries the raw cold-start tally at its start index (pt-mext
+	// writes the cold-start counter value there for the very first
+	// snapshot, the same convention used by findings.counterTotal);
+	// model.MergeMysqladminData strips that raw tally from every
+	// snapshot after the first by appending src[1:] after the NaN
+	// boundary slot, so a block whose startIdx > 0 — whether it is
+	// the first FINITE block after leading NaN padding or any later
+	// post-boundary block — has its first finite sample as a genuine
+	// per-interval delta that MUST be included in both the average
+	// and the rolling-window peak. Tying SkipFirst to startIdx == 0
+	// rather than block ordinal is the canonical predicate
+	// (Principle XIII).
 	var blocks []redoSampleBlock
 	startIdx := -1
 	for i, d := range deltas {
@@ -319,7 +351,7 @@ func readObservedRedoRate(m *model.MysqladminData) (
 				blocks = append(blocks, redoSampleBlock{
 					startIdx:  startIdx,
 					endIdx:    i,
-					SkipFirst: len(blocks) == 0,
+					SkipFirst: startIdx == 0,
 				})
 				startIdx = -1
 			}
@@ -333,23 +365,25 @@ func readObservedRedoRate(m *model.MysqladminData) (
 		blocks = append(blocks, redoSampleBlock{
 			startIdx:  startIdx,
 			endIdx:    len(deltas),
-			SkipFirst: len(blocks) == 0,
+			SkipFirst: startIdx == 0,
 		})
 	}
 
-	// Sum totals and accumulate observed seconds across blocks. For
-	// the first block we skip its first index (the cold-start tally)
-	// but include its timestamp as the block's start boundary. For
-	// subsequent blocks we include every finite sample because
-	// MergeMysqladminData has already stripped the raw tally at the
-	// snapshot boundary. Negative deltas are clamped to 0 to absorb
-	// counter resets (server restart mid-capture re-zeroes
-	// Innodb_os_log_written, producing a negative delta on the next
-	// sample); a counter reset is not a write of negative bytes.
+	// Sum totals and accumulate observed seconds across blocks. For a
+	// SkipFirst block (one that begins at global index 0) we skip
+	// its first index (the cold-start tally) but include its
+	// timestamp as the block's start boundary. For every other block
+	// — including a single-delta post-boundary block — we include
+	// every finite sample because MergeMysqladminData has already
+	// stripped the raw tally at the snapshot boundary. Negative
+	// deltas are clamped to 0 to absorb counter resets (server
+	// restart mid-capture re-zeroes Innodb_os_log_written, producing
+	// a negative delta on the next sample); a counter reset is not a
+	// write of negative bytes.
 	var totalBytes, totalSeconds float64
 	var anyData bool
 	for _, b := range blocks {
-		if b.endIdx-b.startIdx < 2 {
+		if !b.hasUsableDelta() {
 			continue
 		}
 		anyData = true
@@ -414,7 +448,7 @@ func computeRollingPeak(
 	// target window.
 	longest := 0.0
 	for _, b := range blocks {
-		if b.endIdx-b.startIdx < 2 {
+		if !b.hasUsableDelta() {
 			continue
 		}
 		span := timestamps[b.endIdx-1].Sub(timestamps[blockLeftBoundIdx(b)]).Seconds()
@@ -435,10 +469,11 @@ func computeRollingPeak(
 
 	for _, b := range blocks {
 		// We slide a window over the per-sample deltas within this
-		// block. SkipFirst is true only for the first block (the
-		// cold-start tally); subsequent blocks include every finite
-		// sample because MergeMysqladminData has already stripped
-		// the raw tally at the snapshot boundary.
+		// block. SkipFirst is true only for a block that begins at
+		// global index 0 (the cold-start tally); every other block —
+		// including a single-delta post-boundary block — includes
+		// every finite sample because MergeMysqladminData has already
+		// stripped the raw tally at the snapshot boundary.
 		startI := b.startIdx
 		if b.SkipFirst {
 			startI = b.startIdx + 1

--- a/render/redo_sizing.go
+++ b/render/redo_sizing.go
@@ -1,0 +1,397 @@
+package render
+
+import (
+	"fmt"
+	"math"
+	"time"
+
+	"github.com/matias-sanchez/My-gather/model"
+	"github.com/matias-sanchez/My-gather/reportutil"
+)
+
+// kbReferenceRedoSizing is the methodology source cited in the
+// rendered Redo log sizing panel. The user explicitly requested this
+// reference in feature 019-redo-log-sizing-panel; it is held as a
+// package-level constant so tests can assert against the same string
+// the template will render.
+const kbReferenceRedoSizing = "Percona KB0010732"
+
+// redoSizingPeakWindowSeconds is the canonical 15-minute rolling
+// window length (in seconds) used by the panel's peak computation.
+// When the longest contiguous block of mysqladmin samples is shorter
+// than this, computeRedoSizing collapses the window to that block's
+// duration and labels the result so the reader knows the peak is
+// observed over the available window rather than a true 15-minute
+// window.
+const redoSizingPeakWindowSeconds = 15.0 * 60.0
+
+// redoSizingView is the payload for the Redo log sizing panel rendered
+// under the InnoDB Status subsection. The State field communicates
+// which subset of the panel can be populated; the KBReference field
+// is always populated regardless of state. See
+// specs/019-redo-log-sizing-panel/contracts/redo-sizing-panel.md for
+// the full contract.
+type redoSizingView struct {
+	// State drives which template branches render.
+	// Values: "ok" | "config_missing" | "rate_unavailable" | "no_writes".
+	State string
+
+	// ConfiguredBytes is the total redo log capacity in bytes. Zero
+	// when State == "config_missing".
+	ConfiguredBytes float64
+	// ConfiguredText is the human-readable form, or "unavailable".
+	ConfiguredText string
+	// ConfigSource names the variable(s) used:
+	//   "innodb_redo_log_capacity"                          (8.0.30+)
+	//   "innodb_log_file_size x innodb_log_files_in_group"  (5.6/5.7)
+	//   ""                                                  (config_missing)
+	ConfigSource string
+
+	// ObservedRateBytesPerSec is the average rate over the entire
+	// capture. Zero when State == "rate_unavailable".
+	ObservedRateBytesPerSec float64
+	ObservedRateText        string
+	ObservedRatePerMinText  string
+
+	// PeakWindowSeconds is the actual rolling-window length used.
+	// 900 (== 15 minutes) when the longest contiguous block of
+	// samples is at least 15 minutes long; otherwise the longest
+	// block's wall-clock duration in seconds.
+	PeakWindowSeconds float64
+	// PeakWindowLabel is the rendered window descriptor used by the
+	// template, for example "15-minute" or "available 28-second".
+	PeakWindowLabel string
+	// PeakRateBytesPerSec is the peak rate observed over the rolling
+	// window of length PeakWindowSeconds. Zero when no rate is
+	// available or the rate is uniformly zero.
+	PeakRateBytesPerSec float64
+	PeakRateText        string
+
+	// CoverageMinutes is configured_bytes / peak_rate / 60. Zero when
+	// CoverageText == "n/a".
+	CoverageMinutes float64
+	CoverageText    string
+
+	// Recommended target sizes in bytes plus their human form.
+	Recommended15MinBytes float64
+	Recommended15MinText  string
+	Recommended1HourBytes float64
+	Recommended1HourText  string
+
+	// UnderSized is true iff State == "ok" AND CoverageMinutes < 15.
+	// The template uses this as the gate for the warning line.
+	UnderSized  bool
+	WarningLine string
+
+	// KBReference is always populated; the template renders it as
+	// the panel's methodology citation.
+	KBReference string
+}
+
+// computeRedoSizing produces the view payload for the Redo log sizing
+// panel under the InnoDB Status section. Returns nil when the report
+// has no DBSection (the panel does not render at all in that case).
+// In every other case it returns a non-nil view; the view's State
+// field communicates which subset of the panel can be populated. The
+// KBReference field is always populated.
+//
+// The configured-space reader is the canonical source for "how big is
+// this server's redo log": it tries innodb_redo_log_capacity first
+// (the 8.0.30+ model where this single dynamic variable replaces the
+// legacy product) and falls back to
+// innodb_log_file_size * innodb_log_files_in_group (the 5.6/5.7
+// model). The branch is internal to this one function rather than two
+// parallel implementations, per Principle XIII.
+func computeRedoSizing(r *model.Report) *redoSizingView {
+	if r == nil || r.DBSection == nil {
+		return nil
+	}
+	v := &redoSizingView{KBReference: kbReferenceRedoSizing}
+
+	configured, source := readConfiguredRedoSpace(r)
+	if configured > 0 {
+		v.ConfiguredBytes = configured
+		v.ConfiguredText = reportutil.HumanBytes(configured)
+		v.ConfigSource = source
+	} else {
+		v.ConfiguredText = "unavailable"
+	}
+
+	avgRate, peakRate, peakWindow, peakLabel, rateOK, anyWrites :=
+		readObservedRedoRate(r.DBSection.Mysqladmin)
+
+	switch {
+	case !rateOK:
+		v.State = "rate_unavailable"
+		v.ObservedRateText = "unavailable"
+		v.ObservedRatePerMinText = "unavailable"
+		v.PeakRateText = "unavailable"
+		v.CoverageText = "n/a"
+		v.Recommended15MinText = "n/a"
+		v.Recommended1HourText = "n/a"
+		if configured <= 0 {
+			v.State = "config_missing"
+		}
+		v.PeakWindowSeconds = peakWindow
+		v.PeakWindowLabel = peakLabel
+		return v
+	case !anyWrites:
+		v.State = "no_writes"
+		v.ObservedRateBytesPerSec = avgRate
+		v.ObservedRateText = reportutil.HumanBytes(avgRate) + "/s"
+		v.ObservedRatePerMinText = reportutil.HumanBytes(avgRate*60) + "/min"
+		v.PeakWindowSeconds = peakWindow
+		v.PeakWindowLabel = peakLabel
+		v.PeakRateBytesPerSec = 0
+		v.PeakRateText = reportutil.HumanBytes(0) + "/s"
+		v.CoverageText = "n/a"
+		v.Recommended15MinText = "n/a"
+		v.Recommended1HourText = "n/a"
+		if configured <= 0 {
+			v.State = "config_missing"
+		}
+		return v
+	}
+
+	// Rate is real and at least one write was observed.
+	v.ObservedRateBytesPerSec = avgRate
+	v.ObservedRateText = reportutil.HumanBytes(avgRate) + "/s"
+	v.ObservedRatePerMinText = reportutil.HumanBytes(avgRate*60) + "/min"
+	v.PeakRateBytesPerSec = peakRate
+	v.PeakRateText = reportutil.HumanBytes(peakRate) + "/s"
+	v.PeakWindowSeconds = peakWindow
+	v.PeakWindowLabel = peakLabel
+
+	if configured <= 0 {
+		v.State = "config_missing"
+		v.CoverageText = "n/a"
+	} else {
+		v.State = "ok"
+		v.CoverageMinutes = configured / peakRate / 60.0
+		coverFloor := int(math.Floor(v.CoverageMinutes))
+		v.CoverageText = fmt.Sprintf("%d minutes", coverFloor)
+		if v.CoverageMinutes < 15.0 {
+			v.UnderSized = true
+			v.WarningLine = fmt.Sprintf(
+				"Current redo space holds only %d minutes of peak writes - consider raising",
+				coverFloor)
+		}
+	}
+
+	v.Recommended15MinBytes = peakRate * redoSizingPeakWindowSeconds
+	v.Recommended15MinText = reportutil.HumanBytes(v.Recommended15MinBytes)
+	v.Recommended1HourBytes = peakRate * 3600.0
+	v.Recommended1HourText = reportutil.HumanBytes(v.Recommended1HourBytes)
+
+	return v
+}
+
+// readConfiguredRedoSpace returns the configured redo log capacity in
+// bytes plus a source label describing which variable(s) supplied it.
+// On 8.0.30+ instances innodb_redo_log_capacity is the single dynamic
+// variable that replaces the legacy product, and MySQL ignores
+// innodb_log_file_size + innodb_log_files_in_group when capacity is
+// set; this function mirrors that precedence. Returns (0, "") when
+// neither model can be evaluated.
+func readConfiguredRedoSpace(r *model.Report) (float64, string) {
+	if capacity, ok := reportutil.VariableFloat(r, "innodb_redo_log_capacity"); ok && capacity > 0 {
+		return capacity, "innodb_redo_log_capacity"
+	}
+	size, sizeOK := reportutil.VariableFloat(r, "innodb_log_file_size")
+	groups, groupsOK := reportutil.VariableFloat(r, "innodb_log_files_in_group")
+	if sizeOK && groupsOK && size > 0 && groups > 0 {
+		return size * groups, "innodb_log_file_size x innodb_log_files_in_group"
+	}
+	return 0, ""
+}
+
+// redoSampleBlock is one contiguous run of finite Innodb_os_log_written
+// delta samples, expressed as a half-open index range [startIdx, endIdx)
+// into the parallel deltas + timestamps slices on
+// model.MysqladminData. Blocks are separated by NaN slots inserted at
+// snapshot boundaries by model.MergeMysqladminData; the rolling-window
+// peak walk treats each block independently so a single peak window
+// never spans a cross-snapshot gap.
+type redoSampleBlock struct {
+	startIdx int
+	endIdx   int
+}
+
+// readObservedRedoRate scans the Innodb_os_log_written counter
+// time-series in the captured mysqladmin data and returns:
+//
+//	avgRate   — bytes/sec averaged over the total observed seconds
+//	peakRate  — bytes/sec over the busiest 15-minute rolling window
+//	            (or over the longest contiguous block when shorter)
+//	peakWindow — actual rolling-window length used, in seconds
+//	peakLabel  — "15-minute" when peakWindow == 900,
+//	             "available N-second" when shorter
+//	rateOK     — false when the counter is absent or insufficient
+//	             samples / time exist to compute a rate
+//	anyWrites  — true iff at least one non-zero non-NaN delta was seen
+//
+// NaN slots in the delta slice mark snapshot boundaries inserted by
+// model.MergeMysqladminData. They split the rolling-window walk: a
+// single window may not span a NaN boundary, matching the existing
+// findings.captureSeconds policy of excluding cross-snapshot gaps.
+func readObservedRedoRate(m *model.MysqladminData) (
+	avgRate, peakRate, peakWindow float64,
+	peakLabel string,
+	rateOK, anyWrites bool,
+) {
+	if m == nil {
+		return 0, 0, 0, "", false, false
+	}
+	deltas, ok := m.Deltas["Innodb_os_log_written"]
+	if !ok || len(deltas) < 2 {
+		return 0, 0, 0, "", false, false
+	}
+	if !m.IsCounter["Innodb_os_log_written"] {
+		// Defensive: should always be a counter; if it is not, we
+		// cannot interpret the values as bytes-written deltas.
+		return 0, 0, 0, "", false, false
+	}
+	if len(m.Timestamps) != len(deltas) {
+		return 0, 0, 0, "", false, false
+	}
+
+	// Build contiguous blocks separated by NaN slots. Each block is a
+	// half-open index range [start, end) of indices i such that
+	// deltas[i] is finite. We skip index 0 within each block because
+	// pt-mext stores the bogus initial tally at the start of every
+	// snapshot (the same convention used by findings.counterTotal),
+	// which manifests as a non-NaN value at the first index of each
+	// block.
+	var blocks []redoSampleBlock
+	startIdx := -1
+	for i, d := range deltas {
+		if math.IsNaN(d) || math.IsInf(d, 0) {
+			if startIdx >= 0 {
+				blocks = append(blocks, redoSampleBlock{startIdx, i})
+				startIdx = -1
+			}
+			continue
+		}
+		if startIdx < 0 {
+			startIdx = i
+		}
+	}
+	if startIdx >= 0 {
+		blocks = append(blocks, redoSampleBlock{startIdx, len(deltas)})
+	}
+
+	// Sum totals and accumulate observed seconds across blocks. Skip
+	// the first index of each block (the bogus initial tally) when
+	// summing values, but include its timestamp as the block's start
+	// boundary.
+	var totalBytes, totalSeconds float64
+	var anyData bool
+	for _, b := range blocks {
+		if b.endIdx-b.startIdx < 2 {
+			continue
+		}
+		anyData = true
+		span := m.Timestamps[b.endIdx-1].Sub(m.Timestamps[b.startIdx]).Seconds()
+		if span <= 0 {
+			continue
+		}
+		totalSeconds += span
+		for i := b.startIdx + 1; i < b.endIdx; i++ {
+			d := deltas[i]
+			totalBytes += d
+			if d > 0 {
+				anyWrites = true
+			}
+		}
+	}
+	if !anyData || totalSeconds <= 0 {
+		return 0, 0, 0, "", false, false
+	}
+	avgRate = totalBytes / totalSeconds
+
+	// Compute the rolling-window peak. Iterate every block; within
+	// each block, slide a window of length redoSizingPeakWindowSeconds
+	// across consecutive sample pairs and track the maximum
+	// bytes-per-second.
+	peakRate, peakWindow, peakLabel = computeRollingPeak(
+		blocks, deltas, m.Timestamps, redoSizingPeakWindowSeconds)
+	return avgRate, peakRate, peakWindow, peakLabel, true, anyWrites
+}
+
+// computeRollingPeak returns the peak per-second rate observed over
+// any contiguous window of length at least targetWindow seconds in
+// the supplied blocks. If no block is long enough, the function
+// collapses the window to the longest block's wall-clock duration and
+// reports the rate over that block.
+//
+// The returned label is "15-minute" when the actual window matches
+// targetWindow == 900s, otherwise "available N-second" where N is the
+// integer wall-clock seconds of the actual window.
+func computeRollingPeak(
+	blocks []redoSampleBlock,
+	deltas []float64,
+	timestamps []time.Time,
+	targetWindow float64,
+) (peakRate, peakWindow float64, peakLabel string) {
+	// Determine the longest available block in seconds first; this
+	// drives the window-collapse fallback when no block reaches the
+	// target window.
+	longest := 0.0
+	for _, b := range blocks {
+		if b.endIdx-b.startIdx < 2 {
+			continue
+		}
+		span := timestamps[b.endIdx-1].Sub(timestamps[b.startIdx]).Seconds()
+		if span > longest {
+			longest = span
+		}
+	}
+	if longest <= 0 {
+		return 0, 0, ""
+	}
+	window := targetWindow
+	if longest < targetWindow {
+		window = longest
+		peakLabel = fmt.Sprintf("available %d-second", int(math.Round(longest)))
+	} else {
+		peakLabel = "15-minute"
+	}
+
+	for _, b := range blocks {
+		// We slide a window over the per-sample deltas within this
+		// block. Skip the first index per the bogus-initial-tally
+		// convention used in readObservedRedoRate.
+		startI := b.startIdx + 1
+		endI := b.endIdx
+		if endI-startI < 1 {
+			continue
+		}
+		sumStart := startI
+		sumBytes := 0.0
+		for i := startI; i < endI; i++ {
+			sumBytes += deltas[i]
+			// Each delta covers the interval (timestamps[i-1],
+			// timestamps[i]]. The window starts at
+			// timestamps[sumStart-1]. Trim from the left while the
+			// span exceeds the chosen window.
+			for sumStart < i {
+				spanLeft := timestamps[i].Sub(timestamps[sumStart]).Seconds()
+				if spanLeft <= window {
+					break
+				}
+				sumBytes -= deltas[sumStart]
+				sumStart++
+			}
+			actualSpan := timestamps[i].Sub(timestamps[sumStart-1]).Seconds()
+			if actualSpan <= 0 {
+				continue
+			}
+			rate := sumBytes / actualSpan
+			if rate > peakRate {
+				peakRate = rate
+			}
+		}
+	}
+	peakWindow = window
+	return peakRate, peakWindow, peakLabel
+}

--- a/render/redo_sizing.go
+++ b/render/redo_sizing.go
@@ -120,6 +120,17 @@ func computeRedoSizing(r *model.Report) *redoSizingView {
 	avgRate, peakRate, peakWindow, peakLabel, rateOK, anyWrites :=
 		readObservedRedoRate(r.DBSection.Mysqladmin)
 
+	// Defensive: rateOK == true with peakRate <= 0 should be
+	// impossible when anyWrites is true, because clampNonNegative
+	// keeps the sum non-negative and at least one positive delta
+	// landed in some window. It can still arise from degenerate
+	// timestamps (zero spans) where the rolling-window walk never
+	// picks up a positive rate. Treat it as rate_unavailable rather
+	// than dividing by zero in the coverage computation below.
+	if rateOK && anyWrites && !(peakRate > 0) {
+		rateOK = false
+	}
+
 	switch {
 	case !rateOK:
 		v.State = "rate_unavailable"
@@ -212,9 +223,17 @@ func readConfiguredRedoSpace(r *model.Report) (float64, string) {
 // snapshot boundaries by model.MergeMysqladminData; the rolling-window
 // peak walk treats each block independently so a single peak window
 // never spans a cross-snapshot gap.
+//
+// SkipFirst is true only for the very first block of the merged series.
+// pt-mext stores the cold-start tally at index 0 of the first snapshot,
+// which is not a real per-interval delta. model.MergeMysqladminData
+// drops this raw tally for every snapshot after the first (it inserts a
+// NaN at the boundary and appends src[1:]), so post-boundary blocks'
+// first finite samples ARE genuine deltas and must be included.
 type redoSampleBlock struct {
-	startIdx int
-	endIdx   int
+	startIdx  int
+	endIdx    int
+	SkipFirst bool
 }
 
 // readObservedRedoRate scans the Innodb_os_log_written counter
@@ -257,17 +276,24 @@ func readObservedRedoRate(m *model.MysqladminData) (
 
 	// Build contiguous blocks separated by NaN slots. Each block is a
 	// half-open index range [start, end) of indices i such that
-	// deltas[i] is finite. We skip index 0 within each block because
-	// pt-mext stores the bogus initial tally at the start of every
-	// snapshot (the same convention used by findings.counterTotal),
-	// which manifests as a non-NaN value at the first index of each
-	// block.
+	// deltas[i] is finite. Only the FIRST block carries the raw
+	// initial tally at its start index (pt-mext writes the cold-start
+	// counter value there, the same convention used by
+	// findings.counterTotal); model.MergeMysqladminData strips that
+	// raw tally from every snapshot after the first by appending
+	// src[1:] after the NaN boundary slot, so post-boundary blocks'
+	// first finite samples are genuine per-interval deltas and MUST
+	// be included in both the average and the rolling-window peak.
 	var blocks []redoSampleBlock
 	startIdx := -1
 	for i, d := range deltas {
 		if math.IsNaN(d) || math.IsInf(d, 0) {
 			if startIdx >= 0 {
-				blocks = append(blocks, redoSampleBlock{startIdx, i})
+				blocks = append(blocks, redoSampleBlock{
+					startIdx:  startIdx,
+					endIdx:    i,
+					SkipFirst: len(blocks) == 0,
+				})
 				startIdx = -1
 			}
 			continue
@@ -277,13 +303,22 @@ func readObservedRedoRate(m *model.MysqladminData) (
 		}
 	}
 	if startIdx >= 0 {
-		blocks = append(blocks, redoSampleBlock{startIdx, len(deltas)})
+		blocks = append(blocks, redoSampleBlock{
+			startIdx:  startIdx,
+			endIdx:    len(deltas),
+			SkipFirst: len(blocks) == 0,
+		})
 	}
 
-	// Sum totals and accumulate observed seconds across blocks. Skip
-	// the first index of each block (the bogus initial tally) when
-	// summing values, but include its timestamp as the block's start
-	// boundary.
+	// Sum totals and accumulate observed seconds across blocks. For
+	// the first block we skip its first index (the cold-start tally)
+	// but include its timestamp as the block's start boundary. For
+	// subsequent blocks we include every finite sample because
+	// MergeMysqladminData has already stripped the raw tally at the
+	// snapshot boundary. Negative deltas are clamped to 0 to absorb
+	// counter resets (server restart mid-capture re-zeroes
+	// Innodb_os_log_written, producing a negative delta on the next
+	// sample); a counter reset is not a write of negative bytes.
 	var totalBytes, totalSeconds float64
 	var anyData bool
 	for _, b := range blocks {
@@ -296,8 +331,12 @@ func readObservedRedoRate(m *model.MysqladminData) (
 			continue
 		}
 		totalSeconds += span
-		for i := b.startIdx + 1; i < b.endIdx; i++ {
-			d := deltas[i]
+		i0 := b.startIdx
+		if b.SkipFirst {
+			i0 = b.startIdx + 1
+		}
+		for i := i0; i < b.endIdx; i++ {
+			d := clampNonNegative(deltas[i])
 			totalBytes += d
 			if d > 0 {
 				anyWrites = true
@@ -318,15 +357,25 @@ func readObservedRedoRate(m *model.MysqladminData) (
 	return avgRate, peakRate, peakWindow, peakLabel, true, anyWrites
 }
 
-// computeRollingPeak returns the peak per-second rate observed over
-// any contiguous window of length at least targetWindow seconds in
-// the supplied blocks. If no block is long enough, the function
-// collapses the window to the longest block's wall-clock duration and
-// reports the rate over that block.
+// computeRollingPeak returns the peak per-second rate observed over a
+// sliding window whose length is at least targetWindow seconds, taken
+// over the supplied blocks. When no block reaches targetWindow the
+// function collapses the window to the longest block's wall-clock
+// duration and reports the rate over that block (a single fixed
+// window equal in length to the longest block).
 //
-// The returned label is "15-minute" when the actual window matches
-// targetWindow == 900s, otherwise "available N-second" where N is the
-// integer wall-clock seconds of the actual window.
+// The returned label is "15-minute" when the chosen window equals
+// targetWindow == 900s, otherwise "available N-second" where N is
+// math.Floor(window) so the label never overstates the observed
+// window length (28.6s renders as "28-second", never "29-second").
+//
+// Negative deltas are clamped to 0 inside the sum to absorb
+// Innodb_os_log_written counter resets without depressing the peak.
+//
+// Per the contract, a candidate window is only considered when its
+// actualSpan >= window. This excludes sub-window prefix spans at the
+// start of each block, which would otherwise let an early burst be
+// reported as the 15-minute peak.
 func computeRollingPeak(
 	blocks []redoSampleBlock,
 	deltas []float64,
@@ -352,38 +401,65 @@ func computeRollingPeak(
 	window := targetWindow
 	if longest < targetWindow {
 		window = longest
-		peakLabel = fmt.Sprintf("available %d-second", int(math.Round(longest)))
+		peakLabel = fmt.Sprintf("available %d-second", int(math.Floor(window)))
 	} else {
 		peakLabel = "15-minute"
 	}
 
 	for _, b := range blocks {
 		// We slide a window over the per-sample deltas within this
-		// block. Skip the first index per the bogus-initial-tally
-		// convention used in readObservedRedoRate.
-		startI := b.startIdx + 1
+		// block. SkipFirst is true only for the first block (the
+		// cold-start tally); subsequent blocks include every finite
+		// sample because MergeMysqladminData has already stripped
+		// the raw tally at the snapshot boundary.
+		startI := b.startIdx
+		if b.SkipFirst {
+			startI = b.startIdx + 1
+		}
 		endI := b.endIdx
 		if endI-startI < 1 {
 			continue
 		}
+		// Each delta covers the interval (timestamps[i-1],
+		// timestamps[i]]. The window of samples [sumStart..i]
+		// therefore covers (timestamps[sumStart-1], timestamps[i]],
+		// so actualSpan = timestamps[i] - timestamps[sumStart-1].
+		// We need sumStart >= 1 for this to be well-defined, so the
+		// first sample of the very first block (which has no prior
+		// timestamp) is consumed as boundary-only and excluded from
+		// the rolling sum; this matches the SkipFirst rule above and
+		// the per-block startIdx semantics for subsequent blocks
+		// (startIdx is the post-NaN index whose previous slot is the
+		// NaN boundary, never used as a window edge).
 		sumStart := startI
 		sumBytes := 0.0
 		for i := startI; i < endI; i++ {
-			sumBytes += deltas[i]
-			// Each delta covers the interval (timestamps[i-1],
-			// timestamps[i]]. The window starts at
-			// timestamps[sumStart-1]. Trim from the left while the
-			// span exceeds the chosen window.
+			if i == 0 {
+				// Defensive: a block that begins at the global
+				// index 0 cannot anchor actualSpan against a
+				// preceding timestamp; treat it as boundary-only.
+				sumStart = i + 1
+				continue
+			}
+			sumBytes += clampNonNegative(deltas[i])
+			// Trim from the left while removing sumStart still
+			// leaves actualSpan >= window. This produces the
+			// SMALLEST window of length >= window ending at i,
+			// which is the correct denominator for the rolling
+			// peak: any larger window would only dilute the rate.
 			for sumStart < i {
-				spanLeft := timestamps[i].Sub(timestamps[sumStart]).Seconds()
-				if spanLeft <= window {
+				spanAfterTrim := timestamps[i].Sub(timestamps[sumStart]).Seconds()
+				if spanAfterTrim < window {
 					break
 				}
-				sumBytes -= deltas[sumStart]
+				sumBytes -= clampNonNegative(deltas[sumStart])
 				sumStart++
 			}
 			actualSpan := timestamps[i].Sub(timestamps[sumStart-1]).Seconds()
-			if actualSpan <= 0 {
+			if actualSpan < window {
+				// Skip sub-window prefix spans; the contract
+				// requires a full window before a rate becomes a
+				// peak candidate.
 				continue
 			}
 			rate := sumBytes / actualSpan
@@ -394,4 +470,16 @@ func computeRollingPeak(
 	}
 	peakWindow = window
 	return peakRate, peakWindow, peakLabel
+}
+
+// clampNonNegative returns 0 for negative inputs and the value
+// otherwise. Used to absorb Innodb_os_log_written counter resets
+// (server restart mid-capture re-zeroes the counter, so the next
+// delta is a large negative number); a reset is not a write of
+// negative bytes, so it must not depress the rolling sum.
+func clampNonNegative(v float64) float64 {
+	if v < 0 {
+		return 0
+	}
+	return v
 }

--- a/render/redo_sizing.go
+++ b/render/redo_sizing.go
@@ -131,53 +131,61 @@ func computeRedoSizing(r *model.Report) *redoSizingView {
 		rateOK = false
 	}
 
-	switch {
-	case !rateOK:
-		v.State = "rate_unavailable"
+	// Derive State exactly once via the canonical priority function.
+	// The priority order is documented in
+	// specs/019-redo-log-sizing-panel/contracts/redo-sizing-panel.md
+	// (State priority): rate_unavailable > config_missing > no_writes >
+	// ok. Routing every State assignment through this single helper
+	// (Principle XIII) prevents downstream branches from silently
+	// overwriting a higher-priority degradation state with a
+	// lower-priority one — for example, a missing
+	// Innodb_os_log_written counter MUST surface as "rate_unavailable"
+	// (the explicit unavailable message in the template) and MUST NOT
+	// be overwritten to "config_missing" when the redo configuration
+	// variables are also absent, because that would drop the operator
+	// into the generic rate-rows branch with empty placeholder text
+	// like "Peak write rate ( rolling)".
+	v.State = deriveRedoSizingState(rateOK, anyWrites, configured)
+
+	// PeakWindowSeconds and PeakWindowLabel reflect the actual rolling
+	// window the rate readers used; they are populated for every state
+	// so the panel never renders an empty window descriptor.
+	v.PeakWindowSeconds = peakWindow
+	v.PeakWindowLabel = peakLabel
+
+	switch v.State {
+	case "rate_unavailable":
 		v.ObservedRateText = "unavailable"
 		v.ObservedRatePerMinText = "unavailable"
 		v.PeakRateText = "unavailable"
 		v.CoverageText = "n/a"
 		v.Recommended15MinText = "n/a"
 		v.Recommended1HourText = "n/a"
-		if configured <= 0 {
-			v.State = "config_missing"
-		}
-		v.PeakWindowSeconds = peakWindow
-		v.PeakWindowLabel = peakLabel
 		return v
-	case !anyWrites:
-		v.State = "no_writes"
+	case "no_writes":
 		v.ObservedRateBytesPerSec = avgRate
 		v.ObservedRateText = reportutil.HumanBytes(avgRate) + "/s"
 		v.ObservedRatePerMinText = reportutil.HumanBytes(avgRate*60) + "/min"
-		v.PeakWindowSeconds = peakWindow
-		v.PeakWindowLabel = peakLabel
 		v.PeakRateBytesPerSec = 0
 		v.PeakRateText = reportutil.HumanBytes(0) + "/s"
 		v.CoverageText = "n/a"
 		v.Recommended15MinText = "n/a"
 		v.Recommended1HourText = "n/a"
-		if configured <= 0 {
-			v.State = "config_missing"
-		}
 		return v
 	}
 
-	// Rate is real and at least one write was observed.
+	// State is "config_missing" or "ok": the rate is real and at least
+	// one write was observed. Populate the rate-bearing fields once;
+	// the only difference between the two states is whether configured
+	// space is known (and therefore whether coverage and the
+	// under-sized warning can be computed).
 	v.ObservedRateBytesPerSec = avgRate
 	v.ObservedRateText = reportutil.HumanBytes(avgRate) + "/s"
 	v.ObservedRatePerMinText = reportutil.HumanBytes(avgRate*60) + "/min"
 	v.PeakRateBytesPerSec = peakRate
 	v.PeakRateText = reportutil.HumanBytes(peakRate) + "/s"
-	v.PeakWindowSeconds = peakWindow
-	v.PeakWindowLabel = peakLabel
 
-	if configured <= 0 {
-		v.State = "config_missing"
-		v.CoverageText = "n/a"
-	} else {
-		v.State = "ok"
+	if v.State == "ok" {
 		v.CoverageMinutes = configured / peakRate / 60.0
 		coverFloor := int(math.Floor(v.CoverageMinutes))
 		v.CoverageText = fmt.Sprintf("%d minutes", coverFloor)
@@ -187,6 +195,9 @@ func computeRedoSizing(r *model.Report) *redoSizingView {
 				"Current redo space holds only %d minutes of peak writes - consider raising",
 				coverFloor)
 		}
+	} else {
+		// config_missing: no configured space, so coverage is n/a.
+		v.CoverageText = "n/a"
 	}
 
 	v.Recommended15MinBytes = peakRate * redoSizingPeakWindowSeconds
@@ -195,6 +206,43 @@ func computeRedoSizing(r *model.Report) *redoSizingView {
 	v.Recommended1HourText = reportutil.HumanBytes(v.Recommended1HourBytes)
 
 	return v
+}
+
+// deriveRedoSizingState is the canonical State-derivation predicate
+// for the Redo log sizing panel. It returns one of the four documented
+// State values in priority order so the highest-impact degradation
+// surfaces in the rendered panel when multiple degradation conditions
+// hold simultaneously. The contract documents this priority order
+// explicitly (specs/019-redo-log-sizing-panel/contracts/redo-sizing-panel.md
+// — "State priority"):
+//
+//  1. "rate_unavailable" — Innodb_os_log_written absent or insufficient
+//     samples; without an observed write rate the operator cannot size
+//     the redo log regardless of whether configuration variables were
+//     captured. The template renders the explicit unavailable message
+//     for this state, which is the most useful output for the operator.
+//  2. "config_missing"  — rate observed but configured redo space
+//     unknown; the operator gets the recommendation rows but no
+//     coverage estimate.
+//  3. "no_writes"       — rate observed and configured space known
+//     (or not), but every observed delta is zero.
+//  4. "ok"              — rate observed, configured space known, at
+//     least one observed write.
+//
+// Routing every State assignment through this single function is the
+// canonical implementation per Principle XIII; downstream branches
+// must not overwrite the returned value.
+func deriveRedoSizingState(rateOK, anyWrites bool, configured float64) string {
+	switch {
+	case !rateOK:
+		return "rate_unavailable"
+	case configured <= 0:
+		return "config_missing"
+	case !anyWrites:
+		return "no_writes"
+	default:
+		return "ok"
+	}
 }
 
 // readConfiguredRedoSpace returns the configured redo log capacity in

--- a/render/redo_sizing.go
+++ b/render/redo_sizing.go
@@ -236,6 +236,33 @@ type redoSampleBlock struct {
 	SkipFirst bool
 }
 
+// blockLeftBoundIdx returns the timestamp index that anchors the left
+// edge of the wall-clock interval covered by a block's included
+// deltas. This is the canonical span-derivation helper shared by both
+// the average-rate observed-seconds accumulator and the rolling-peak
+// fallback span; routing both call sites through it keeps the math
+// canonical (Principle XIII).
+//
+// For the first block (SkipFirst == true) the cold-start tally at
+// startIdx is excluded, so the first INCLUDED delta is at startIdx+1
+// and covers the interval (timestamps[startIdx], timestamps[startIdx+1]];
+// the block's left bound is therefore timestamps[startIdx].
+//
+// For every post-boundary block (SkipFirst == false) the raw tally was
+// already stripped by model.MergeMysqladminData (it appends a NaN
+// boundary slot and then src[1:]), so the first INCLUDED delta at
+// startIdx covers the interval (timestamps[startIdx-1], timestamps[startIdx]];
+// the block's left bound is therefore timestamps[startIdx-1]. By
+// construction such a block always has startIdx >= 1 because the NaN
+// boundary at startIdx-1 was inserted before src[1:] was appended; the
+// startIdx <= 0 clamp below is defensive insurance only.
+func blockLeftBoundIdx(b redoSampleBlock) int {
+	if b.SkipFirst || b.startIdx <= 0 {
+		return b.startIdx
+	}
+	return b.startIdx - 1
+}
+
 // readObservedRedoRate scans the Innodb_os_log_written counter
 // time-series in the captured mysqladmin data and returns:
 //
@@ -326,7 +353,7 @@ func readObservedRedoRate(m *model.MysqladminData) (
 			continue
 		}
 		anyData = true
-		span := m.Timestamps[b.endIdx-1].Sub(m.Timestamps[b.startIdx]).Seconds()
+		span := m.Timestamps[b.endIdx-1].Sub(m.Timestamps[blockLeftBoundIdx(b)]).Seconds()
 		if span <= 0 {
 			continue
 		}
@@ -390,7 +417,7 @@ func computeRollingPeak(
 		if b.endIdx-b.startIdx < 2 {
 			continue
 		}
-		span := timestamps[b.endIdx-1].Sub(timestamps[b.startIdx]).Seconds()
+		span := timestamps[b.endIdx-1].Sub(timestamps[blockLeftBoundIdx(b)]).Seconds()
 		if span > longest {
 			longest = span
 		}
@@ -430,7 +457,11 @@ func computeRollingPeak(
 		// the rolling sum; this matches the SkipFirst rule above and
 		// the per-block startIdx semantics for subsequent blocks
 		// (startIdx is the post-NaN index whose previous slot is the
-		// NaN boundary, never used as a window edge).
+		// NaN boundary, never used as a window edge). Note that the
+		// initial sumStart-1 here equals blockLeftBoundIdx(b) by
+		// construction (startI is startIdx+1 for SkipFirst blocks and
+		// startIdx otherwise); both paths express the same canonical
+		// span-derivation invariant.
 		sumStart := startI
 		sumBytes := 0.0
 		for i := startI; i < endI; i++ {

--- a/render/redo_sizing_state_test.go
+++ b/render/redo_sizing_state_test.go
@@ -1,0 +1,194 @@
+package render
+
+import (
+	"bytes"
+	"html/template"
+	"strings"
+	"testing"
+)
+
+// redoSizingPanelTemplate is a verbatim copy of the redo-sizing panel
+// fragment from render/templates/db.html.tmpl. Tests use it to assert
+// the State value drives the EXPECTED template branch end-to-end —
+// the production template is the consumer of computeRedoSizing's
+// State priority order, so the assertion must exercise the same
+// branch structure (Principle XIII).
+const redoSizingPanelTemplate = `` +
+	`{{- with .RedoSizing }}` +
+	`<div class="redo-sizing">` +
+	`{{- if eq .State "config_missing" }}` +
+	`<p class="v">unavailable</p>` +
+	`<p class="sub">Redo configuration variables not present in this capture.</p>` +
+	`{{- else }}` +
+	`<p class="v">{{.ConfiguredText}}</p>` +
+	`<p class="sub">configured redo space — source: <code>{{.ConfigSource}}</code></p>` +
+	`{{- end }}` +
+	`{{- if eq .State "rate_unavailable" }}` +
+	`<p class="stats">Observed write rate: unavailable (no <code>Innodb_os_log_written</code> samples)</p>` +
+	`{{- else if eq .State "no_writes" }}` +
+	`<p class="stats">Observed average write rate: <span>{{.ObservedRateText}}</span> · <span>{{.ObservedRatePerMinText}}</span></p>` +
+	`<p class="stats">No observed redo writes during the capture — coverage and recommendations are not applicable.</p>` +
+	`{{- else }}` +
+	`<p class="stats">Observed average write rate: <span>{{.ObservedRateText}}</span> · <span>{{.ObservedRatePerMinText}}</span></p>` +
+	`<p class="stats">Peak write rate ({{.PeakWindowLabel}} rolling): <span>{{.PeakRateText}}</span></p>` +
+	`{{- if eq .State "ok" }}` +
+	`<p class="stats">Coverage at peak: <span>{{.CoverageText}}</span></p>` +
+	`{{- end }}` +
+	`{{- end }}` +
+	`</div>` +
+	`{{- end }}`
+
+// renderRedoSizingPanel executes the panel-fragment template against
+// the supplied view and returns the rendered HTML so tests can assert
+// on the user-visible output.
+func renderRedoSizingPanel(t *testing.T, v *redoSizingView) string {
+	t.Helper()
+	tmpl, err := template.New("redo").Parse(redoSizingPanelTemplate)
+	if err != nil {
+		t.Fatalf("parse template: %v", err)
+	}
+	var buf bytes.Buffer
+	if err := tmpl.Execute(&buf, struct{ RedoSizing *redoSizingView }{v}); err != nil {
+		t.Fatalf("execute template: %v", err)
+	}
+	return buf.String()
+}
+
+// TestComputeRedoSizing_DualMissing_PrefersRateUnavailable is the
+// regression test for the Codex P2 finding at render/redo_sizing.go:145
+// (PR #58 wave 5). When BOTH Innodb_os_log_written AND the redo
+// configuration variables are absent, the canonical State priority
+// (rate_unavailable > config_missing > no_writes > ok) requires the
+// panel to render the explicit unavailable message rather than the
+// generic rate rows with empty placeholder text such as
+// "Peak write rate ( rolling)". The previous implementation overwrote
+// State from "rate_unavailable" to "config_missing" in this dual-missing
+// case, dropping the operator into the misleading fallback branch and
+// regressing the FR-009 graceful-degradation behavior (Principle III).
+func TestComputeRedoSizing_DualMissing_PrefersRateUnavailable(t *testing.T) {
+	// Both variables AND counter are absent (dual-missing capture).
+	r := makeRedoReport(t, nil, nil, 1)
+	v := computeRedoSizing(r)
+	if v == nil {
+		t.Fatal("expected non-nil view")
+	}
+	if v.State != "rate_unavailable" {
+		t.Fatalf("State = %q, want rate_unavailable "+
+			"(rate_unavailable must take priority over config_missing "+
+			"when both degradation conditions hold)", v.State)
+	}
+	if v.ObservedRateText != "unavailable" {
+		t.Fatalf("ObservedRateText = %q, want %q", v.ObservedRateText, "unavailable")
+	}
+	if v.PeakRateText != "unavailable" {
+		t.Fatalf("PeakRateText = %q, want %q", v.PeakRateText, "unavailable")
+	}
+	if v.CoverageText != "n/a" {
+		t.Fatalf("CoverageText = %q, want n/a", v.CoverageText)
+	}
+	if v.Recommended15MinText != "n/a" || v.Recommended1HourText != "n/a" {
+		t.Fatalf("recommendations should be n/a, got %q / %q",
+			v.Recommended15MinText, v.Recommended1HourText)
+	}
+
+	// Render the panel fragment and assert the misleading
+	// fallback-branch text never appears. The bad output is recognizable
+	// because PeakWindowLabel is empty in the rate_unavailable state,
+	// so the template's "Peak write rate ({{.PeakWindowLabel}} rolling)"
+	// line would render as the literal "Peak write rate ( rolling)"
+	// if State were ever overwritten to config_missing.
+	html := renderRedoSizingPanel(t, v)
+	if strings.Contains(html, "Peak write rate ( rolling)") {
+		t.Fatalf("rendered panel contains the misleading empty-window "+
+			"placeholder %q; rate_unavailable state must not fall "+
+			"through to the generic rate-rows branch:\n%s",
+			"Peak write rate ( rolling)", html)
+	}
+	if strings.Contains(html, "Peak write rate (") {
+		t.Fatalf("rendered panel contains a Peak-write-rate row at all "+
+			"in the rate_unavailable state; only the explicit "+
+			"unavailable message should render:\n%s", html)
+	}
+	if !strings.Contains(html, "Observed write rate: unavailable") {
+		t.Fatalf("rendered panel missing the explicit "+
+			"unavailable message required by FR-009:\n%s", html)
+	}
+}
+
+// TestComputeRedoSizing_StatePriorityIsCanonical exercises every
+// (rate present/absent) x (config present/absent) x (writes/no writes)
+// combination and asserts that deriveRedoSizingState returns the
+// highest-priority State per the canonical priority order documented
+// in specs/019-redo-log-sizing-panel/contracts/redo-sizing-panel.md
+// (rate_unavailable > config_missing > no_writes > ok). This is the
+// belt-and-braces guard against a future branch silently overwriting
+// State after the helper returns (Principle XIII).
+func TestComputeRedoSizing_StatePriorityIsCanonical(t *testing.T) {
+	cases := []struct {
+		name       string
+		rateOK     bool
+		anyWrites  bool
+		configured float64
+		wantState  string
+	}{
+		{
+			name:       "rate_unavailable_dominates_all",
+			rateOK:     false,
+			anyWrites:  false,
+			configured: 0,
+			wantState:  "rate_unavailable",
+		},
+		{
+			name:       "rate_unavailable_dominates_config_missing",
+			rateOK:     false,
+			anyWrites:  true,
+			configured: 0,
+			wantState:  "rate_unavailable",
+		},
+		{
+			name:       "rate_unavailable_with_config_present",
+			rateOK:     false,
+			anyWrites:  true,
+			configured: 4 << 30,
+			wantState:  "rate_unavailable",
+		},
+		{
+			name:       "config_missing_dominates_no_writes",
+			rateOK:     true,
+			anyWrites:  false,
+			configured: 0,
+			wantState:  "config_missing",
+		},
+		{
+			name:       "config_missing_with_writes",
+			rateOK:     true,
+			anyWrites:  true,
+			configured: 0,
+			wantState:  "config_missing",
+		},
+		{
+			name:       "no_writes_with_config_present",
+			rateOK:     true,
+			anyWrites:  false,
+			configured: 4 << 30,
+			wantState:  "no_writes",
+		},
+		{
+			name:       "ok_with_writes_and_config",
+			rateOK:     true,
+			anyWrites:  true,
+			configured: 4 << 30,
+			wantState:  "ok",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := deriveRedoSizingState(tc.rateOK, tc.anyWrites, tc.configured)
+			if got != tc.wantState {
+				t.Fatalf("deriveRedoSizingState(rateOK=%v, anyWrites=%v, "+
+					"configured=%v) = %q, want %q",
+					tc.rateOK, tc.anyWrites, tc.configured, got, tc.wantState)
+			}
+		})
+	}
+}

--- a/render/redo_sizing_test.go
+++ b/render/redo_sizing_test.go
@@ -1,6 +1,7 @@
 package render
 
 import (
+	"math"
 	"strings"
 	"testing"
 	"time"
@@ -129,7 +130,7 @@ func TestComputeRedoSizing_57_WellSized(t *testing.T) {
 		t.Fatalf("ConfigSource = %q", v.ConfigSource)
 	}
 	if v.ConfiguredText != "2.00 GiB" {
-		t.Fatalf("ConfiguredText = %q, want 2.0 GiB", v.ConfiguredText)
+		t.Fatalf("ConfiguredText = %q, want 2.00 GiB", v.ConfiguredText)
 	}
 	if v.UnderSized {
 		t.Fatalf("UnderSized = true, want false")
@@ -188,7 +189,7 @@ func TestComputeRedoSizing_80Plus_WellSized(t *testing.T) {
 		t.Fatalf("ConfigSource = %q, want innodb_redo_log_capacity", v.ConfigSource)
 	}
 	if v.ConfiguredText != "16.00 GiB" {
-		t.Fatalf("ConfiguredText = %q, want 16.0 GiB", v.ConfiguredText)
+		t.Fatalf("ConfiguredText = %q, want 16.00 GiB", v.ConfiguredText)
 	}
 	if v.UnderSized {
 		t.Fatalf("UnderSized = true, want false")
@@ -258,7 +259,7 @@ func TestComputeRedoSizing_RateUnavailable(t *testing.T) {
 			v.Recommended15MinText, v.Recommended1HourText)
 	}
 	if v.ConfiguredText != "2.00 GiB" {
-		t.Fatalf("ConfiguredText = %q, want 2.0 GiB", v.ConfiguredText)
+		t.Fatalf("ConfiguredText = %q, want 2.00 GiB", v.ConfiguredText)
 	}
 }
 
@@ -347,5 +348,213 @@ func TestComputeRedoSizing_WarningBoundary(t *testing.T) {
 	if !vBelow.UnderSized {
 		t.Fatalf("below: UnderSized = false, want true (coverage = %.4f)",
 			vBelow.CoverageMinutes)
+	}
+}
+
+// TestComputeRedoSizing_FullWindowRequired_BurstyPrefix verifies the
+// rolling-peak walk does NOT report a sub-window prefix burst as the
+// peak when the capture is long enough to reach a full window.
+//
+// Setup: 1800 samples at 1s steps (30 minutes total, well beyond the
+// 900s target window). The first 60 samples write 100 MiB/s (an early
+// 60-second burst); every later sample writes 1 MiB/s. The peak over
+// any 900-second window is therefore:
+//
+//	worst case window straddling the burst:
+//	  60 * 100 MiB + 840 * 1 MiB = 6840 MiB  -> 7.6 MiB/s
+//
+// The naive (pre-fix) implementation would have reported the prefix
+// burst rate of 100 MiB/s by accepting sub-window prefix spans as
+// peak candidates. The fixed implementation must report ~7.6 MiB/s.
+func TestComputeRedoSizing_FullWindowRequired_BurstyPrefix(t *testing.T) {
+	const burstSamples = 60
+	const burstRate = 100 << 20 // 100 MiB/s
+	const tailRate = 1 << 20    // 1 MiB/s
+	deltas := make([]float64, 1800)
+	for i := range deltas {
+		if i < burstSamples {
+			deltas[i] = burstRate
+		} else {
+			deltas[i] = tailRate
+		}
+	}
+	r := makeRedoReport(t, vars57(1<<30, 16), deltas, 1)
+	v := computeRedoSizing(r)
+	if v == nil {
+		t.Fatal("expected non-nil view")
+	}
+	if v.PeakWindowSeconds != 900 {
+		t.Fatalf("PeakWindowSeconds = %v, want 900 (full window)", v.PeakWindowSeconds)
+	}
+	if v.PeakWindowLabel != "15-minute" {
+		t.Fatalf("PeakWindowLabel = %q, want %q",
+			v.PeakWindowLabel, "15-minute")
+	}
+	// Worst-case window covers the burst plus 840s of tail rate:
+	// (60 * 100 + 840 * 1) MiB / 900s = 6840/900 MiB/s ≈ 7.6 MiB/s.
+	wantPeak := float64(burstSamples*burstRate+(900-burstSamples)*tailRate) / 900.0
+	if math.Abs(v.PeakRateBytesPerSec-wantPeak) > wantPeak*0.001 {
+		t.Fatalf("PeakRateBytesPerSec = %.0f B/s, want ~%.0f B/s; "+
+			"the prefix-burst rate of 100 MiB/s must NOT win",
+			v.PeakRateBytesPerSec, wantPeak)
+	}
+}
+
+// TestComputeRedoSizing_PeakRateZeroGuard verifies that a
+// degenerate-timestamp case where rateOK could be true with peakRate
+// == 0 routes to rate_unavailable rather than dividing by zero in the
+// coverage calculation.
+//
+// Setup: clamp the per-sample timestamps so every interval is zero
+// (every sample shares the same wall-clock instant). This makes the
+// rolling-window walk unable to anchor a non-zero actualSpan, so
+// peakRate stays 0 even though the deltas are positive.
+func TestComputeRedoSizing_PeakRateZeroGuard(t *testing.T) {
+	r := makeRedoReport(t, vars57(1<<30, 2), constantDeltas(30, 1<<20), 1)
+	// Collapse every timestamp to the same instant so the
+	// rolling-window walk sees zero spans everywhere.
+	if r.DBSection == nil || r.DBSection.Mysqladmin == nil {
+		t.Fatal("setup: expected mysqladmin data")
+	}
+	ts := r.DBSection.Mysqladmin.Timestamps
+	if len(ts) == 0 {
+		t.Fatal("setup: empty timestamps")
+	}
+	pinned := ts[0]
+	for i := range ts {
+		ts[i] = pinned
+	}
+	v := computeRedoSizing(r)
+	if v == nil {
+		t.Fatal("expected non-nil view")
+	}
+	if v.State != "rate_unavailable" {
+		t.Fatalf("State = %q, want rate_unavailable (peakRate must not divide by zero)",
+			v.State)
+	}
+	if v.CoverageText != "n/a" {
+		t.Fatalf("CoverageText = %q, want n/a", v.CoverageText)
+	}
+	if v.UnderSized {
+		t.Fatal("UnderSized must be false when state is not ok")
+	}
+}
+
+// TestComputeRedoSizing_NegativeDeltaClamp verifies that a negative
+// per-sample delta (a counter reset from a server restart mid-capture)
+// is clamped to 0 and does NOT depress the rolling sum.
+//
+// Setup: 60 samples at 1s steps. Most samples write 1 MiB; one sample
+// in the middle is -500 MiB (simulated counter reset). The clamped
+// peak rate must equal the unclamped 1 MiB/s rate, NOT a depressed
+// rate that subtracts the bogus negative.
+func TestComputeRedoSizing_NegativeDeltaClamp(t *testing.T) {
+	const oneMiB = 1 << 20
+	deltas := make([]float64, 60)
+	for i := range deltas {
+		deltas[i] = oneMiB
+	}
+	deltas[30] = -500 * oneMiB // simulate a counter reset
+
+	r := makeRedoReport(t, vars57(1<<30, 16), deltas, 1)
+	v := computeRedoSizing(r)
+	if v == nil {
+		t.Fatal("expected non-nil view")
+	}
+	// makeRedoReport prepends a cold-start tally at index 0, so the
+	// merged series has 61 samples covering 60 wall-clock seconds.
+	// With the clamp the negative delta contributes 0 instead of
+	// -500 MiB, giving sum = 59 * 1 MiB over 60s. WITHOUT the clamp
+	// the sum would be (59 - 500) MiB ≈ -441 MiB, an absurd
+	// negative rate that would route to no_writes/rate_unavailable
+	// or report a negative coverage. The clamp keeps the rate
+	// strictly positive and close to 1 MiB/s.
+	const samples = 60
+	const totalSeconds = float64(samples)
+	wantRate := float64((samples-1)*oneMiB) / totalSeconds
+	if math.Abs(v.PeakRateBytesPerSec-wantRate) > wantRate*0.01 {
+		t.Fatalf("PeakRateBytesPerSec = %.0f, want ~%.0f (negative delta must clamp to 0)",
+			v.PeakRateBytesPerSec, wantRate)
+	}
+	if math.Abs(v.ObservedRateBytesPerSec-wantRate) > wantRate*0.01 {
+		t.Fatalf("ObservedRateBytesPerSec = %.0f, want ~%.0f (negative delta must clamp to 0)",
+			v.ObservedRateBytesPerSec, wantRate)
+	}
+	if v.State != "ok" {
+		t.Fatalf("State = %q, want ok (clamp must keep the rate positive)",
+			v.State)
+	}
+}
+
+// TestComputeRedoSizing_MultiBlock_PostBoundaryFirstSampleIncluded
+// verifies that the first finite sample of a post-NaN block is
+// included in the rolling-window peak. model.MergeMysqladminData
+// strips the raw cold-start tally from snapshots after the first
+// (it inserts a NaN at the boundary and appends src[1:]), so the
+// first finite sample after the NaN IS a real per-interval delta.
+//
+// Setup: build a synthetic two-block series by hand (the
+// makeRedoReport helper builds only single-block reports). Block A
+// has its raw tally at index 0 followed by 60 zero samples. A NaN
+// boundary follows. Block B is 60 samples each at 1 MiB/s. A naive
+// implementation that skips the first finite sample of every block
+// would drop Block B's first 1 MiB sample, yielding 59 MiB / 60s
+// ≈ 1006 KiB/s; the correct implementation includes all 60 samples
+// for a peak of 1 MiB/s.
+func TestComputeRedoSizing_MultiBlock_PostBoundaryFirstSampleIncluded(t *testing.T) {
+	const blockA = 60
+	const blockB = 60
+	const oneMiB = 1 << 20
+	r := makeRedoReport(t, vars57(1<<30, 16), nil, 1)
+	if r.DBSection == nil {
+		t.Fatal("setup: expected DBSection")
+	}
+	// Total samples: blockA finite + 1 NaN boundary + blockB finite.
+	n := blockA + 1 + blockB
+	ts := make([]time.Time, n)
+	base := time.Date(2026, 5, 7, 12, 0, 0, 0, time.UTC)
+	for i := 0; i < n; i++ {
+		ts[i] = base.Add(time.Duration(i) * time.Second)
+	}
+	series := make([]float64, n)
+	// Block A: index 0 is the raw cold-start tally (skipped); the
+	// remaining samples are 0 (idle).
+	series[0] = 999_999_999
+	for i := 1; i < blockA; i++ {
+		series[i] = 0
+	}
+	// NaN boundary at index blockA (snapshot break).
+	series[blockA] = math.NaN()
+	// Block B: every sample is a real 1 MiB/s delta. Note that
+	// after the NaN boundary, MergeMysqladminData would have
+	// already stripped the raw tally upstream, so series[blockA+1]
+	// IS a real delta and MUST be included.
+	for i := blockA + 1; i < n; i++ {
+		series[i] = oneMiB
+	}
+	r.DBSection.Mysqladmin = &model.MysqladminData{
+		SampleCount:        n,
+		Timestamps:         ts,
+		Deltas:             map[string][]float64{"Innodb_os_log_written": series},
+		IsCounter:          map[string]bool{"Innodb_os_log_written": true},
+		SnapshotBoundaries: []int{0, blockA + 1},
+		VariableNames:      []string{"Innodb_os_log_written"},
+	}
+
+	v := computeRedoSizing(r)
+	if v == nil {
+		t.Fatal("expected non-nil view")
+	}
+	if v.State != "ok" {
+		t.Fatalf("State = %q, want ok", v.State)
+	}
+	// Block B is the longest block reaching a full peak; both
+	// blocks are 60 samples / 60 seconds long, so the window
+	// collapses to 60s and the peak is the full Block B average.
+	const wantPeak = float64(oneMiB)
+	if math.Abs(v.PeakRateBytesPerSec-wantPeak) > wantPeak*0.005 {
+		t.Fatalf("PeakRateBytesPerSec = %.0f, want %.0f "+
+			"(post-boundary first sample must be included)",
+			v.PeakRateBytesPerSec, wantPeak)
 	}
 }

--- a/render/redo_sizing_test.go
+++ b/render/redo_sizing_test.go
@@ -660,3 +660,197 @@ func TestComputeRedoSizing_MultiBlock_PostBoundarySpanLeftBound(t *testing.T) {
 			v.PeakRateBytesPerSec, wantPeak)
 	}
 }
+
+// TestComputeRedoSizing_NaNPaddedFirstBlock_DoesNotSkip is the
+// regression test for the SkipFirst-by-global-index fix. When
+// Innodb_os_log_written is absent in early snapshots and only appears
+// later, model.MergeMysqladminData pads the early indices with NaN and
+// then strips the cold-start tally for the variable's first appearance
+// (it inserts a NaN boundary slot and appends src[1:]). The resulting
+// merged series therefore has its FIRST FINITE block starting at some
+// startIdx > 0, and that block's first finite sample IS a real
+// per-interval delta — there is no cold-start tally to skip.
+//
+// Setup: a synthetic series with two NaN-padded slots followed by 60
+// real 1 MiB deltas at a 1 s step. With the correct math (SkipFirst
+// gated on startIdx == 0) the block has startIdx == 2, SkipFirst is
+// false, and ALL 60 deltas contribute, yielding ObservedAvg == 1 MiB/s.
+//
+// A buggy implementation that ties SkipFirst to "first finite block"
+// would set SkipFirst == true here, drop the delta at startIdx, and
+// also lose the corresponding interval — yielding 59 MiB / 59 s, which
+// happens to round to the same average value but is a discriminating
+// loss in the rolling-peak walk: with the buggy SkipFirst the first
+// usable index is 3, the rolling window over the remaining 59 samples
+// has length 59 s; with the correct SkipFirst it has length 60 s and
+// the peak rate is exactly 1 MiB/s computed from 60 MiB over 60 s.
+// We assert directly on the bytes count via the recommended-15-min
+// number (peak * 900) — under the bug the panel would be missing
+// 1 MiB of bytes from its peak input, which surfaces as a >1.5%
+// shortfall in PeakRateBytesPerSec when the window collapses to the
+// available-block length.
+func TestComputeRedoSizing_NaNPaddedFirstBlock_DoesNotSkip(t *testing.T) {
+	const oneMiB = 1 << 20
+	const padded = 2
+	const blockLen = 60
+	r := makeRedoReport(t, vars57(1<<30, 16), nil, 1)
+	if r.DBSection == nil {
+		t.Fatal("setup: expected DBSection")
+	}
+	n := padded + blockLen
+	ts := make([]time.Time, n)
+	base := time.Date(2026, 5, 7, 12, 0, 0, 0, time.UTC)
+	for i := 0; i < n; i++ {
+		ts[i] = base.Add(time.Duration(i) * time.Second)
+	}
+	series := make([]float64, n)
+	// Leading NaN padding (variable absent in early snapshots).
+	for i := 0; i < padded; i++ {
+		series[i] = math.NaN()
+	}
+	// First finite block: 60 real 1 MiB deltas. The first one at
+	// startIdx == padded is a genuine per-interval delta because
+	// MergeMysqladminData has already stripped the cold-start tally
+	// for this variable's first appearance.
+	for i := padded; i < n; i++ {
+		series[i] = oneMiB
+	}
+	r.DBSection.Mysqladmin = &model.MysqladminData{
+		SampleCount:        n,
+		Timestamps:         ts,
+		Deltas:             map[string][]float64{"Innodb_os_log_written": series},
+		IsCounter:          map[string]bool{"Innodb_os_log_written": true},
+		SnapshotBoundaries: []int{0, padded},
+		VariableNames:      []string{"Innodb_os_log_written"},
+	}
+
+	v := computeRedoSizing(r)
+	if v == nil {
+		t.Fatal("expected non-nil view")
+	}
+	if v.State != "ok" {
+		t.Fatalf("State = %q, want ok", v.State)
+	}
+	// Block span: ts[n-1] - ts[startIdx-1] = ts[n-1] - ts[padded-1] =
+	// 60 s. Bytes: 60 MiB. Peak == ObservedAvg == 1 MiB/s.
+	const wantRate = float64(oneMiB)
+	if math.Abs(v.ObservedRateBytesPerSec-wantRate) > wantRate*0.001 {
+		t.Fatalf("ObservedRateBytesPerSec = %.0f, want %.0f "+
+			"(NaN-padded first block must not be treated as cold-start)",
+			v.ObservedRateBytesPerSec, wantRate)
+	}
+	if math.Abs(v.PeakRateBytesPerSec-wantRate) > wantRate*0.001 {
+		t.Fatalf("PeakRateBytesPerSec = %.0f, want %.0f "+
+			"(NaN-padded first block must not be treated as cold-start)",
+			v.PeakRateBytesPerSec, wantRate)
+	}
+	// Window collapses to the block's wall-clock duration; with the
+	// correct SkipFirst (gated on startIdx == 0) the block span is
+	// 60 s. A buggy implementation that strips the first delta would
+	// shrink the window to 59 s.
+	if math.Abs(v.PeakWindowSeconds-60.0) > 1e-9 {
+		t.Fatalf("PeakWindowSeconds = %.3f, want 60.000 "+
+			"(NaN-padded first block must include its first finite delta)",
+			v.PeakWindowSeconds)
+	}
+	if v.PeakWindowLabel != "available 60-second" {
+		t.Fatalf("PeakWindowLabel = %q, want %q",
+			v.PeakWindowLabel, "available 60-second")
+	}
+}
+
+// TestComputeRedoSizing_SingleDeltaPostBoundaryBlock_Counted is the
+// regression test for the "single-delta post-boundary block" rejection
+// fix. When a snapshot contributes exactly two samples (one cold-start
+// tally + one per-interval delta), MergeMysqladminData replaces the
+// tally with a NaN boundary and appends src[1:], yielding a
+// post-boundary block of exactly one finite sample. That single delta
+// covers a real interval (timestamps[startIdx-1], timestamps[startIdx]]
+// and MUST be included in both the average and the peak walk.
+//
+// Setup: Block A is a 2-sample idle block (cold-start tally + one
+// zero delta) covering ts[0]..ts[1] = 1 s. A NaN boundary follows at
+// ts[2] = 2 s. Block B is a single 1 MiB delta at ts[3] = 4 s, so
+// its left-bound interval is (ts[2], ts[3]] = 2 s. Block B is the
+// longest block so the rolling-window walk collapses to its 2 s span.
+//
+// With the correct math:
+//   - Block A: 1 s observed, 0 bytes (idle).
+//   - Block B: 2 s observed, 1 MiB bytes — single-delta post-boundary
+//     block, MUST be kept under the new hasUsableDelta() predicate.
+//   - longest block = 2 s, window collapses to 2 s, peak walk visits
+//     Block B and produces a candidate of 1 MiB / 2 s = 524 288 B/s.
+//   - State == "ok", PeakRateBytesPerSec == 524 288.
+//
+// A buggy implementation with the old `endIdx-startIdx < 2` filter
+// drops Block B entirely, yielding 0 bytes / 1 s in Block A only,
+// anyWrites == false, and the panel reports no_writes (zero peak
+// rate, zero observed rate).
+func TestComputeRedoSizing_SingleDeltaPostBoundaryBlock_Counted(t *testing.T) {
+	const oneMiB = 1 << 20
+	r := makeRedoReport(t, vars57(1<<30, 16), nil, 1)
+	if r.DBSection == nil {
+		t.Fatal("setup: expected DBSection")
+	}
+	// Series layout (indices, timestamps in seconds):
+	//   0   ts=0  Block A cold-start tally (skipped).
+	//   1   ts=1  Block A zero delta.
+	//   2   ts=2  NaN boundary.
+	//   3   ts=4  Block B single 1 MiB delta (interval ts[2]..ts[3] = 2 s).
+	const n = 4
+	ts := []time.Time{
+		time.Date(2026, 5, 7, 12, 0, 0, 0, time.UTC),
+		time.Date(2026, 5, 7, 12, 0, 1, 0, time.UTC),
+		time.Date(2026, 5, 7, 12, 0, 2, 0, time.UTC),
+		time.Date(2026, 5, 7, 12, 0, 4, 0, time.UTC),
+	}
+	series := []float64{
+		999_999_999,
+		0,
+		math.NaN(),
+		oneMiB,
+	}
+	r.DBSection.Mysqladmin = &model.MysqladminData{
+		SampleCount:        n,
+		Timestamps:         ts,
+		Deltas:             map[string][]float64{"Innodb_os_log_written": series},
+		IsCounter:          map[string]bool{"Innodb_os_log_written": true},
+		SnapshotBoundaries: []int{0, 3},
+		VariableNames:      []string{"Innodb_os_log_written"},
+	}
+
+	v := computeRedoSizing(r)
+	if v == nil {
+		t.Fatal("expected non-nil view")
+	}
+	if v.State != "ok" {
+		t.Fatalf("State = %q, want ok (single-delta post-boundary "+
+			"block must contribute its bytes)", v.State)
+	}
+	// Observed seconds = Block A (1 s) + Block B (2 s) = 3 s. Bytes
+	// = 1 MiB. ObservedAvg = 1 MiB / 3 s.
+	const wantAvg = float64(oneMiB) / 3.0
+	if math.Abs(v.ObservedRateBytesPerSec-wantAvg) > wantAvg*0.001 {
+		t.Fatalf("ObservedRateBytesPerSec = %.4f, want %.4f "+
+			"(single-delta post-boundary block must be counted)",
+			v.ObservedRateBytesPerSec, wantAvg)
+	}
+	// Longest block is Block B at 2 s; window collapses to 2 s.
+	if math.Abs(v.PeakWindowSeconds-2.0) > 1e-9 {
+		t.Fatalf("PeakWindowSeconds = %.3f, want 2.000 "+
+			"(single-delta post-boundary block must drive longest "+
+			"block measurement)",
+			v.PeakWindowSeconds)
+	}
+	if v.PeakWindowLabel != "available 2-second" {
+		t.Fatalf("PeakWindowLabel = %q, want %q",
+			v.PeakWindowLabel, "available 2-second")
+	}
+	// Peak = 1 MiB / 2 s = 524 288 B/s.
+	const wantPeak = float64(oneMiB) / 2.0
+	if math.Abs(v.PeakRateBytesPerSec-wantPeak) > wantPeak*0.001 {
+		t.Fatalf("PeakRateBytesPerSec = %.4f, want %.4f "+
+			"(single-delta post-boundary block must drive the peak)",
+			v.PeakRateBytesPerSec, wantPeak)
+	}
+}

--- a/render/redo_sizing_test.go
+++ b/render/redo_sizing_test.go
@@ -1,0 +1,351 @@
+package render
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/matias-sanchez/My-gather/model"
+)
+
+// makeRedoReport builds a synthetic *model.Report whose VariablesSection
+// contains the supplied variable map and whose DBSection.Mysqladmin
+// carries an Innodb_os_log_written counter time-series with the given
+// per-sample byte deltas. Each delta covers stepSeconds of wall-clock
+// time. To match the pt-mext convention used by the production
+// helpers, the first sample of each block holds a "raw initial tally"
+// value that the readers ignore; the caller-supplied deltas occupy
+// indices 1..len(deltas). Pass nil deltas to omit the counter
+// entirely.
+func makeRedoReport(t *testing.T, vars map[string]string, deltas []float64, stepSeconds float64) *model.Report {
+	t.Helper()
+	r := &model.Report{}
+
+	if vars != nil {
+		entries := make([]model.VariableEntry, 0, len(vars))
+		for k, v := range vars {
+			entries = append(entries, model.VariableEntry{Name: k, Value: v})
+		}
+		r.VariablesSection = &model.VariablesSection{
+			PerSnapshot: []model.SnapshotVariables{
+				{Data: &model.VariablesData{Entries: entries}},
+			},
+		}
+	}
+
+	r.DBSection = &model.DBSection{}
+	if deltas != nil {
+		// Sample 0 is the bogus initial tally; sample i (i>=1) holds
+		// deltas[i-1]. Timestamps are stepSeconds apart.
+		n := len(deltas) + 1
+		ts := make([]time.Time, n)
+		base := time.Date(2026, 5, 7, 12, 0, 0, 0, time.UTC)
+		for i := 0; i < n; i++ {
+			ts[i] = base.Add(time.Duration(float64(i)*stepSeconds) * time.Second)
+		}
+		series := make([]float64, n)
+		series[0] = 999_999_999 // ignored by readers
+		for i, d := range deltas {
+			series[i+1] = d
+		}
+		r.DBSection.Mysqladmin = &model.MysqladminData{
+			SampleCount:        n,
+			Timestamps:         ts,
+			Deltas:             map[string][]float64{"Innodb_os_log_written": series},
+			IsCounter:          map[string]bool{"Innodb_os_log_written": true},
+			SnapshotBoundaries: []int{0},
+			VariableNames:      []string{"Innodb_os_log_written"},
+		}
+	}
+	return r
+}
+
+// vars57 returns a synthetic 5.7-style variable map with the given
+// per-file size (bytes) and number of files.
+func vars57(perFileBytes int64, files int) map[string]string {
+	return map[string]string{
+		"innodb_log_file_size":      itoa(perFileBytes),
+		"innodb_log_files_in_group": itoa(int64(files)),
+	}
+}
+
+// vars80 returns a synthetic 8.0.30+ variable map setting
+// innodb_redo_log_capacity directly. The legacy variables are also
+// included to confirm the reader prefers the dynamic capacity.
+func vars80(capacityBytes int64) map[string]string {
+	return map[string]string{
+		"innodb_redo_log_capacity":  itoa(capacityBytes),
+		"innodb_log_file_size":      itoa(1 << 30),
+		"innodb_log_files_in_group": "2",
+	}
+}
+
+func itoa(n int64) string {
+	// Avoid pulling fmt for one call site; this is plenty for a test.
+	if n == 0 {
+		return "0"
+	}
+	neg := n < 0
+	if neg {
+		n = -n
+	}
+	var buf [20]byte
+	i := len(buf)
+	for n > 0 {
+		i--
+		buf[i] = byte('0' + n%10)
+		n /= 10
+	}
+	if neg {
+		i--
+		buf[i] = '-'
+	}
+	return string(buf[i:])
+}
+
+// constantDeltas returns n samples each carrying the same byte delta,
+// useful for setting up a known peak rate (bytes per stepSeconds).
+func constantDeltas(n int, perSample float64) []float64 {
+	out := make([]float64, n)
+	for i := range out {
+		out[i] = perSample
+	}
+	return out
+}
+
+func TestComputeRedoSizing_57_WellSized(t *testing.T) {
+	// 5.7 server, configured 2 GiB. Workload writes 1 MiB per second
+	// for 30 samples (30 seconds). Coverage on the available window
+	// computes to (2 GiB / 1 MiB/s) / 60 ≈ 34 minutes, well-sized.
+	r := makeRedoReport(t, vars57(1<<30, 2), constantDeltas(30, 1<<20), 1)
+	v := computeRedoSizing(r)
+	if v == nil {
+		t.Fatal("expected non-nil view")
+	}
+	if v.State != "ok" {
+		t.Fatalf("State = %q, want %q", v.State, "ok")
+	}
+	if v.ConfigSource != "innodb_log_file_size x innodb_log_files_in_group" {
+		t.Fatalf("ConfigSource = %q", v.ConfigSource)
+	}
+	if v.ConfiguredText != "2.00 GiB" {
+		t.Fatalf("ConfiguredText = %q, want 2.0 GiB", v.ConfiguredText)
+	}
+	if v.UnderSized {
+		t.Fatalf("UnderSized = true, want false")
+	}
+	if v.WarningLine != "" {
+		t.Fatalf("WarningLine = %q, want empty", v.WarningLine)
+	}
+	if v.KBReference != kbReferenceRedoSizing {
+		t.Fatalf("KBReference = %q", v.KBReference)
+	}
+	if v.Recommended15MinText == "n/a" || v.Recommended1HourText == "n/a" {
+		t.Fatalf("recommendations should be populated, got %q / %q",
+			v.Recommended15MinText, v.Recommended1HourText)
+	}
+}
+
+func TestComputeRedoSizing_57_UnderSized(t *testing.T) {
+	// 5.7 server, configured 256 MiB total (128 MiB x 2). Peak rate
+	// 10 MiB/s -> coverage ≈ 0.4 minutes, far below the 15-minute
+	// threshold.
+	r := makeRedoReport(t, vars57(128<<20, 2), constantDeltas(30, 10<<20), 1)
+	v := computeRedoSizing(r)
+	if v == nil {
+		t.Fatal("expected non-nil view")
+	}
+	if v.State != "ok" {
+		t.Fatalf("State = %q", v.State)
+	}
+	if !v.UnderSized {
+		t.Fatalf("UnderSized = false, want true (coverage = %.2f min)",
+			v.CoverageMinutes)
+	}
+	want := "Current redo space holds only "
+	if !strings.HasPrefix(v.WarningLine, want) {
+		t.Fatalf("WarningLine = %q, want prefix %q", v.WarningLine, want)
+	}
+	if !strings.Contains(v.WarningLine, "minutes of peak writes - consider raising") {
+		t.Fatalf("WarningLine missing canonical suffix: %q", v.WarningLine)
+	}
+}
+
+func TestComputeRedoSizing_80Plus_WellSized(t *testing.T) {
+	// 8.0.30+: innodb_redo_log_capacity set to 16 GiB, with the
+	// legacy variables also present (vars80 includes them). The
+	// reader must prefer the dynamic capacity and ignore the legacy
+	// product.
+	r := makeRedoReport(t, vars80(16<<30), constantDeltas(30, 1<<20), 1)
+	v := computeRedoSizing(r)
+	if v == nil {
+		t.Fatal("expected non-nil view")
+	}
+	if v.State != "ok" {
+		t.Fatalf("State = %q", v.State)
+	}
+	if v.ConfigSource != "innodb_redo_log_capacity" {
+		t.Fatalf("ConfigSource = %q, want innodb_redo_log_capacity", v.ConfigSource)
+	}
+	if v.ConfiguredText != "16.00 GiB" {
+		t.Fatalf("ConfiguredText = %q, want 16.0 GiB", v.ConfiguredText)
+	}
+	if v.UnderSized {
+		t.Fatalf("UnderSized = true, want false")
+	}
+}
+
+func TestComputeRedoSizing_80Plus_UnderSized(t *testing.T) {
+	// 8.0.30+ with a 512 MiB capacity against a 10 MiB/s workload.
+	r := makeRedoReport(t, vars80(512<<20), constantDeltas(30, 10<<20), 1)
+	v := computeRedoSizing(r)
+	if v == nil {
+		t.Fatal("expected non-nil view")
+	}
+	if v.State != "ok" {
+		t.Fatalf("State = %q", v.State)
+	}
+	if v.ConfigSource != "innodb_redo_log_capacity" {
+		t.Fatalf("ConfigSource = %q", v.ConfigSource)
+	}
+	if !v.UnderSized {
+		t.Fatalf("UnderSized = false, want true")
+	}
+	if v.WarningLine == "" {
+		t.Fatal("WarningLine should be populated for under-sized 8.0+ case")
+	}
+}
+
+func TestComputeRedoSizing_ConfigMissing(t *testing.T) {
+	// Variables absent; counter present.
+	r := makeRedoReport(t, nil, constantDeltas(30, 1<<20), 1)
+	v := computeRedoSizing(r)
+	if v == nil {
+		t.Fatal("expected non-nil view")
+	}
+	if v.State != "config_missing" {
+		t.Fatalf("State = %q, want config_missing", v.State)
+	}
+	if v.ConfiguredText != "unavailable" {
+		t.Fatalf("ConfiguredText = %q", v.ConfiguredText)
+	}
+	if v.CoverageText != "n/a" {
+		t.Fatalf("CoverageText = %q", v.CoverageText)
+	}
+	if v.KBReference != kbReferenceRedoSizing {
+		t.Fatalf("KBReference = %q", v.KBReference)
+	}
+}
+
+func TestComputeRedoSizing_RateUnavailable(t *testing.T) {
+	// Variables present; counter absent.
+	r := makeRedoReport(t, vars57(1<<30, 2), nil, 1)
+	v := computeRedoSizing(r)
+	if v == nil {
+		t.Fatal("expected non-nil view")
+	}
+	if v.State != "rate_unavailable" {
+		t.Fatalf("State = %q, want rate_unavailable", v.State)
+	}
+	if v.ObservedRateText != "unavailable" {
+		t.Fatalf("ObservedRateText = %q", v.ObservedRateText)
+	}
+	if v.CoverageText != "n/a" {
+		t.Fatalf("CoverageText = %q", v.CoverageText)
+	}
+	if v.Recommended15MinText != "n/a" || v.Recommended1HourText != "n/a" {
+		t.Fatalf("recommendations should be n/a, got %q / %q",
+			v.Recommended15MinText, v.Recommended1HourText)
+	}
+	if v.ConfiguredText != "2.00 GiB" {
+		t.Fatalf("ConfiguredText = %q, want 2.0 GiB", v.ConfiguredText)
+	}
+}
+
+func TestComputeRedoSizing_ShortCaptureWindow(t *testing.T) {
+	// Capture window is 30s total, far shorter than 15 minutes. The
+	// panel should collapse the window and label it accordingly.
+	r := makeRedoReport(t, vars57(1<<30, 2), constantDeltas(30, 1<<20), 1)
+	v := computeRedoSizing(r)
+	if v == nil {
+		t.Fatal("expected non-nil view")
+	}
+	if v.PeakWindowSeconds >= 900 {
+		t.Fatalf("PeakWindowSeconds = %v, want < 900", v.PeakWindowSeconds)
+	}
+	if !strings.HasPrefix(v.PeakWindowLabel, "available ") {
+		t.Fatalf("PeakWindowLabel = %q, want prefix %q",
+			v.PeakWindowLabel, "available ")
+	}
+	if v.CoverageText == "n/a" || v.CoverageText == "" {
+		t.Fatalf("CoverageText = %q, want populated coverage", v.CoverageText)
+	}
+}
+
+func TestComputeRedoSizing_NoWrites(t *testing.T) {
+	// Counter present but every delta is zero (idle workload).
+	r := makeRedoReport(t, vars57(1<<30, 2), constantDeltas(30, 0), 1)
+	v := computeRedoSizing(r)
+	if v == nil {
+		t.Fatal("expected non-nil view")
+	}
+	if v.State != "no_writes" {
+		t.Fatalf("State = %q, want no_writes", v.State)
+	}
+	if v.ConfiguredText != "2.00 GiB" {
+		t.Fatalf("ConfiguredText = %q", v.ConfiguredText)
+	}
+	if v.CoverageText != "n/a" {
+		t.Fatalf("CoverageText = %q", v.CoverageText)
+	}
+	if v.Recommended15MinText != "n/a" || v.Recommended1HourText != "n/a" {
+		t.Fatalf("recommendations should be n/a, got %q / %q",
+			v.Recommended15MinText, v.Recommended1HourText)
+	}
+	if v.UnderSized {
+		t.Fatalf("UnderSized = true on no-writes, want false")
+	}
+	if v.WarningLine != "" {
+		t.Fatalf("WarningLine = %q, want empty", v.WarningLine)
+	}
+	if v.KBReference != kbReferenceRedoSizing {
+		t.Fatalf("KBReference = %q", v.KBReference)
+	}
+}
+
+func TestComputeRedoSizing_WarningBoundary(t *testing.T) {
+	// Set up a constant 1 MiB/s workload. Configured = 900 MiB
+	// gives coverage of exactly 15.0 minutes; configured = 899 MiB
+	// gives coverage just below 15 minutes.
+	const oneMiBperSec = 1 << 20
+
+	rEqual := makeRedoReport(t, vars57(900<<20, 1),
+		constantDeltas(60, oneMiBperSec), 1)
+	vEqual := computeRedoSizing(rEqual)
+	if vEqual == nil {
+		t.Fatal("expected non-nil view (equal)")
+	}
+	if vEqual.State != "ok" {
+		t.Fatalf("equal: State = %q", vEqual.State)
+	}
+	if vEqual.CoverageMinutes != 15 {
+		t.Fatalf("equal: CoverageMinutes = %v, want 15", vEqual.CoverageMinutes)
+	}
+	if vEqual.UnderSized {
+		t.Fatalf("equal: UnderSized = true, want false (boundary inclusive at 15)")
+	}
+	if vEqual.WarningLine != "" {
+		t.Fatalf("equal: WarningLine = %q, want empty", vEqual.WarningLine)
+	}
+
+	rBelow := makeRedoReport(t, vars57(899<<20, 1),
+		constantDeltas(60, oneMiBperSec), 1)
+	vBelow := computeRedoSizing(rBelow)
+	if vBelow == nil {
+		t.Fatal("expected non-nil view (below)")
+	}
+	if !vBelow.UnderSized {
+		t.Fatalf("below: UnderSized = false, want true (coverage = %.4f)",
+			vBelow.CoverageMinutes)
+	}
+}

--- a/render/redo_sizing_test.go
+++ b/render/redo_sizing_test.go
@@ -558,3 +558,105 @@ func TestComputeRedoSizing_MultiBlock_PostBoundaryFirstSampleIncluded(t *testing
 			v.PeakRateBytesPerSec, wantPeak)
 	}
 }
+
+// TestComputeRedoSizing_MultiBlock_PostBoundarySpanLeftBound is the
+// regression test for the post-boundary span-derivation fix. The
+// average-rate observed-seconds accumulator and the rolling-peak
+// fallback span both anchor a post-boundary block's left edge at
+// timestamps[startIdx-1] (the snapshot-boundary timestamp) because
+// model.MergeMysqladminData's NaN+src[1:] append makes the included
+// delta at startIdx cover (timestamps[startIdx-1], timestamps[startIdx]].
+// A naive implementation that anchors at timestamps[startIdx] biases
+// both the observed-seconds denominator (under-counted) and the peak
+// fallback span (under-counted) downward, biasing both rates upward.
+//
+// Setup: a synthetic two-block series tuned so the post-boundary
+// block dominates and a one-step left-bound shift is a meaningful
+// fraction of total observed-seconds. Block A holds only the
+// cold-start tally plus one finite delta (1 MiB over 10 s). The NaN
+// boundary follows. Block B holds 6 finite deltas of 1 MiB each at
+// a 10 s step. With the correct math:
+//
+//   - Block A span = 10 s, contributes 1 MiB.
+//   - Block B span = ts[end-1] - ts[startIdx-1] = 6 * 10 = 60 s,
+//     contributes 6 MiB.
+//   - ObservedAvg = 7 MiB / 70 s = 104 857.6 B/s.
+//   - longest block = 60 s, window collapses to 60 s, label
+//     "available 60-second", peak walk over Block B yields
+//     6 MiB / 60 s = 104 857.6 B/s.
+//
+// A naive implementation that anchors Block B at ts[startIdx]
+// instead would compute span_B = 50 s, yielding ObservedAvg
+// ≈ 122 137 B/s and Peak (window collapsed to 50 s)
+// ≈ 104 857.6 B/s but with a "available 50-second" label. The peak
+// label and the observed-average value are both discriminating.
+func TestComputeRedoSizing_MultiBlock_PostBoundarySpanLeftBound(t *testing.T) {
+	const oneMiB = 1 << 20
+	const stepSeconds = 10
+	r := makeRedoReport(t, vars57(1<<30, 16), nil, 1)
+	if r.DBSection == nil {
+		t.Fatal("setup: expected DBSection")
+	}
+	// Total samples: 2 (Block A) + 1 (NaN boundary) + 6 (Block B) = 9.
+	const blockA = 2
+	const blockB = 6
+	n := blockA + 1 + blockB
+	ts := make([]time.Time, n)
+	base := time.Date(2026, 5, 7, 12, 0, 0, 0, time.UTC)
+	for i := 0; i < n; i++ {
+		ts[i] = base.Add(time.Duration(i*stepSeconds) * time.Second)
+	}
+	series := make([]float64, n)
+	// Block A: index 0 raw cold-start tally (skipped), index 1 a real
+	// 1 MiB delta covering ts[0]..ts[1] = 10 s.
+	series[0] = 999_999_999
+	series[1] = oneMiB
+	// NaN boundary at index 2.
+	series[2] = math.NaN()
+	// Block B: 6 real 1 MiB deltas at indices 3..8. The first one at
+	// index 3 covers (ts[2], ts[3]] per MergeMysqladminData's
+	// NaN+src[1:] convention; its left bound is ts[2].
+	for i := blockA + 1; i < n; i++ {
+		series[i] = oneMiB
+	}
+	r.DBSection.Mysqladmin = &model.MysqladminData{
+		SampleCount:        n,
+		Timestamps:         ts,
+		Deltas:             map[string][]float64{"Innodb_os_log_written": series},
+		IsCounter:          map[string]bool{"Innodb_os_log_written": true},
+		SnapshotBoundaries: []int{0, blockA + 1},
+		VariableNames:      []string{"Innodb_os_log_written"},
+	}
+
+	v := computeRedoSizing(r)
+	if v == nil {
+		t.Fatal("expected non-nil view")
+	}
+	if v.State != "ok" {
+		t.Fatalf("State = %q, want ok", v.State)
+	}
+	// Block A: 1 MiB over 10 s. Block B: 6 MiB over 60 s. Total
+	// 7 MiB over 70 s = 104 857.6 B/s.
+	const wantAvg = float64(oneMiB) * 7 / 70
+	if math.Abs(v.ObservedRateBytesPerSec-wantAvg) > wantAvg*0.001 {
+		t.Fatalf("ObservedRateBytesPerSec = %.4f, want %.4f "+
+			"(post-boundary block left bound must be timestamps[startIdx-1])",
+			v.ObservedRateBytesPerSec, wantAvg)
+	}
+	// Longest block is Block B at 60 s; window collapses to 60 s.
+	if math.Abs(v.PeakWindowSeconds-60.0) > 1e-9 {
+		t.Fatalf("PeakWindowSeconds = %.3f, want 60.000 "+
+			"(post-boundary block fallback span must be 60 s)",
+			v.PeakWindowSeconds)
+	}
+	if v.PeakWindowLabel != "available 60-second" {
+		t.Fatalf("PeakWindowLabel = %q, want %q",
+			v.PeakWindowLabel, "available 60-second")
+	}
+	// Peak = 6 MiB / 60 s = 104 857.6 B/s.
+	const wantPeak = float64(oneMiB) * 6 / 60
+	if math.Abs(v.PeakRateBytesPerSec-wantPeak) > wantPeak*0.001 {
+		t.Fatalf("PeakRateBytesPerSec = %.4f, want %.4f",
+			v.PeakRateBytesPerSec, wantPeak)
+	}
+}

--- a/render/templates/db.html.tmpl
+++ b/render/templates/db.html.tmpl
@@ -173,6 +173,37 @@
     {{- else }}
     <p class="banner missing">Data not available — no <code>-innodbstatus1</code> files were present in this collection.</p>
     {{- end }}
+    {{- if .RedoSizing }}
+    {{- with .RedoSizing }}
+    <div class="redo-sizing callout{{if .UnderSized}} sev-warn{{end}}">
+      <p class="k">Redo log sizing</p>
+      {{- if eq .State "config_missing" }}
+      <p class="v">unavailable</p>
+      <p class="sub">Redo configuration variables not present in this capture.</p>
+      {{- else }}
+      <p class="v">{{.ConfiguredText}}</p>
+      <p class="sub">configured redo space — source: <code>{{.ConfigSource}}</code></p>
+      {{- end }}
+      {{- if eq .State "rate_unavailable" }}
+      <p class="stats">Observed write rate: unavailable (no <code>Innodb_os_log_written</code> samples)</p>
+      {{- else if eq .State "no_writes" }}
+      <p class="stats">Observed average write rate: <span>{{.ObservedRateText}}</span> · <span>{{.ObservedRatePerMinText}}</span></p>
+      <p class="stats">No observed redo writes during the capture — coverage and recommendations are not applicable.</p>
+      {{- else }}
+      <p class="stats">Observed average write rate: <span>{{.ObservedRateText}}</span> · <span>{{.ObservedRatePerMinText}}</span></p>
+      <p class="stats">Peak write rate ({{.PeakWindowLabel}} rolling): <span>{{.PeakRateText}}</span></p>
+      {{- if eq .State "ok" }}
+      <p class="stats">Coverage at peak: <span>{{.CoverageText}}</span></p>
+      <p class="stats">Recommended for 15 minutes of peak: <span>{{.Recommended15MinText}}</span> · Recommended for 1 hour of peak: <span>{{.Recommended1HourText}}</span></p>
+      {{- end }}
+      {{- end }}
+      {{- if .UnderSized }}
+      <p class="warn">{{.WarningLine}}</p>
+      {{- end }}
+      <p class="sub">Methodology: {{.KBReference}}</p>
+    </div>
+    {{- end }}
+    {{- end }}
   </div>
 </details>
 

--- a/render/view.go
+++ b/render/view.go
@@ -69,6 +69,14 @@ type reportView struct {
 	// DB section payload
 	HasInnoDB           bool
 	InnoDBMetrics       []innoDBMetricView
+	// RedoSizing carries the Redo log sizing panel payload rendered
+	// under the InnoDB Status subsection. A nil value means the panel
+	// is not rendered at all (no DBSection on the report); a non-nil
+	// value with State == "config_missing", "rate_unavailable", or
+	// "no_writes" means the panel renders with the corresponding
+	// placeholder content. See render/redo_sizing.go for the canonical
+	// computation and specs/019-redo-log-sizing-panel for the contract.
+	RedoSizing          *redoSizingView
 	HasMysqladmin       bool
 	MysqladminVariables []string
 	MysqladminCount     int

--- a/render/view.go
+++ b/render/view.go
@@ -67,8 +67,8 @@ type reportView struct {
 	VariableSnapshots []variableSnapshotView
 
 	// DB section payload
-	HasInnoDB           bool
-	InnoDBMetrics       []innoDBMetricView
+	HasInnoDB     bool
+	InnoDBMetrics []innoDBMetricView
 	// RedoSizing carries the Redo log sizing panel payload rendered
 	// under the InnoDB Status subsection. A nil value means the panel
 	// is not rendered at all (no DBSection on the report); a non-nil

--- a/specs/019-redo-log-sizing-panel/checklists/requirements.md
+++ b/specs/019-redo-log-sizing-panel/checklists/requirements.md
@@ -1,0 +1,40 @@
+# Specification Quality Checklist: Redo log sizing panel
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-05-07
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+All checklist items pass on the first pass. The user explicitly preset the
+methodology source (Percona KB0010732), the configuration-model split
+(legacy 5.6/5.7 versus 8.0.30+), the peak-window definition (busiest 15-minute
+rolling window), and the warning threshold (below 15 minutes), so no
+[NEEDS CLARIFICATION] markers were required. Edge cases for short capture
+windows, missing variables, missing counter, and zero observed write rate
+are explicitly enumerated and addressed by FR-008 through FR-010.

--- a/specs/019-redo-log-sizing-panel/contracts/redo-sizing-panel.md
+++ b/specs/019-redo-log-sizing-panel/contracts/redo-sizing-panel.md
@@ -1,0 +1,161 @@
+# Contract: Redo log sizing panel
+
+**Feature**: 019-redo-log-sizing-panel
+**Owner**: `render/redo_sizing.go`
+**Consumers**: `render/build_view.go`, `render/templates/db.html.tmpl`
+
+## Function contract
+
+```go
+// computeRedoSizing produces the view payload for the Redo log sizing
+// panel under the InnoDB Status section. Returns nil when the report
+// has no DBSection (the panel does not render at all in that case).
+// In every other case it returns a non-nil view; the view's State
+// field communicates which subset of the panel can be populated:
+//
+//   - "ok"               — configured space and observed rate both known
+//   - "config_missing"   — variables for configured redo space absent
+//   - "rate_unavailable" — Innodb_os_log_written absent or insufficient
+//   - "no_writes"        — observed peak rate is zero
+//
+// The KB0010732 citation is always populated.
+func computeRedoSizing(r *model.Report) *redoSizingView
+```
+
+## View struct contract
+
+```go
+type redoSizingView struct {
+    // State drives which template branches render.
+    // Values: "ok" | "config_missing" | "rate_unavailable" | "no_writes"
+    State string
+
+    // ConfiguredBytes is the total redo log capacity in bytes.
+    // Zero when State == "config_missing".
+    ConfiguredBytes float64
+    // ConfiguredText is the human-readable form, or "unavailable".
+    ConfiguredText string
+    // ConfigSource names the variable(s) used:
+    //   "innodb_redo_log_capacity"                     (8.0.30+ model)
+    //   "innodb_log_file_size x innodb_log_files_in_group" (5.6/5.7 model)
+    //   ""                                              (config_missing)
+    ConfigSource string
+
+    // ObservedRateBytesPerSec is the average rate over the entire capture.
+    // Zero when State == "rate_unavailable".
+    ObservedRateBytesPerSec float64
+    ObservedRateText        string // "12.5 MiB/s" or "unavailable"
+    ObservedRatePerMinText  string // "750 MiB/min" or "unavailable"
+
+    // PeakWindowSeconds is the actual rolling-window length used.
+    // 900 (== 15 minutes) when the capture is at least 15 minutes long;
+    // otherwise the full available capture window in seconds.
+    PeakWindowSeconds float64
+    // PeakWindowLabel is the rendered window descriptor, e.g.
+    // "15-minute" or "available 28-second".
+    PeakWindowLabel string
+    // PeakRateBytesPerSec is the peak rate observed over the rolling
+    // window of length PeakWindowSeconds. Zero when State !=
+    // "ok"/"under_sized" (i.e. when no rate is available or the rate
+    // is uniformly zero).
+    PeakRateBytesPerSec float64
+    PeakRateText        string
+
+    // CoverageMinutes is configured_bytes / peak_rate, in minutes.
+    // Zero when CoverageText == "n/a".
+    CoverageMinutes float64
+    CoverageText    string // "12 minutes" | "62 minutes" | "n/a"
+
+    // Recommended target sizes in bytes and human form.
+    Recommended15MinBytes float64
+    Recommended15MinText  string // "9.0 GiB" | "n/a"
+    Recommended1HourBytes float64
+    Recommended1HourText  string // "36.0 GiB" | "n/a"
+
+    // UnderSized is true iff State == "ok" AND CoverageMinutes < 15.
+    // The template uses this as the gate for the warning line.
+    UnderSized   bool
+    WarningLine  string // "Current redo space holds only X minutes of peak writes - consider raising"
+
+    // KBReference is always populated; the template renders it as the
+    // panel's methodology citation.
+    KBReference string // "Percona KB0010732"
+}
+```
+
+## Behavioral contract
+
+1. **8.0.30+ detection**: When `innodb_redo_log_capacity` is present
+   and parses to a positive float, `ConfiguredBytes` equals that value
+   and `ConfigSource == "innodb_redo_log_capacity"`. The legacy
+   variables, if present, are ignored.
+2. **5.6/5.7 detection**: When `innodb_redo_log_capacity` is absent
+   (or zero / unparseable), but `innodb_log_file_size` and
+   `innodb_log_files_in_group` are both present and positive,
+   `ConfiguredBytes == innodb_log_file_size * innodb_log_files_in_group`
+   and
+   `ConfigSource == "innodb_log_file_size x innodb_log_files_in_group"`.
+3. **Configuration missing**: When neither model can be evaluated,
+   `State == "config_missing"`, `ConfiguredText == "unavailable"`,
+   and `CoverageText == "n/a"`.
+4. **Rate computation**: The average rate (`ObservedRateBytesPerSec`)
+   is `sum(deltas) / observed_seconds`, identical in spirit to
+   `findings/inputs.go::counterRatePerSec` but computed locally so
+   the panel does not depend on the findings package.
+5. **Rolling-window peak**: `PeakRateBytesPerSec` is the maximum, over
+   every contiguous block of samples covering at least one full
+   `PeakWindowSeconds`-second window, of `bytes_in_window /
+   actual_window_seconds`. NaN slots (snapshot boundaries) split
+   blocks; a window may not span a NaN slot.
+6. **Window collapse**: If the longest contiguous block is shorter than
+   900 seconds, `PeakWindowSeconds` is set to the longest block's
+   duration in seconds and `PeakWindowLabel` reflects the actual
+   window length (e.g. `"available 28-second"`). The peak in that
+   case is the rate over the longest contiguous block.
+7. **Coverage**: `CoverageMinutes == ConfiguredBytes / PeakRateBytesPerSec / 60`.
+   Rendered as the integer floor (rounded down) so a 7.8-minute
+   coverage reports as "7 minutes" and the warning fires.
+8. **Recommended sizes**: `PeakRateBytesPerSec * 900` for 15 minutes,
+   `PeakRateBytesPerSec * 3600` for 1 hour. Both rendered with
+   `reportutil.HumanBytes`.
+9. **Warning gate**: The `UnderSized` flag is set, and `WarningLine`
+   populated, iff `State == "ok"` AND `CoverageMinutes < 15`. Coverage
+   exactly equal to 15 does not trigger the warning.
+10. **KB citation**: `KBReference == "Percona KB0010732"` in every state.
+
+## Test contract
+
+`render/redo_sizing_test.go` MUST cover:
+
+- T1: 5.7 server, well-sized (configured 4 GiB, peak rate that yields >=
+  15 minutes coverage). Asserts `State == "ok"`, `UnderSized == false`,
+  `ConfigSource == "innodb_log_file_size x innodb_log_files_in_group"`,
+  `ConfiguredText == "4.0 GiB"`, `WarningLine == ""`.
+- T2: 5.7 server, under-sized (configured 256 MiB, peak rate that yields
+  < 15 minutes coverage). Asserts `State == "ok"`, `UnderSized == true`,
+  `WarningLine` matches `"Current redo space holds only N minutes of peak
+  writes - consider raising"` with N being the floor minutes value.
+- T3: 8.0.30+ server, well-sized (configured 16 GiB via
+  `innodb_redo_log_capacity`, even though `innodb_log_file_size` is
+  also present at the legacy value). Asserts `State == "ok"`,
+  `UnderSized == false`,
+  `ConfigSource == "innodb_redo_log_capacity"`, `ConfiguredText == "16.0
+  GiB"`.
+- T4: 8.0.30+ server, under-sized (configured 512 MiB via
+  `innodb_redo_log_capacity` against a high-write-rate fixture).
+  Asserts `State == "ok"`, `UnderSized == true`, `WarningLine`
+  populated.
+- T5: Variables missing entirely. Asserts `State == "config_missing"`,
+  `ConfiguredText == "unavailable"`, `CoverageText == "n/a"`,
+  `KBReference == "Percona KB0010732"`.
+- T6: `Innodb_os_log_written` counter missing. Asserts
+  `State == "rate_unavailable"`, `ObservedRateText == "unavailable"`,
+  `CoverageText == "n/a"`, `Recommended15MinText == "n/a"`.
+- T7: Capture window shorter than 15 minutes. Asserts that
+  `PeakWindowSeconds < 900`, `PeakWindowLabel` reflects the actual
+  available window in seconds, and the panel still produces a coverage
+  estimate using that shorter window.
+
+All tests construct synthetic `*model.Report` values directly (no
+filesystem fixtures) so they remain fast and isolated from parser
+behavior.

--- a/specs/019-redo-log-sizing-panel/contracts/redo-sizing-panel.md
+++ b/specs/019-redo-log-sizing-panel/contracts/redo-sizing-panel.md
@@ -116,6 +116,19 @@ type redoSizingView struct {
      on the next sample. Negative deltas are clamped to 0 (a reset
      is not a write of negative bytes); this also defends against
      any other counter-reset scenario.
+
+   **Per-block observed-seconds left bound**: each block's
+   contribution to `observed_seconds` is `timestamps[endIdx-1] -
+   timestamps[leftBoundIdx]`, where `leftBoundIdx` is derived by the
+   canonical `blockLeftBoundIdx` helper. For the first block the
+   left bound is `timestamps[startIdx]` because the cold-start tally
+   at `startIdx` is excluded from the sum. For every post-boundary
+   block the left bound is `timestamps[startIdx-1]` (the
+   snapshot-boundary timestamp): `model.MergeMysqladminData`'s
+   `NaN+src[1:]` append makes the first INCLUDED delta at `startIdx`
+   cover the interval `(timestamps[startIdx-1], timestamps[startIdx]]`,
+   so the observed-seconds denominator MUST include that interval to
+   match the bytes counted into the numerator.
 5. **Rolling-window peak**: `PeakRateBytesPerSec` is the maximum, over
    every contiguous block of samples, of `bytes_in_window /
    actual_window_seconds` for windows whose `actual_window_seconds`
@@ -128,6 +141,18 @@ type redoSizingView struct {
    boundaries) split blocks; a window may not span a NaN slot.
    The cold-start tally skip and negative-delta clamp from item 4
    apply here as well.
+
+   **Fallback longest-block span**: when no block reaches the target
+   window, the rolling-window walk collapses to a single fixed
+   window equal in length to the longest block. The longest-block
+   span is measured as `timestamps[endIdx-1] -
+   timestamps[blockLeftBoundIdx(b)]`, the same canonical
+   span-derivation used by the observed-seconds accumulator in
+   item 4. For a post-boundary block this means the fallback span
+   anchors at `timestamps[startIdx-1]` (the snapshot-boundary
+   timestamp), not `timestamps[startIdx]`, so the wall-clock window
+   reflects the interval actually covered by the block's first
+   included delta.
 6. **Window collapse**: If the longest contiguous block is shorter than
    900 seconds, `PeakWindowSeconds` is set to the longest block's
    duration in seconds and `PeakWindowLabel` reflects the actual

--- a/specs/019-redo-log-sizing-panel/contracts/redo-sizing-panel.md
+++ b/specs/019-redo-log-sizing-panel/contracts/redo-sizing-panel.md
@@ -83,6 +83,37 @@ type redoSizingView struct {
 }
 ```
 
+## State priority
+
+`computeRedoSizing` derives `State` exactly once via the canonical
+helper `deriveRedoSizingState(rateOK, anyWrites, configured)`. When
+multiple degradation conditions hold simultaneously the helper
+returns the highest-priority state in this order so the most useful
+output for the operator always surfaces in the rendered panel
+(Principle III, Principle XIII):
+
+1. `"rate_unavailable"` — `Innodb_os_log_written` is absent or
+   insufficient samples exist to compute a rate. Without an observed
+   write rate the operator cannot size the redo log regardless of
+   whether the configuration variables were captured, so this state
+   takes priority over `config_missing`. The template renders the
+   explicit unavailable message for this state; downstream branches
+   MUST NOT overwrite it (otherwise the panel falls into the generic
+   rate rows with empty placeholder text such as
+   `"Peak write rate ( rolling)"`).
+2. `"config_missing"` — rate observed but configured redo space
+   unknown. The operator still gets the recommendation rows, just no
+   coverage estimate.
+3. `"no_writes"` — rate observed AND configured space known, but
+   every observed delta is zero.
+4. `"ok"` — rate observed, configured space known, and at least one
+   observed write.
+
+Downstream branches in `computeRedoSizing` MUST NOT reassign `State`
+after the helper returns; field population for each state is purely
+dispatch on the helper's result. This is the canonical
+State-derivation site for the panel.
+
 ## Behavioral contract
 
 1. **8.0.30+ detection**: When `innodb_redo_log_capacity` is present

--- a/specs/019-redo-log-sizing-panel/contracts/redo-sizing-panel.md
+++ b/specs/019-redo-log-sizing-panel/contracts/redo-sizing-panel.md
@@ -103,31 +103,54 @@ type redoSizingView struct {
    `findings/inputs.go::counterRatePerSec` but computed locally so
    the panel does not depend on the findings package. Two
    per-sample normalisations apply before the sum:
-   - **Cold-start tally skip (first block only)**: pt-mext records
+   - **Cold-start tally skip (global-index gate)**: pt-mext records
      the cold-start counter value at index 0 of the first snapshot;
      this is not a per-interval delta and is excluded from the sum.
-     `model.MergeMysqladminData` strips the equivalent raw tally
-     from every snapshot AFTER the first by replacing it with a NaN
-     boundary slot and appending `src[1:]`, so the first finite
-     sample of every post-boundary block IS a real per-interval
-     delta and is included.
+     `SkipFirst` is set on a block iff `startIdx == 0`, i.e. iff the
+     block begins at the very first global timestamp. Any block
+     whose first finite sample lives at `startIdx > 0` — whether
+     it is the FIRST FINITE block after leading NaN padding (e.g.
+     when `Innodb_os_log_written` is absent in early snapshots and
+     appears later) or any later post-boundary block — already had
+     its raw tally stripped by `model.MergeMysqladminData` (it
+     replaces the tally with a NaN boundary slot and appends
+     `src[1:]`), so its first finite sample IS a real per-interval
+     delta and is included. Tying `SkipFirst` to global index 0,
+     not to block ordinal, is the canonical predicate (Principle
+     XIII).
    - **Negative-delta clamp**: a server restart mid-capture
      re-zeroes `Innodb_os_log_written`, producing a negative delta
      on the next sample. Negative deltas are clamped to 0 (a reset
      is not a write of negative bytes); this also defends against
      any other counter-reset scenario.
 
+   **Per-block usability gate**: a block contributes to either the
+   observed-seconds accumulator or the longest-block measurement
+   iff `redoSampleBlock.hasUsableDelta()` is true. A block is
+   unusable iff it carries zero finite samples, OR it is a
+   `SkipFirst` block (begins at global index 0) with only the
+   cold-start tally and no per-interval delta. Every other block
+   — including a single-delta post-boundary block produced when a
+   snapshot contributes exactly two raw samples
+   (`MergeMysqladminData` strips the cold-start tally and emits
+   one finite delta after the NaN boundary) — is kept, because
+   that single delta covers a real interval bounded on the left
+   by `timestamps[startIdx-1]` and contributes both bytes and
+   wall-clock seconds. This is the canonical "block carries at
+   least one usable delta" predicate (Principle XIII).
+
    **Per-block observed-seconds left bound**: each block's
    contribution to `observed_seconds` is `timestamps[endIdx-1] -
    timestamps[leftBoundIdx]`, where `leftBoundIdx` is derived by the
-   canonical `blockLeftBoundIdx` helper. For the first block the
-   left bound is `timestamps[startIdx]` because the cold-start tally
-   at `startIdx` is excluded from the sum. For every post-boundary
-   block the left bound is `timestamps[startIdx-1]` (the
-   snapshot-boundary timestamp): `model.MergeMysqladminData`'s
-   `NaN+src[1:]` append makes the first INCLUDED delta at `startIdx`
-   cover the interval `(timestamps[startIdx-1], timestamps[startIdx]]`,
-   so the observed-seconds denominator MUST include that interval to
+   canonical `blockLeftBoundIdx` helper. For a `SkipFirst` block
+   (one that begins at global index 0) the left bound is
+   `timestamps[startIdx]` because the cold-start tally at
+   `startIdx` is excluded from the sum. For every other block the
+   left bound is `timestamps[startIdx-1]` (the snapshot-boundary
+   timestamp): `model.MergeMysqladminData`'s `NaN+src[1:]` append
+   makes the first INCLUDED delta at `startIdx` cover the interval
+   `(timestamps[startIdx-1], timestamps[startIdx]]`, so the
+   observed-seconds denominator MUST include that interval to
    match the bytes counted into the numerator.
 5. **Rolling-window peak**: `PeakRateBytesPerSec` is the maximum, over
    every contiguous block of samples, of `bytes_in_window /

--- a/specs/019-redo-log-sizing-panel/contracts/redo-sizing-panel.md
+++ b/specs/019-redo-log-sizing-panel/contracts/redo-sizing-panel.md
@@ -101,20 +101,48 @@ type redoSizingView struct {
 4. **Rate computation**: The average rate (`ObservedRateBytesPerSec`)
    is `sum(deltas) / observed_seconds`, identical in spirit to
    `findings/inputs.go::counterRatePerSec` but computed locally so
-   the panel does not depend on the findings package.
+   the panel does not depend on the findings package. Two
+   per-sample normalisations apply before the sum:
+   - **Cold-start tally skip (first block only)**: pt-mext records
+     the cold-start counter value at index 0 of the first snapshot;
+     this is not a per-interval delta and is excluded from the sum.
+     `model.MergeMysqladminData` strips the equivalent raw tally
+     from every snapshot AFTER the first by replacing it with a NaN
+     boundary slot and appending `src[1:]`, so the first finite
+     sample of every post-boundary block IS a real per-interval
+     delta and is included.
+   - **Negative-delta clamp**: a server restart mid-capture
+     re-zeroes `Innodb_os_log_written`, producing a negative delta
+     on the next sample. Negative deltas are clamped to 0 (a reset
+     is not a write of negative bytes); this also defends against
+     any other counter-reset scenario.
 5. **Rolling-window peak**: `PeakRateBytesPerSec` is the maximum, over
-   every contiguous block of samples covering at least one full
-   `PeakWindowSeconds`-second window, of `bytes_in_window /
-   actual_window_seconds`. NaN slots (snapshot boundaries) split
-   blocks; a window may not span a NaN slot.
+   every contiguous block of samples, of `bytes_in_window /
+   actual_window_seconds` for windows whose `actual_window_seconds`
+   is at least `PeakWindowSeconds`. The walk uses a sliding window
+   that retains the SMALLEST window of length >= target ending at
+   each sample (so any larger window cannot dilute the rate).
+   Sub-window prefix spans at the start of each block are NOT
+   candidates: the contract requires a full target-length window
+   before a rate qualifies as a peak. NaN slots (snapshot
+   boundaries) split blocks; a window may not span a NaN slot.
+   The cold-start tally skip and negative-delta clamp from item 4
+   apply here as well.
 6. **Window collapse**: If the longest contiguous block is shorter than
    900 seconds, `PeakWindowSeconds` is set to the longest block's
    duration in seconds and `PeakWindowLabel` reflects the actual
-   window length (e.g. `"available 28-second"`). The peak in that
-   case is the rate over the longest contiguous block.
+   window length, computed as `math.Floor(window)` so the label
+   never overstates the observed window length (e.g. a 28.6s
+   longest block renders as `"available 28-second"`, never
+   `"available 29-second"`). The peak in that case is the rate
+   over the longest contiguous block.
 7. **Coverage**: `CoverageMinutes == ConfiguredBytes / PeakRateBytesPerSec / 60`.
    Rendered as the integer floor (rounded down) so a 7.8-minute
-   coverage reports as "7 minutes" and the warning fires.
+   coverage reports as "7 minutes" and the warning fires. The
+   `computeRedoSizing` helper guards `PeakRateBytesPerSec > 0`
+   before this division: degenerate timestamp inputs that yield a
+   zero peak rate while `rateOK` would otherwise be true are
+   reclassified as `rate_unavailable` rather than dividing by zero.
 8. **Recommended sizes**: `PeakRateBytesPerSec * 900` for 15 minutes,
    `PeakRateBytesPerSec * 3600` for 1 hour. Both rendered with
    `reportutil.HumanBytes`.

--- a/specs/019-redo-log-sizing-panel/plan.md
+++ b/specs/019-redo-log-sizing-panel/plan.md
@@ -1,0 +1,143 @@
+# Implementation Plan: Redo log sizing panel
+
+**Branch**: `019-redo-log-sizing-panel` | **Date**: 2026-05-07 | **Spec**: [spec.md](./spec.md)
+**Input**: Feature specification from `specs/019-redo-log-sizing-panel/spec.md`
+
+## Summary
+
+Add a new "Redo log sizing" panel under the existing InnoDB Status section
+of the My-gather report. The panel reads MySQL's redo configuration from the
+captured `-variables` file (using `innodb_redo_log_capacity` on 8.0.30+ or
+`innodb_log_file_size * innodb_log_files_in_group` on 5.6/5.7), reads the
+observed redo write rate from the `Innodb_os_log_written` counter
+time-series in the captured `-mysqladmin` file, computes the busiest
+15-minute rolling window of writes (or the full available capture window
+when shorter), and renders a single panel that shows configured space,
+observed rate, coverage estimate in minutes, recommended target sizes for
+15 minutes and 1 hour of peak writes, an under-15-minutes warning, and a
+citation of Percona KB0010732 as the methodology source.
+
+## Technical Context
+
+**Language/Version**: Go 1.26.2 (matches the existing `go.mod` directive)
+**Primary Dependencies**: Standard library only. Reuses existing My-gather
+packages: `model`, `parse`, `findings`, `render`, `reportutil`.
+**Storage**: N/A
+**Testing**: `go test` with the existing `testdata/`-driven golden test
+infrastructure. The new panel adds focused Go unit tests at the package
+level only; no new golden fixture is required because the panel is part of
+the existing `db.html.tmpl` output and the existing report-level golden
+tests already exercise that template.
+**Target Platform**: Same release matrix as the rest of My-gather
+(`linux/amd64`, `linux/arm64`, `darwin/amd64`, `darwin/arm64`), built
+`CGO_ENABLED=0`.
+**Project Type**: Go CLI (single static binary) with HTML report output
+embedded via `//go:embed`.
+**Performance Goals**: No measurable regression on report generation time.
+The redo-sizing computation is one pass over the existing
+`Innodb_os_log_written` delta slice plus a constant-time variable lookup.
+**Constraints**: One canonical computation path branching on detected
+MySQL version internally rather than two parallel implementations. No
+hidden fallbacks. No new external dependencies. No source file over
+1000 lines (Principle XV).
+**Scale/Scope**: One panel, one new render-side computation file, one new
+view struct, one new template partial under the existing `db.html.tmpl`,
+and focused tests covering the 5.7 path, the 8.0.30+ path, the under-sized
+case, the well-sized case, and the missing-input degradation paths.
+
+## Constitution Check
+
+| Principle | Status | Notes |
+|-----------|--------|-------|
+| I. Single Static Binary | PASS | No CGO, no new dynamic dependency. |
+| II. Read-Only Inputs | PASS | The panel reads parsed model state only; no path writes inside the input tree. |
+| III. Graceful Degradation (NON-NEGOTIABLE) | PASS | Missing variables, missing counter, and zero observed rate render observable "unavailable" / "no observed redo writes" states (FR-008, FR-009, FR-010). |
+| IV. Deterministic Output | PASS | The computation is a pure function of the parsed report; no map iteration order, no goroutine, no time.Now. |
+| V. Self-Contained HTML | PASS | Panel renders inline in the existing embedded template; no external asset added. |
+| VI. Library-First Architecture | PASS | New computation lives in `render/` next to the existing InnoDB aggregation; new view type is `package render` private; godoc on every exported identifier. |
+| VII. Typed Errors | PASS | The panel surfaces missing-input states via the view struct, not as branchable errors; no new `fmt.Errorf` branches added for callers. |
+| VIII. Reference Fixtures & Golden Tests | PASS | No new collector parser is added (the panel reads existing parsed `-variables` and `-mysqladmin` data). The existing report-level golden test continues to cover `db.html.tmpl`. |
+| IX. Zero Network at Runtime | PASS | No network code introduced. |
+| X. Minimal Dependencies | PASS | Standard library only; no new direct dependency. |
+| XI. Reports Optimized for Humans Under Pressure | PASS | The panel directly answers a top-of-funnel sizing question that would otherwise require manual computation against the KB0010732 method; the warning line surfaces the verdict without scanning. |
+| XII. Pinned Go Version | PASS | No Go version change. |
+| XIII. Canonical Code Path (NON-NEGOTIABLE) | PASS | See Canonical Path Audit below. |
+| XIV. English-Only Durable Artifacts | PASS | All new files are in English. |
+| XV. Bounded Source File Size | PASS | New `render/redo_sizing.go` file estimated at well under 300 lines. `render/innodb.go` (currently 352 lines) is unchanged; the new code lives in its own file rather than growing the existing one. |
+
+**Canonical Path Audit (Principle XIII)**:
+
+- **Canonical owner/path for touched behavior**: The new panel's
+  computation lives in a single new file `render/redo_sizing.go` that
+  exposes one builder function consumed by `render/build_view.go`. The
+  configured-space reader inside that function is the canonical source
+  for "how big is this server's redo log"; it branches on
+  `innodb_redo_log_capacity` presence inside one function rather than
+  via two parallel implementations. The observed-rate reader uses the
+  existing `Innodb_os_log_written` delta slice on
+  `model.MysqladminData.Deltas` (the same slice consumed by the
+  existing redo Findings rules) and reuses
+  `reportutil.VariableFloat` for variable lookup, so there is no
+  duplicate variable-reading or counter-reading helper introduced.
+- **Replaced or retired paths**: None. This is an additive panel.
+  The existing `findings/rules_redo.go` rules (`redo.checkpoint_age`,
+  `redo.pending_writes`, `redo.pending_fsyncs`, `redo.log_waits`)
+  remain unchanged; they cover orthogonal signals (checkpoint age,
+  pending I/O backlog, log-buffer waits) that the new panel does not
+  duplicate. The new panel is the canonical owner of the
+  capacity-vs-write-rate sizing analysis, which no existing rule
+  performs.
+- **External degradation paths**: When the `-variables` file is absent
+  the panel renders "redo configuration unavailable" (FR-008); when
+  `Innodb_os_log_written` is absent or insufficient it renders "rate
+  unavailable" (FR-009); when the observed peak rate is zero it
+  renders "no observed redo writes during the capture" (FR-010). All
+  three are observable to the report reader and covered by tests.
+  No silent internal fallback path exists.
+- **Review check**: Reviewer verifies that
+  (a) `render/redo_sizing.go` is the only file in the repository that
+  computes configured redo space from the variables, that
+  (b) the rolling-window helper is defined once and not duplicated by
+  any other render or findings code, and that
+  (c) no new helper duplicates `reportutil.VariableFloat` or the
+  existing `findings/inputs.go` counter-reading helpers.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/019-redo-log-sizing-panel/
+├── spec.md
+├── plan.md
+├── research.md
+├── quickstart.md
+├── contracts/redo-sizing-panel.md
+├── checklists/requirements.md
+└── tasks.md
+```
+
+### Source Code (repository root)
+
+```text
+render/
+├── redo_sizing.go            # NEW - computeRedoSizing(report) -> redoSizingView
+├── redo_sizing_test.go       # NEW - 5.7 path, 8.0.30+ path, under-sized, well-sized, missing-input paths
+├── view.go                   # MODIFIED - adds RedoSizing *redoSizingView field on view + redoSizingView type
+├── build_view.go             # MODIFIED - calls computeRedoSizing in the existing DBSection block
+├── innodb.go                 # UNCHANGED
+└── templates/
+    └── db.html.tmpl          # MODIFIED - adds the new panel partial under the existing InnoDB Status <details>
+```
+
+**Structure Decision**: Reuses the existing My-gather Go layout (CLI in
+`cmd/`, parsers in `parse/`, model in `model/`, render in `render/`,
+findings in `findings/`, shared helpers in `reportutil/`). The new panel
+is fully scoped to the `render/` package because it consumes already
+parsed data and produces view fields consumed by the existing template
+infrastructure. No new package is introduced.
+
+## Complexity Tracking
+
+No constitution exceptions are required. All gates pass without a
+justification entry.

--- a/specs/019-redo-log-sizing-panel/quickstart.md
+++ b/specs/019-redo-log-sizing-panel/quickstart.md
@@ -1,0 +1,70 @@
+# Quickstart: Redo log sizing panel
+
+**Feature**: 019-redo-log-sizing-panel
+**Audience**: My-gather contributors verifying the new panel locally.
+
+## Build
+
+```sh
+go build ./...
+```
+
+## Test
+
+Run the new panel's focused tests:
+
+```sh
+go test ./render/ -run TestComputeRedoSizing -v
+```
+
+Run the full suite to confirm no regression in surrounding render
+or determinism tests:
+
+```sh
+go test ./...
+```
+
+Run `go vet`:
+
+```sh
+go vet ./...
+```
+
+## Manual verification
+
+Generate a report from a real pt-stalk capture and open the resulting
+HTML:
+
+```sh
+go run ./cmd/my-gather -in <pt-stalk-capture-dir> -out /tmp/report.html
+open /tmp/report.html
+```
+
+Open the **Database Usage** section, then the **InnoDB status** subsection.
+The new **Redo log sizing** panel renders immediately under the existing
+InnoDB callouts, with:
+
+- Configured redo space (e.g. `2.0 GiB`).
+- Source label (`innodb_redo_log_capacity` or
+  `innodb_log_file_size x innodb_log_files_in_group`).
+- Observed write rate as `bytes/sec` and `bytes/min`.
+- Peak window descriptor (e.g. `15-minute` or `available 28-second`).
+- Coverage estimate in minutes.
+- Recommended sizes for `15 minutes of peak` and `1 hour of peak`.
+- A warning line when coverage is below 15 minutes.
+- A citation of `Percona KB0010732` as the methodology source.
+
+## Pre-push gate
+
+The constitution pre-push hook runs from the repo root and is wired
+via `.claude/settings.json`:
+
+```sh
+.git/hooks/pre-push
+```
+
+Or invoke the hook script directly:
+
+```sh
+scripts/hooks/pre-push-constitution-guard.sh
+```

--- a/specs/019-redo-log-sizing-panel/research.md
+++ b/specs/019-redo-log-sizing-panel/research.md
@@ -1,0 +1,110 @@
+# Research: Redo log sizing panel
+
+**Feature**: 019-redo-log-sizing-panel
+**Date**: 2026-05-07
+
+## Methodology source
+
+Percona Knowledge Base article **KB0010732** is the methodology source
+for the panel. The user supplied the article reference and instructed
+the panel to cite it directly.
+
+The KB describes the canonical sizing recommendation as:
+"the redo log should hold at least 15 minutes of writes at the peak
+write rate, ideally 1 hour of writes". The panel computes both the
+15-minute and 1-hour target sizes and surfaces a warning when the
+configured redo space holds less than 15 minutes of peak writes.
+
+## MySQL configuration model
+
+Two models exist and the panel must support both:
+
+1. **MySQL 5.6 / 5.7 / early 8.0**: Total redo space is the product of
+   two static variables - `innodb_log_file_size` (per file) times
+   `innodb_log_files_in_group` (number of files). Both are static and
+   require a server restart to change.
+
+2. **MySQL 8.0.30 and later**: Total redo space is a single dynamic
+   variable - `innodb_redo_log_capacity` - in bytes. The legacy
+   variables still appear in `SHOW GLOBAL VARIABLES` for backward
+   compatibility, but MySQL ignores them and uses
+   `innodb_redo_log_capacity` exclusively.
+
+The detection rule, applied inside the single canonical computation
+function, is: if `innodb_redo_log_capacity` is present and parses to
+a positive number, use it. Otherwise fall back to
+`innodb_log_file_size * innodb_log_files_in_group`. This is one
+canonical branching path inside one function, not two parallel
+implementations (Principle XIII).
+
+## Observed write rate
+
+`Innodb_os_log_written` is the cumulative byte counter for redo log
+writes. pt-stalk's mysqladmin extended-status capture stores it in the
+counter time-series consumed by the existing My-gather Findings rules
+(see `findings/inputs.go::counterTotal` and `counterRatePerSec`). The
+existing helper convention is:
+
+- `model.MysqladminData.Deltas[name]` is a `[]float64` of length
+  `SampleCount`.
+- For counters (`IsCounter[name] == true`), index 0 is the bogus initial
+  raw tally and is excluded; later indices are per-sample deltas in the
+  variable's native units (bytes for `Innodb_os_log_written`).
+- `NaN` slots mark snapshot boundaries inserted by
+  `model.MergeMysqladminData`; the rolling-window code must skip them.
+- `model.MysqladminData.Timestamps[i]` is the wall-clock timestamp of
+  sample `i` (`time.Time`).
+
+The new computation walks the `Innodb_os_log_written` delta slice and
+the parallel `Timestamps` slice once, using a sliding-window pointer
+to compute the maximum bytes-per-second rate over any 15-minute window
+(or the full capture window when shorter). The window walk treats NaN
+slots as "drop the in-progress accumulator and restart from the next
+non-NaN sample" so cross-snapshot gaps do not get folded into the rate.
+
+## Capture-window-shorter-than-15-minutes case
+
+pt-stalk runs typically capture about 30 seconds per trigger. A literal
+"15-minute rolling window" is undefined when the entire capture is
+shorter than 15 minutes. The panel collapses the window size to
+`min(15 minutes, total observed seconds)` and labels the coverage value
+("over the available N seconds") so the reader is not misled into
+treating a short-burst peak as a sustained 15-minute peak.
+
+## Where the panel renders
+
+The InnoDB Status section is `<details id="sub-db-innodb">` inside
+`render/templates/db.html.tmpl`. It currently contains a `.callouts` div
+that ranges over `.InnoDBMetrics`. The new panel renders as an
+additional `<div class="callout">`-style block immediately after the
+existing callouts, gated on a new `.RedoSizing` view-struct pointer.
+This keeps the panel visually adjacent to the existing InnoDB scalars
+and preserves the current section structure.
+
+## Reuse of existing helpers
+
+- `reportutil.VariableFloat(r, name)` reads a single
+  SHOW GLOBAL VARIABLES value as a float. Used for
+  `innodb_redo_log_capacity`, `innodb_log_file_size`, and
+  `innodb_log_files_in_group`.
+- `reportutil.HumanBytes(v)` renders a byte count using binary units.
+  Used for the configured space, the recommended sizes, and the
+  observed bytes/sec and bytes/min rate displays.
+- `model.MysqladminData.Deltas` and `Timestamps` provide the
+  `Innodb_os_log_written` series directly. The rolling-window walk
+  is local to `render/redo_sizing.go`; it does not duplicate
+  `findings/inputs.go::counterTotal` because that helper sums the
+  whole window rather than computing a sliding-window peak.
+
+## Out of scope
+
+- The new panel does not modify, extend, or replace any existing
+  `findings/rules_redo.go` rule. Those rules cover orthogonal signals
+  (checkpoint age, pending I/O, log-buffer waits) and remain the
+  canonical owners of those signals.
+- The new panel does not introduce a new findings rule. Sizing
+  recommendations are presented inline in the panel itself, not as a
+  separate Advisor entry, because the answer is a quantitative
+  computation rather than a heuristic threshold and pairing the
+  recommendation with the configured-vs-observed numbers in one panel
+  matches Principle XI's "humans under pressure" priority.

--- a/specs/019-redo-log-sizing-panel/spec.md
+++ b/specs/019-redo-log-sizing-panel/spec.md
@@ -1,0 +1,270 @@
+# Feature Specification: Redo log sizing panel
+
+**Feature Branch**: `019-redo-log-sizing-panel`
+**Created**: 2026-05-07
+**Status**: Draft
+**Input**: User description: "Add a Redo log sizing panel to the InnoDB Status section, supporting both the legacy 5.6/5.7 redo configuration model and the 8.0.30+ dynamic capacity model, deriving observed redo write rate from the Innodb_os_log_written counter time-series, and warning when the configured redo space holds less than 15 minutes of peak writes. Methodology source: Percona KB0010732."
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Quantify whether the configured redo log holds the workload (Priority: P1)
+
+A support engineer reading a My-gather report for an incident wants a single
+panel that tells them, in plain numbers, whether the redo log on this server
+is sized for the actual write rate observed in the capture. They do not want
+to compute the rate by hand from raw counters or look up which configuration
+variable is current for the server's MySQL version.
+
+**Why this priority**: Redo log sizing is one of the most common InnoDB
+sizing questions on real cases and a frequent root cause of checkpoint
+stalls. Without this panel the user reads `Innodb_os_log_written` counters
+and `innodb_log_file_size`/`innodb_redo_log_capacity` variables manually,
+applies the KB0010732 method by hand, and reaches the same conclusion.
+Putting this in one panel eliminates that manual step.
+
+**Independent Test**: Open a generated report from a pt-stalk capture that
+contains both `-variables` and `-mysqladmin` files for a MySQL instance and
+verify the InnoDB Status section shows a Redo log sizing panel with the
+configured redo space, the observed write rate, and a coverage estimate
+in minutes.
+
+**Acceptance Scenarios**:
+
+1. **Given** a pt-stalk capture from a MySQL 5.7 server with
+   `innodb_log_file_size=1073741824` and `innodb_log_files_in_group=2`
+   and an `Innodb_os_log_written` counter time-series, **When** the report
+   is generated, **Then** the panel shows configured redo space `2.0 GiB`
+   (1 GiB x 2), an observed write rate in bytes/sec and bytes/min, and a
+   coverage estimate in minutes computed against the busiest 15-minute
+   rolling window of writes.
+2. **Given** a pt-stalk capture from a MySQL 8.0.30+ server with
+   `innodb_redo_log_capacity=4294967296` and an `Innodb_os_log_written`
+   counter time-series, **When** the report is generated, **Then** the
+   panel shows configured redo space `4.0 GiB` (taken from
+   `innodb_redo_log_capacity` directly, ignoring the legacy variables), an
+   observed write rate, and a coverage estimate.
+3. **Given** any supported capture, **When** the panel is rendered, **Then**
+   it shows a one-line citation of Percona KB0010732 as the methodology
+   source.
+
+---
+
+### User Story 2 - Surface under-sized redo as a callout (Priority: P1)
+
+A support engineer scanning the report wants the panel to flag, without
+hunting, when the configured redo space is small enough that the workload
+fills it in less than 15 minutes at peak. That threshold is the actionable
+boundary from KB0010732 — below it, checkpoint stalls become very likely
+under load; at or above it, the configuration is healthy.
+
+**Why this priority**: The panel is only useful at incident time if the
+"this is undersized" verdict is unambiguous and pre-computed. A user under
+pressure should not have to read the bytes/sec number and decide for
+themselves whether 12 minutes of coverage is acceptable.
+
+**Independent Test**: Generate a report from a synthetic capture where the
+configured redo space holds less than 15 minutes of peak writes and verify
+the panel renders the warning line "Current redo space holds only X
+minutes of peak writes - consider raising" with X computed from the data.
+
+**Acceptance Scenarios**:
+
+1. **Given** a capture where coverage at peak is 7 minutes, **When** the
+   panel renders, **Then** it shows the warning line "Current redo space
+   holds only 7 minutes of peak writes - consider raising".
+2. **Given** a capture where coverage at peak is 45 minutes, **When** the
+   panel renders, **Then** it does not show the warning line.
+3. **Given** a capture where coverage at peak is exactly 15 minutes, **When**
+   the panel renders, **Then** it does not show the warning line (the
+   threshold is "below 15 minutes", inclusive of 15 is acceptable).
+
+---
+
+### User Story 3 - Show recommended sizes for 15 minutes and 1 hour of peak (Priority: P2)
+
+A support engineer who confirms the redo log is undersized wants the panel
+to suggest concrete target sizes derived from the same observed peak rate,
+so the recommendation in the case response is grounded in this capture
+rather than a generic rule of thumb.
+
+**Why this priority**: This converts the diagnostic from "you have a
+problem" into "here is the size to set", which is the recommendation a
+support engineer would otherwise compute by hand from the same numbers.
+
+**Independent Test**: For any capture with a non-zero observed peak rate,
+verify the panel shows two recommended target sizes labelled "15 minutes
+of peak" and "1 hour of peak" in human-readable bytes.
+
+**Acceptance Scenarios**:
+
+1. **Given** an observed peak rate of `10 MiB/s`, **When** the panel
+   renders, **Then** the recommended sizes are computed from
+   `peak_rate * 15 * 60` and `peak_rate * 60 * 60` respectively, and
+   shown in human-readable bytes (for example `9.0 GiB` and `36.0 GiB`).
+2. **Given** the configured redo space already exceeds the 1-hour
+   recommendation, **When** the panel renders, **Then** the recommended
+   sizes are still shown alongside the configured value so the user can
+   see the headroom.
+
+---
+
+### Edge Cases
+
+- **Capture window shorter than 15 minutes** (the common pt-stalk case is
+  about 30 seconds per trigger): the panel falls back to the full
+  available capture window as the rolling-window size and labels the
+  coverage line so the reader knows the peak is "observed over the
+  available window" rather than a true 15-minute peak. The panel does
+  not silently treat a 30-second peak as a 15-minute peak.
+- **`Innodb_os_log_written` absent or only one sample**: the observed
+  write rate cannot be computed; the panel renders a "rate unavailable"
+  state for the rate, coverage, and recommendation rows, but still shows
+  the configured redo space if the variables are present.
+- **Server variables absent**: the panel renders a "redo configuration
+  unavailable" state and skips the coverage and recommendation rows
+  entirely. The KB reference is still shown.
+- **Mixed-model variables** (legacy `innodb_log_file_size` present
+  alongside `innodb_redo_log_capacity` on an 8.0.30+ server): the panel
+  uses `innodb_redo_log_capacity` as the source of truth and ignores the
+  legacy variables, matching MySQL 8.0.30+ behavior.
+- **Zero observed write rate**: coverage is undefined; the panel shows
+  the configured size and a "no observed redo writes during the capture"
+  state for coverage and recommendations.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: The InnoDB Status section MUST contain a panel titled
+  "Redo log sizing".
+- **FR-002**: The panel MUST display the configured redo log space in
+  human-readable bytes, computed as
+  `innodb_redo_log_capacity` when that variable is present (8.0.30+
+  model), otherwise as
+  `innodb_log_file_size * innodb_log_files_in_group` (legacy 5.6/5.7
+  model).
+- **FR-003**: The panel MUST display the observed redo write rate as
+  bytes per second and bytes per minute, derived from the
+  `Innodb_os_log_written` counter time-series in the captured pt-stalk
+  data using the existing canonical counter-rate computation (delta
+  divided by interval, excluding the bogus first sample).
+- **FR-004**: The panel MUST display a coverage estimate, expressed as
+  the number of minutes of peak observed write rate that the configured
+  redo space currently holds, where the peak is computed as the busiest
+  rolling 15-minute window of `Innodb_os_log_written` deltas in the
+  capture. If the capture is shorter than 15 minutes, the rolling
+  window collapses to the full available capture window and the panel
+  labels the coverage value so the reader knows the peak is observed
+  over the available window rather than a true 15-minute window.
+- **FR-005**: The panel MUST display two recommended redo log sizes,
+  computed as `peak_rate * 15 * 60` and `peak_rate * 60 * 60`, in
+  human-readable bytes.
+- **FR-006**: When the coverage estimate is below 15 minutes, the panel
+  MUST display the warning line "Current redo space holds only X minutes
+  of peak writes - consider raising" with X being the computed coverage
+  rounded to a whole number of minutes.
+- **FR-007**: The panel MUST display a citation of Percona KB0010732 as
+  the methodology source.
+- **FR-008**: When the configuration variables required to compute
+  configured redo space are missing, the panel MUST render a
+  "redo configuration unavailable" state for the configured space,
+  coverage, and recommendation rows, but MUST still render the panel
+  shell and the KB citation.
+- **FR-009**: When the `Innodb_os_log_written` counter is absent or
+  cannot produce a rate (insufficient samples), the panel MUST render
+  a "rate unavailable" state for the rate, coverage, and recommendation
+  rows, but MUST still render the configured space when available.
+- **FR-010**: When the observed peak rate is zero, the panel MUST render
+  a "no observed redo writes during the capture" state for the coverage
+  and recommendation rows.
+
+### Canonical Path Expectations
+
+- **Canonical owner/path**: A new panel under the existing InnoDB Status
+  section in `render/`, backed by a single redo-sizing computation
+  function. The configured-space computation is the canonical source for
+  reading the redo configuration, regardless of MySQL version - branching
+  on the `innodb_redo_log_capacity` variable presence happens inside that
+  one function rather than via two parallel implementations. The
+  observed-rate computation reuses the existing canonical counter-rate
+  helper (the same path used by the existing Redo Log advisor rules) so
+  there is no second `Innodb_os_log_written` rate computation in the
+  codebase.
+- **Old path treatment**: N/A - this is an additive panel. Existing
+  `findings/rules_redo.go` rules (`redo.checkpoint_age`,
+  `redo.pending_writes`, `redo.pending_fsyncs`, `redo.log_waits`) are
+  unchanged and remain the canonical owners of their respective signals.
+  The new panel is the canonical owner of redo-log capacity sizing
+  against the observed write rate, which no existing rule covers.
+- **External degradation**: When configuration variables or the
+  `Innodb_os_log_written` counter are missing or yield insufficient
+  data, the panel renders observable "unavailable" states (FR-008,
+  FR-009, FR-010) rather than silently substituting placeholder values.
+  These states are covered by tests.
+- **Review check**: Reviewer verifies that the redo configured-space
+  reader is the only path computing configured redo size, that the
+  observed-rate computation routes through the existing canonical
+  counter helper, and that there is no duplicated rolling-window helper
+  if a future feature needs the same primitive.
+
+### Key Entities *(include if feature involves data)*
+
+- **Configured redo space**: A single byte-valued quantity describing
+  the total redo log space MySQL is configured to use. Sourced from
+  `innodb_redo_log_capacity` on 8.0.30+, or
+  `innodb_log_file_size * innodb_log_files_in_group` on 5.6/5.7.
+- **Observed redo write rate**: A time-series of per-sample bytes
+  written to the redo log, derived from the `Innodb_os_log_written`
+  counter deltas in the mysqladmin capture. The panel uses the rolling
+  15-minute window peak (or the full capture window if shorter) for its
+  coverage and recommendation calculations, and the overall average
+  rate for its informational bytes/sec and bytes/min display.
+- **Coverage estimate**: A minute-valued quantity equal to
+  `configured_redo_space / peak_rate`, expressed in minutes.
+- **Recommended sizes**: Two byte-valued quantities equal to
+  `peak_rate * 15 * 60` and `peak_rate * 60 * 60`.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: A support engineer reading a generated report can
+  determine in under 30 seconds whether the redo log is sized
+  appropriately for the captured workload, without consulting any
+  external KB or running side calculations.
+- **SC-002**: For an undersized redo log, the report displays both the
+  problem statement and the recommended target sizes for 15 minutes
+  and 1 hour of peak writes within the same panel.
+- **SC-003**: The panel renders correctly for both the legacy 5.6/5.7
+  redo configuration model and the 8.0.30+ dynamic capacity model,
+  verified by tests against synthetic captures using each model.
+- **SC-004**: The panel renders gracefully when configuration variables
+  or the `Innodb_os_log_written` counter are missing, by showing the
+  applicable "unavailable" state rather than failing the report
+  generation, verified by tests.
+- **SC-005**: The "warning when coverage is below 15 minutes" behavior
+  is unambiguous: the warning line either renders or does not, with no
+  intermediate "maybe" state, verified by tests covering the
+  under-sized case and the well-sized case for both configuration
+  models.
+
+## Assumptions
+
+- The pt-stalk captures pointed at My-gather typically contain both
+  `-variables` (single-shot SHOW GLOBAL VARIABLES output) and
+  `-mysqladmin` (extended-status time-series including
+  `Innodb_os_log_written`). The panel relies on both being present;
+  graceful-degradation states cover the case where either is missing.
+- The observed pt-stalk capture window per trigger is typically much
+  shorter than 15 minutes (about 30 seconds is common). The panel
+  collapses the rolling window to the full available capture window
+  in that case and labels the coverage value so the reader knows the
+  peak is observed over the available window rather than a true
+  15-minute window.
+- The KB0010732 methodology source is referenced by article number
+  only, with no need to embed the article body in the report.
+- The new panel is additive and does not change the behavior of the
+  existing Redo Log advisor rules in `findings/rules_redo.go`. Those
+  rules continue to flag checkpoint-age utilization and pending I/O
+  saturation; this panel covers the orthogonal capacity-vs-write-rate
+  sizing question that no existing rule addresses.

--- a/specs/019-redo-log-sizing-panel/tasks.md
+++ b/specs/019-redo-log-sizing-panel/tasks.md
@@ -1,0 +1,217 @@
+---
+description: "Task list for feature 019-redo-log-sizing-panel"
+---
+
+# Tasks: Redo log sizing panel
+
+**Input**: Design documents from `specs/019-redo-log-sizing-panel/`
+**Prerequisites**: plan.md, spec.md, research.md, contracts/redo-sizing-panel.md, quickstart.md
+
+**Tests**: Included; the spec explicitly requires unit tests for both
+the 5.7 path and the 8.0.30+ path (well-sized and under-sized cases).
+
+## Canonical Path Metadata (Principle XIII)
+
+- **Canonical owner/path**: `render/redo_sizing.go` is the single
+  source of redo-log sizing analysis (configured space + observed
+  rate + coverage + recommendations). The InnoDB section template
+  partial in `render/templates/db.html.tmpl` is the single rendering
+  path. The view field `RedoSizing *redoSizingView` on the existing
+  view struct in `render/view.go` is the single carrier between
+  computation and template.
+- **Old path treatment**: N/A. Additive panel; no existing path is
+  replaced. Existing `findings/rules_redo.go` rules remain unchanged.
+- **External degradation evidence**: T016 (variables-missing test),
+  T017 (counter-missing test), T018 (short-capture-window test),
+  T019 (no-writes test), T020 (warning-boundary test).
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]** marks tasks that touch different files and can run in parallel.
+- **[Story]** ties the task to a user story from spec.md.
+
+## Phase 1: Scaffolding
+
+- [ ] T001 [P] Add the `redoSizingView` struct to `render/view.go`
+      next to the existing `innoDBMetricView` definition. Include
+      every field and godoc comment described in
+      `specs/019-redo-log-sizing-panel/contracts/redo-sizing-panel.md`.
+- [ ] T002 [P] Add a `RedoSizing *redoSizingView` field on the main
+      view struct in `render/view.go` in the DB section payload block
+      (immediately after `InnoDBMetrics`). Document the contract that
+      a nil value means "panel not rendered" and a non-nil value with
+      `State == "config_missing"` means "panel rendered with placeholder
+      content".
+
+## Phase 2: Computation (canonical owner)
+
+- [ ] T003 [US1] Create `render/redo_sizing.go` with the
+      `computeRedoSizing(r *model.Report) *redoSizingView` function.
+      Implement the canonical configured-space reader: try
+      `innodb_redo_log_capacity` via `reportutil.VariableFloat`, then
+      fall back to `innodb_log_file_size * innodb_log_files_in_group`.
+      Populate `ConfiguredBytes`, `ConfiguredText` (via
+      `reportutil.HumanBytes`), and `ConfigSource`. Set
+      `KBReference = "Percona KB0010732"` in every state. (Implements
+      FR-001, FR-002, FR-007, FR-008.)
+- [ ] T004 [US1] In the same file, implement the average-rate
+      computation: walk `r.DBSection.Mysqladmin.Deltas["Innodb_os_log_written"]`
+      and sum non-NaN entries past index 0; divide by the sum of
+      per-snapshot wall-clock spans (mirroring
+      `findings/inputs.go::captureSeconds` semantics, computed locally).
+      Populate `ObservedRateBytesPerSec`, `ObservedRateText`, and
+      `ObservedRatePerMinText`. Render as
+      `reportutil.HumanBytes(rate) + "/s"` and
+      `reportutil.HumanBytes(rate*60) + "/min"`. (Implements FR-003.)
+- [ ] T005 [US1] In the same file, implement the rolling-window peak
+      computation: scan the deltas + timestamps slice with a two-pointer
+      sliding window of length 900 seconds. Track the maximum
+      `bytes_in_window / actual_window_seconds`. NaN slots split the
+      walk: when one is encountered, drop the in-progress accumulator
+      and restart from the next non-NaN sample. If no contiguous block
+      of length 900s exists, set `PeakWindowSeconds` to the longest
+      contiguous block's wall-clock span and `PeakWindowLabel` to the
+      `"available N-second"` form; otherwise set them to 900 and
+      `"15-minute"`. Populate `PeakRateBytesPerSec` and `PeakRateText`.
+      (Implements FR-004 plus the short-window edge case.)
+- [ ] T006 [US1] Compute coverage: `CoverageMinutes = ConfiguredBytes /
+      PeakRateBytesPerSec / 60`; render `CoverageText` as
+      `fmt.Sprintf("%d minutes", int(math.Floor(CoverageMinutes)))`.
+      Set `CoverageText = "n/a"` whenever any input is missing.
+      (Implements FR-004.)
+- [ ] T007 [US3] Compute recommended sizes:
+      `Recommended15MinBytes = PeakRateBytesPerSec * 900` and
+      `Recommended1HourBytes = PeakRateBytesPerSec * 3600`. Render via
+      `reportutil.HumanBytes`. Set `*Text` fields to `"n/a"` when no
+      observed peak rate is available. (Implements FR-005.)
+- [ ] T008 [US2] Set `UnderSized = (State == "ok" && CoverageMinutes <
+      15)` and populate `WarningLine` with the exact phrase from FR-006:
+      `"Current redo space holds only X minutes of peak writes - consider
+      raising"` where X is the floored minute count. Leave both empty
+      otherwise. (Implements FR-006.)
+
+## Phase 3: View wiring
+
+- [ ] T009 In `render/build_view.go`, inside the existing
+      `if r.DBSection != nil` block, after the `InnoDBMetrics` lines,
+      call `v.RedoSizing = computeRedoSizing(r)`. No other call site
+      may compute this view; this is the single canonical wiring point.
+
+## Phase 4: Template
+
+- [ ] T010 In `render/templates/db.html.tmpl`, inside the existing
+      `<details id="sub-db-innodb">` body, after the `.callouts` div
+      and before its closing `</div>` of class `body`, add a new
+      `<div class="redo-sizing">` block guarded by `{{- if .RedoSizing }}`.
+      Render the panel rows with explicit unambiguous labels so
+      reader does not conflate the average rate with the peak rate:
+      title `"Redo log sizing"`, configured space with its source
+      label, the average rate row labelled
+      `"Observed average write rate"` showing both per-sec and
+      per-min, the peak rate row labelled
+      `"Peak write rate (<window-label> rolling)"` using
+      `RedoSizing.PeakWindowLabel`, coverage in minutes labelled
+      `"Coverage at peak"`, recommended sizes labelled
+      `"Recommended for 15 minutes of peak"` and
+      `"Recommended for 1 hour of peak"`, the warning line guarded
+      by `{{- if .RedoSizing.UnderSized }}`, and the KB citation
+      labelled `"Methodology: Percona KB0010732"`. Branch on
+      `.State` for the `"config_missing"`, `"rate_unavailable"`, and
+      `"no_writes"` states. Use the existing `sev-warn` callout
+      class for the warning state.
+
+## Phase 5: Tests
+
+- [ ] T011 [US1] Create `render/redo_sizing_test.go`. Add helpers
+      `makeReportWithVarsAndCounter` (synthetic *model.Report builder
+      taking variable map, deltas, and timestamps; produces a
+      report.DBSection with mysqladmin populated) and
+      `assertField(t, got, want)`.
+- [ ] T012 [US1] Add test `TestComputeRedoSizing_57_WellSized`: 5.7
+      vars (`innodb_log_file_size=1073741824`,
+      `innodb_log_files_in_group=2`), low-write-rate counter series.
+      Asserts `State == "ok"`, `ConfigSource ==
+      "innodb_log_file_size x innodb_log_files_in_group"`,
+      `ConfiguredText == "2.0 GiB"`, `UnderSized == false`,
+      `WarningLine == ""`, `KBReference == "Percona KB0010732"`.
+- [ ] T013 [US1, US2] Add test `TestComputeRedoSizing_57_UnderSized`:
+      same 5.7 vars but with `innodb_log_file_size=134217728` (256 MiB
+      total) and a high-write-rate counter series. Asserts `State ==
+      "ok"`, `UnderSized == true`, `WarningLine` matches the FR-006
+      phrasing, `Recommended15MinText` and `Recommended1HourText`
+      populated.
+- [ ] T014 [US1] Add test `TestComputeRedoSizing_80Plus_WellSized`:
+      vars include `innodb_redo_log_capacity=17179869184` (16 GiB) AND
+      `innodb_log_file_size=1073741824` + `innodb_log_files_in_group=2`
+      (the legacy values that 8.0.30+ ignores). Counter series chosen
+      so coverage at peak >= 60 minutes. Asserts `State == "ok"`,
+      `ConfigSource == "innodb_redo_log_capacity"`, `ConfiguredText
+      == "16.0 GiB"`, `UnderSized == false`. Confirms the legacy
+      variables are ignored when `innodb_redo_log_capacity` is set.
+- [ ] T015 [US1, US2] Add test `TestComputeRedoSizing_80Plus_UnderSized`:
+      vars include `innodb_redo_log_capacity=536870912` (512 MiB)
+      against a high-write-rate counter series. Asserts `State == "ok"`,
+      `ConfigSource == "innodb_redo_log_capacity"`, `UnderSized ==
+      true`, `WarningLine` populated.
+- [ ] T016 Add test `TestComputeRedoSizing_ConfigMissing`: variables
+      section absent; counter series present. Asserts `State ==
+      "config_missing"`, `ConfiguredText == "unavailable"`,
+      `CoverageText == "n/a"`, `KBReference == "Percona KB0010732"`.
+- [ ] T017 Add test `TestComputeRedoSizing_RateUnavailable`: variables
+      present; `Innodb_os_log_written` absent from
+      `Mysqladmin.Deltas`. Asserts `State == "rate_unavailable"`,
+      `ConfiguredText` populated, `ObservedRateText == "unavailable"`,
+      `CoverageText == "n/a"`, `Recommended15MinText == "n/a"`.
+- [ ] T018 Add test `TestComputeRedoSizing_ShortCaptureWindow`:
+      variables present; counter series spans 30 seconds total.
+      Asserts `PeakWindowSeconds < 900`, `PeakWindowLabel` matches
+      `"available N-second"` (where N is the actual span), and
+      `CoverageText` is populated using the shorter window's peak.
+- [ ] T019 Add test `TestComputeRedoSizing_NoWrites`: variables and
+      `Innodb_os_log_written` counter both present, but every counter
+      delta is zero (idle workload). Asserts `State == "no_writes"`,
+      `ConfiguredText` populated, `ObservedRateText == "0 B/s"` (or
+      the equivalent rendering of zero), `CoverageText == "n/a"`,
+      `Recommended15MinText == "n/a"`, `Recommended1HourText == "n/a"`,
+      `UnderSized == false`, `WarningLine == ""`, `KBReference ==
+      "Percona KB0010732"`. (Implements FR-010.)
+- [ ] T020 Add test `TestComputeRedoSizing_WarningBoundary`: choose
+      configured space and a constant peak write rate so coverage is
+      exactly 15.0 minutes (e.g. configured = 900 MiB, peak rate =
+      1 MiB/s). Asserts `CoverageMinutes == 15`, `UnderSized ==
+      false`, `WarningLine == ""`. Then re-run with configured =
+      899 MiB and assert `UnderSized == true`. (Implements US2 AC3
+      explicitly.)
+
+## Phase 6: Validation
+
+- [ ] T021 Run `go vet ./...` and `go test ./...` from repo root.
+      Fix any failure.
+- [ ] T022 Run the constitution pre-push guard locally
+      (`scripts/hooks/pre-push-constitution-guard.sh` or via
+      `git push` after staging) and address any guard finding before
+      pushing.
+
+## Phase 7: Cross-agent sync
+
+- [ ] T023 Update `CLAUDE.md`, `AGENTS.md`, and `.specify/feature.json`
+      so all three signals point at `019-redo-log-sizing-panel` (per
+      the side-by-side agent contract in CLAUDE.md). The
+      `.specify/feature.json` change is already applied during
+      `/speckit-specify`; this task confirms it and updates the
+      Markdown context files.
+
+## Dependency graph
+
+```
+T001 ─┐
+T002 ─┴─> T003 ─> T004 ─> T005 ─> T006 ─> T007 ─> T008 ─> T009 ─> T010
+                                                                    │
+                                  T011 ──────────┬─> T012, T013, T014, T015, T016, T017, T018, T019, T020
+                                                  │
+                                                  └─> T021 ─> T022 ─> T023
+```
+
+T012-T020 may run in parallel once T011 lands. T001 and T002 may run
+in parallel because they touch the same file (`view.go`) at separate
+locations and can be staged together.

--- a/testdata/golden/db.example2.html
+++ b/testdata/golden/db.example2.html
@@ -163,7 +163,7 @@
       <p class="k">Redo log sizing</p>
       <p class="v">unavailable</p>
       <p class="sub">Redo configuration variables not present in this capture.</p>
-      <p class="stats">Observed average write rate: <span>3 MiB/s</span> · <span>153 MiB/min</span></p>
+      <p class="stats">Observed average write rate: <span>3 MiB/s</span> · <span>156 MiB/min</span></p>
       <p class="stats">Peak write rate (available 29-second rolling): <span>3 MiB/s</span></p>
       <p class="sub">Methodology: Percona KB0010732</p>
     </div>

--- a/testdata/golden/db.example2.html
+++ b/testdata/golden/db.example2.html
@@ -163,7 +163,7 @@
       <p class="k">Redo log sizing</p>
       <p class="v">unavailable</p>
       <p class="sub">Redo configuration variables not present in this capture.</p>
-      <p class="stats">Observed average write rate: <span>3 MiB/s</span> · <span>156 MiB/min</span></p>
+      <p class="stats">Observed average write rate: <span>3 MiB/s</span> · <span>153 MiB/min</span></p>
       <p class="stats">Peak write rate (available 29-second rolling): <span>3 MiB/s</span></p>
       <p class="sub">Methodology: Percona KB0010732</p>
     </div>

--- a/testdata/golden/db.example2.html
+++ b/testdata/golden/db.example2.html
@@ -159,6 +159,14 @@
         <div class="hll-sparkline" data-chart="innodb-hll" aria-label="History list length trend across snapshots"></div>
       </div>
     </div>
+    <div class="redo-sizing callout">
+      <p class="k">Redo log sizing</p>
+      <p class="v">unavailable</p>
+      <p class="sub">Redo configuration variables not present in this capture.</p>
+      <p class="stats">Observed average write rate: <span>3 MiB/s</span> · <span>153 MiB/min</span></p>
+      <p class="stats">Peak write rate (available 29-second rolling): <span>3 MiB/s</span></p>
+      <p class="sub">Methodology: Percona KB0010732</p>
+    </div>
   </div>
 </details>
 


### PR DESCRIPTION
## Summary

Closes #55. Adds a new "Redo log sizing" panel under the InnoDB Status section of the report that quantifies whether the configured redo log space is sized for the captured workload, using the [Percona KB0010732](https://percona.service-now.com/kb_view.do?sysparm_article=KB0010732) methodology.

The panel:

- Shows the configured redo log space, sourcing it from `innodb_redo_log_capacity` on MySQL 8.0.30+ and from `innodb_log_file_size x innodb_log_files_in_group` on 5.6/5.7. Detection happens inside one canonical computation function rather than via two parallel implementations, per Principle XIII.
- Shows the observed average redo write rate as bytes/sec and bytes/min, derived from the `Innodb_os_log_written` counter time-series in the captured pt-stalk `-mysqladmin` data.
- Shows the peak write rate over the busiest 15-minute rolling window of writes (or the longest available contiguous window when the capture is shorter than 15 minutes; the panel labels which window length it used).
- Shows the coverage estimate in minutes and recommended target sizes for 15 minutes and 1 hour of peak writes.
- Renders a one-line warning ("Current redo space holds only X minutes of peak writes - consider raising") when coverage is below 15 minutes; the warning is suppressed at exactly 15 minutes and above.
- Cites Percona KB0010732 inline as the methodology source.

Existing `findings/rules_redo.go` rules (`redo.checkpoint_age`, `redo.pending_writes`, `redo.pending_fsyncs`, `redo.log_waits`) are unchanged; this panel covers the orthogonal capacity-vs-write-rate sizing question that no existing rule addresses.

## Test plan

- [x] `go vet ./...` passes
- [x] `go test ./...` passes (including the regenerated `testdata/golden/db.example2.html`)
- [x] `scripts/hooks/pre-push-constitution-guard.sh` passes
- [x] New tests in `render/redo_sizing_test.go` cover both the 5.7 path (`innodb_log_file_size + innodb_log_files_in_group`) and the 8.0.30+ path (`innodb_redo_log_capacity`), each in well-sized and under-sized variants, plus the 15-minute warning boundary, the short-capture-window fallback, the missing-variables degradation state, the missing-counter degradation state, and the no-writes idle-workload state.
- [ ] Manual verification: generate a report from a real pt-stalk capture and confirm the panel renders under InnoDB Status.

## Constitution

- Principle III: missing variables, missing counter, and zero observed rate render observable "unavailable" / "no observed redo writes" states (FR-008, FR-009, FR-010).
- Principle XIII: single canonical `computeRedoSizing` function in `render/redo_sizing.go` is the only computation path; the version detection branches inside it rather than producing two parallel implementations. The observed-rate computation uses the existing `model.MysqladminData.Deltas` slice the same way `findings/inputs.go::counterTotal` does, without duplicating the helper.
- Principle XV: new file is under 400 lines; no existing source file grew past 1000 lines.