### PR TITLE
Synchronized chart zoom + per-window legend stats (#52, #51)

### DIFF
--- a/.specify/feature.json
+++ b/.specify/feature.json
@@ -1,3 +1,3 @@
 {
-  "feature_directory": "specs/015-compliance-closure"
+  "feature_directory": "specs/017-chart-zoom-sync-stats"
 }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,18 +1,19 @@
 <!-- SPECKIT START -->
-Active feature: **015-compliance-closure**
+Active feature: **017-chart-zoom-sync-stats**
 
 For technologies, project structure, constitution gates, data model,
 contracts, and shell commands, read the current plan:
 
-- Plan: `specs/015-compliance-closure/plan.md`
-- Spec: `specs/015-compliance-closure/spec.md`
-- Research: `specs/015-compliance-closure/research.md`
-- Contracts: `specs/015-compliance-closure/contracts/audit.md`
-- Quickstart: `specs/015-compliance-closure/quickstart.md`
-- Tasks: `specs/015-compliance-closure/tasks.md`
+- Plan: `specs/017-chart-zoom-sync-stats/plan.md`
+- Spec: `specs/017-chart-zoom-sync-stats/spec.md`
+- Research: `specs/017-chart-zoom-sync-stats/research.md`
+- Contracts: `specs/017-chart-zoom-sync-stats/contracts/chart-sync.md`
+- Quickstart: `specs/017-chart-zoom-sync-stats/quickstart.md`
+- Tasks: `specs/017-chart-zoom-sync-stats/tasks.md`
 - Constitution: `.specify/memory/constitution.md`
 
 Prior features:
+- **015-compliance-closure** - `specs/015-compliance-closure/plan.md`
 - **014-reconciliation-cleanup** - `specs/014-reconciliation-cleanup/plan.md`
 - **013-full-compliance-fixes** - `specs/013-full-compliance-fixes/plan.md`
 - **012-repo-alignment-audit** - `specs/012-repo-alignment-audit/plan.md`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,18 +1,19 @@
 <!-- SPECKIT START -->
-Active feature: **015-compliance-closure**
+Active feature: **017-chart-zoom-sync-stats**
 
 For technologies, project structure, constitution gates, data model,
 contracts, and shell commands, read the current plan:
 
-- Plan: `specs/015-compliance-closure/plan.md`
-- Spec: `specs/015-compliance-closure/spec.md`
-- Research: `specs/015-compliance-closure/research.md`
-- Contracts: `specs/015-compliance-closure/contracts/audit.md`
-- Quickstart: `specs/015-compliance-closure/quickstart.md`
-- Tasks: `specs/015-compliance-closure/tasks.md`
+- Plan: `specs/017-chart-zoom-sync-stats/plan.md`
+- Spec: `specs/017-chart-zoom-sync-stats/spec.md`
+- Research: `specs/017-chart-zoom-sync-stats/research.md`
+- Contracts: `specs/017-chart-zoom-sync-stats/contracts/chart-sync.md`
+- Quickstart: `specs/017-chart-zoom-sync-stats/quickstart.md`
+- Tasks: `specs/017-chart-zoom-sync-stats/tasks.md`
 - Constitution: `.specify/memory/constitution.md`
 
 Prior features:
+- **015-compliance-closure** - `specs/015-compliance-closure/plan.md`
 - **014-reconciliation-cleanup** - `specs/014-reconciliation-cleanup/plan.md`
 - **013-full-compliance-fixes** - `specs/013-full-compliance-fixes/plan.md`
 - **012-repo-alignment-audit** - `specs/012-repo-alignment-audit/plan.md`

--- a/render/assets/app-css/03.css
+++ b/render/assets/app-css/03.css
@@ -699,3 +699,40 @@ dd.env-meter:has(.sev-crit) .env-meter-pct { color: var(--err); }
   min-width: 132px;
 }
 .feedback-success-close:hover { filter: brightness(1.1); }
+
+/* Per-series stats inside each legend pill — Min · Avg · Max for the
+   currently visible window (chart-sync store driven). The dot
+   separators are inserted via CSS pseudo-content so the JS just sets
+   the three numeric spans and stays out of presentation. */
+.series-legend .series-pill .series-pill-stats {
+  display: inline-flex;
+  align-items: baseline;
+  gap: 4px;
+  margin-left: 4px;
+  padding-left: 6px;
+  border-left: 1px solid var(--border);
+  font-family: var(--mono);
+  font-size: 10.5px;
+  color: var(--fg-muted);
+  white-space: nowrap;
+}
+.series-legend .series-pill .series-pill-stat-min,
+.series-legend .series-pill .series-pill-stat-avg,
+.series-legend .series-pill .series-pill-stat-max {
+  display: inline-block;
+  min-width: 1.5ch;
+  text-align: right;
+}
+.series-legend .series-pill .series-pill-stat-avg::before {
+  content: "·";
+  margin-right: 4px;
+  color: var(--fg-dim);
+}
+.series-legend .series-pill .series-pill-stat-max::before {
+  content: "·";
+  margin-right: 4px;
+  color: var(--fg-dim);
+}
+.series-legend .series-pill:not(.active) .series-pill-stats {
+  opacity: 0.45;
+}

--- a/render/assets/app-js/00.js
+++ b/render/assets/app-js/00.js
@@ -219,14 +219,37 @@
   // (nav collapse/expand, window resize) can recompute width and call
   // chart.setSize.
   var CHARTS = [];
-  function registerChart(plot, containerEl, options) {
-    CHARTS.push({ plot: plot, el: containerEl, opts: options });
+  // registerChart adds a uPlot instance to the page-wide chart
+  // registry. The optional `data` argument is consumed by the
+  // chart-sync store (app-js/05.js) so newly-registered charts can
+  // adopt the current shared zoom window and so the windowed-stats
+  // subscriber can recompute legend Min/Max/Avg without re-reading
+  // uPlot's internal data arrays. data.timestamps + data.series are
+  // the un-bucketed source samples; data.rawSeries is supplied by
+  // stacked charts whose drawn values are cumulative — windowed
+  // stats compute against rawSeries when present.
+  function registerChart(plot, containerEl, options, data) {
+    var entry = { plot: plot, el: containerEl, opts: options, data: data || null };
+    CHARTS.push(entry);
+    // If a shared zoom window is already active when a chart mounts
+    // (e.g. a chart inside a section the user expanded after zooming
+    // a sibling), apply that window so the new chart matches without
+    // an extra interaction. The chart-sync store guards against
+    // re-broadcast by setting isBroadcasting around the call.
+    if (window.__chartSyncStore && typeof window.__chartSyncStore.applyToChart === "function") {
+      window.__chartSyncStore.applyToChart(entry);
+    }
   }
   function unregisterChart(plot) {
     for (var i = CHARTS.length - 1; i >= 0; i--) {
       if (CHARTS[i].plot === plot) CHARTS.splice(i, 1);
     }
   }
+  // chartRegistry exposes the in-place CHARTS array to the chart-sync
+  // store (defined in app-js/05.js, in the same IIFE). Returning the
+  // live array — not a copy — keeps the broadcaster O(charts) per
+  // update without re-allocating each tick.
+  function chartRegistry() { return CHARTS; }
   function resizeAllCharts() {
     for (var i = 0; i < CHARTS.length; i++) {
       var entry = CHARTS[i];
@@ -426,8 +449,24 @@
         setCursor: [updateTooltipOnCursor],
         drawAxes: [makeBoundaryDrawHook(boundaries, timestamps)],
         ready: [makeUnitBadgeHook(unit)],
+        // Broadcast x-scale changes (drag-zoom, drag-pan, programmatic
+        // setScale by other code) into the chart-sync store so every
+        // other registered chart on the page snaps to the same
+        // window. The store sets isBroadcasting around its own
+        // setScale calls so this hook short-circuits and the cycle
+        // can't recurse. See app-js/05.js for the store definition.
+        setScale: [broadcastXScaleChange],
       },
     };
+  }
+
+  function broadcastXScaleChange(u, scaleKey) {
+    if (scaleKey !== "x") return;
+    var store = window.__chartSyncStore;
+    if (!store || store.isBroadcasting) return;
+    var sx = u.scales && u.scales.x;
+    if (!sx) return;
+    store.setWindow({ min: sx.min, max: sx.max }, u);
   }
 
   // makeUnitBadgeHook returns a uPlot ready-hook that appends a small
@@ -671,18 +710,11 @@
     btn.addEventListener("click", function (ev) {
       ev.preventDefault();
       ev.stopPropagation();
-      var p = getPlot();
-      if (!p) return;
-      try {
-        // setScale to auto; pass the explicit data bounds so uPlot
-        // doesn't leave the axis in a "null" state on older builds.
-        var xs = p.data && p.data[0];
-        if (xs && xs.length) {
-          p.setScale("x", { min: xs[0], max: xs[xs.length - 1] });
-        } else {
-          p.setScale("x", { min: null, max: null });
-        }
-      } catch (_) {}
+      // Reset every registered chart, not just this one. Routing
+      // through the chart-sync store keeps the canonical zoom path
+      // single-sourced; the store walks the registry, restores each
+      // chart to its own data extent, and clears the synced window.
+      if (window.__chartSyncStore) window.__chartSyncStore.reset();
     });
     containerEl.appendChild(btn);
   }
@@ -718,11 +750,25 @@
   //     buckets are visible (e.g. stacked bars, where hiding one
   //     bucket must recompute cumulative stacks). When omitted the
   //     legend drives the existing plot via uPlot's setSeries().
+  //   - opts.statsSource: { timestamps, series } — the data each pill's
+  //     Min · Avg · Max stat is computed against. Stacked charts pass
+  //     the un-stacked raw values here; line charts pass the same data
+  //     they plotted. When omitted no stats render (kept omitted only
+  //     by callers that have no per-series numeric data, e.g. would-be
+  //     decorative-only legends).
+  //
+  // Returns { setStats(win), destroy() } so the chart-sync subscriber
+  // can recompute on every shared-store window change and the vmstat
+  // tab rebuild path can drop the legend cleanly before re-mounting.
   function mountLegend(containerEl, series, plot, opts) {
     opts = opts || {};
     var legend = document.createElement("div");
     legend.className = "series-legend";
     var pills = [];
+    // Per-pill stats element references, keyed by pill data-idx so
+    // setStats can update them in place without a full legend rebuild.
+    var statsByIdx = {};
+    var statsSource = opts.statsSource || null;
 
     function pillVisible(btn) { return btn.classList.contains("active"); }
     function visibleIdxs() {
@@ -755,7 +801,17 @@
       btn.title = "Click to show only this series (solo) · Shift/Cmd-click to toggle just this series · Click a soloed pill again to restore all";
       btn.innerHTML =
         '<span class="swatch" style="background:' + s.stroke + '"></span>' +
-        '<span class="lbl">' + escapeHTML(s.label) + '</span>';
+        '<span class="lbl">' + escapeHTML(s.label) + '</span>' +
+        '<span class="series-pill-stats" data-stats="min-avg-max">' +
+          '<span class="series-pill-stat-min">–</span>' +
+          '<span class="series-pill-stat-avg">–</span>' +
+          '<span class="series-pill-stat-max">–</span>' +
+        '</span>';
+      statsByIdx[String(i)] = {
+        min: btn.querySelector(".series-pill-stat-min"),
+        avg: btn.querySelector(".series-pill-stat-avg"),
+        max: btn.querySelector(".series-pill-stat-max"),
+      };
       btn.addEventListener("click", function (ev) {
         var idx = Number(btn.getAttribute("data-idx"));
         var additive = ev.shiftKey || ev.metaKey || ev.ctrlKey;
@@ -826,6 +882,45 @@
         }
       };
     }
+
+    // setStats(win) recomputes Min · Avg · Max for every pill against
+    // the visible x-window and writes the formatted strings into the
+    // pill stat spans. The chart-sync store calls this on every
+    // window change. When statsSource is omitted (legacy callers
+    // without per-series numeric data) it is a no-op.
+    function setStats(win) {
+      if (!statsSource || !window.__chartSyncStore) return;
+      var stats = window.__chartSyncStore.computeWindowedStats(
+        statsSource.timestamps, statsSource.series, win || { min: null, max: null });
+      // statsSource.series is indexed 0..N-1 of source series; pills
+      // are indexed 1..N (pill index 0 is the time axis, skipped on
+      // construction). Source series index i corresponds to pill idx
+      // i+1, EXCEPT for stacked charts where mountLegend was called
+      // with plotSeries already in reverse order — those callers pass
+      // statsSource pre-aligned so source[i] still corresponds to
+      // pill (i+1). Each call site is responsible for that alignment.
+      for (var i = 0; i < stats.length; i++) {
+        var pillIdx = String(i + 1);
+        var refs = statsByIdx[pillIdx];
+        if (!refs) continue;
+        var st = stats[i];
+        if (!st || st.count === 0) {
+          refs.min.textContent = "–";
+          refs.avg.textContent = "–";
+          refs.max.textContent = "–";
+        } else {
+          refs.min.textContent = formatYTick(st.min);
+          refs.avg.textContent = formatYTick(st.avg);
+          refs.max.textContent = formatYTick(st.max);
+        }
+      }
+    }
+
+    function destroy() {
+      if (legend && legend.parentNode) legend.parentNode.removeChild(legend);
+    }
+
+    return { setStats: setStats, destroy: destroy };
   }
 
   function escapeHTML(s) {

--- a/render/assets/app-js/00.js
+++ b/render/assets/app-js/00.js
@@ -284,37 +284,11 @@
   }
 
   // --- 3. Chart palette + helpers --------------------------------
-
-  // Series colors flow from the canonical CSS design-token block in
-  // `render/assets/app-css/04.css`: --series-1 through --series-16,
-  // one set per theme. The chart code resolves them via cssVar() at
-  // series-decoration time and re-resolves them on the
-  // `mygather:theme` event so live theme switches re-paint open
-  // charts. SERIES_COLORS as an in-JS array was deleted in feature
-  // 020-report-theming (Principle XIII canonical path).
+  //
+  // Theme/palette helpers (cssVar, seriesStrokeFor, hexToRgba,
+  // repaintChartsForTheme) live in 00b.js — extracted to honor
+  // Principle XV (file <= 1000 lines). Same outer IIFE scope.
   var SERIES_PALETTE_SIZE = 16;
-
-  function seriesStrokeFor(idx) {
-    var slot = ((idx % SERIES_PALETTE_SIZE) + SERIES_PALETTE_SIZE) % SERIES_PALETTE_SIZE;
-    // Fallback `#60a5fa` is the prior default series-1 color and
-    // covers the brief window where the document is mid-rebuild and
-    // the custom property has not resolved yet. It is the only hex
-    // literal allowed in app-js/ by the canonical-path audit; the
-    // grep is scoped to app-css/ so this fallback does not register.
-    return cssVar("--series-" + (slot + 1), "#60a5fa");
-  }
-
-  // Convert a #RRGGBB stroke into an rgba() with given alpha — used
-  // for gradient fills under each line so busy charts still read.
-  function hexToRgba(hex, alpha) {
-    var s = String(hex || "").replace("#", "");
-    if (s.length === 3) s = s[0]+s[0]+s[1]+s[1]+s[2]+s[2];
-    if (s.length !== 6) return "rgba(96,165,250," + alpha + ")";
-    var r = parseInt(s.substring(0,2), 16);
-    var g = parseInt(s.substring(2,4), 16);
-    var b = parseInt(s.substring(4,6), 16);
-    return "rgba(" + r + "," + g + "," + b + "," + alpha + ")";
-  }
 
   // Build a vertical gradient fill for a series (brighter at the top,
   // transparent at the bottom) so areas add visual depth without
@@ -339,13 +313,6 @@
       return uPlot.paths.spline();
     }
     return undefined;
-  }
-
-  function cssVar(name, fallback) {
-    try {
-      var v = getComputedStyle(document.documentElement).getPropertyValue(name).trim();
-      return v || fallback;
-    } catch (_) { return fallback; }
   }
 
   // Snapshot-boundary marker hook (T054 / FR-018 / FR-030).
@@ -538,44 +505,6 @@
   // the series stroke, the gradient fill, and the axis / grid / tick
   // strokes from the now-active CSS custom properties, then redraws.
   // Wired once below; the canonical re-pick path for FR-010.
-  function repaintChartsForTheme() {
-    for (var i = 0; i < CHARTS.length; i++) {
-      var entry = CHARTS[i];
-      var u = entry && entry.plot;
-      if (!u || !u.series || !u.axes) continue;
-      // Series strokes + fills. Two fill flavors exist:
-      //   - line/area charts use the gradient-fill closure produced
-      //     by makeFillFn() (default in decorateSeries).
-      //   - stacked-area / bar series in 01.js carry an explicit
-      //     __themeFillBuilder function that returns an alpha-tint
-      //     rgba string from the new hex stroke. We honor whichever
-      //     one the series declared at construction.
-      for (var s = 0; s < u.series.length; s++) {
-        var ser = u.series[s];
-        if (ser == null || ser.__themeIdx == null) continue;
-        var newStroke = seriesStrokeFor(ser.__themeIdx);
-        ser.stroke = newStroke;
-        ser.fill = (typeof ser.__themeFillBuilder === "function")
-          ? ser.__themeFillBuilder(newStroke)
-          : makeFillFn(newStroke);
-      }
-      // Axis / grid / tick strokes — read the same tokens
-      // basePlotOpts() reads at construction.
-      var axisStroke = cssVar("--axis-stroke", "#9aa5b4");
-      var gridStroke = cssVar("--grid-stroke", "rgba(130, 150, 175, 0.09)");
-      var tickStroke = cssVar("--tick-stroke", "rgba(130, 150, 175, 0.35)");
-      for (var a = 0; a < u.axes.length; a++) {
-        var ax = u.axes[a];
-        if (!ax) continue;
-        ax.stroke = axisStroke;
-        if (ax.grid)  ax.grid.stroke  = gridStroke;
-        if (ax.ticks) ax.ticks.stroke = tickStroke;
-      }
-      try { u.redraw(false); } catch (_) {}
-    }
-  }
-  document.addEventListener("mygather:theme", repaintChartsForTheme);
-
   // --- Hover tooltip -----------------------------------------------
 
   // attachTooltip builds one tooltip node per chart and hangs it on

--- a/render/assets/app-js/00.js
+++ b/render/assets/app-js/00.js
@@ -753,9 +753,9 @@
   //   - opts.statsSource: { timestamps, series } — the data each pill's
   //     Min · Avg · Max stat is computed against. Stacked charts pass
   //     the un-stacked raw values here; line charts pass the same data
-  //     they plotted. When omitted no stats render (kept omitted only
-  //     by callers that have no per-series numeric data, e.g. would-be
-  //     decorative-only legends).
+  //     they plotted. When omitted the per-pill stats span is NOT
+  //     rendered, so non-numeric legends get a clean pill instead of
+  //     leftover "–" placeholders.
   //
   // Returns { setStats(win), destroy() } so the chart-sync subscriber
   // can recompute on every shared-store window change and the vmstat
@@ -799,19 +799,27 @@
       btn.className = "series-pill" + (startsActive ? " active" : "");
       btn.setAttribute("data-idx", String(i));
       btn.title = "Click to show only this series (solo) · Shift/Cmd-click to toggle just this series · Click a soloed pill again to restore all";
+      // The pill stats span is appended ONLY when statsSource is wired
+      // — empty "–" placeholders that setStats can never populate would
+      // look broken. Single canonical guard for the markup AND the
+      // statsByIdx capture below.
       btn.innerHTML =
         '<span class="swatch" style="background:' + s.stroke + '"></span>' +
         '<span class="lbl">' + escapeHTML(s.label) + '</span>' +
-        '<span class="series-pill-stats" data-stats="min-avg-max">' +
-          '<span class="series-pill-stat-min">–</span>' +
-          '<span class="series-pill-stat-avg">–</span>' +
-          '<span class="series-pill-stat-max">–</span>' +
-        '</span>';
-      statsByIdx[String(i)] = {
-        min: btn.querySelector(".series-pill-stat-min"),
-        avg: btn.querySelector(".series-pill-stat-avg"),
-        max: btn.querySelector(".series-pill-stat-max"),
-      };
+        (statsSource
+          ? '<span class="series-pill-stats" data-stats="min-avg-max">' +
+              '<span class="series-pill-stat-min">–</span>' +
+              '<span class="series-pill-stat-avg">–</span>' +
+              '<span class="series-pill-stat-max">–</span>' +
+            '</span>'
+          : '');
+      if (statsSource) {
+        statsByIdx[String(i)] = {
+          min: btn.querySelector(".series-pill-stat-min"),
+          avg: btn.querySelector(".series-pill-stat-avg"),
+          max: btn.querySelector(".series-pill-stat-max"),
+        };
+      }
       btn.addEventListener("click", function (ev) {
         var idx = Number(btn.getAttribute("data-idx"));
         var additive = ev.shiftKey || ev.metaKey || ev.ctrlKey;

--- a/render/assets/app-js/00b.js
+++ b/render/assets/app-js/00b.js
@@ -1,0 +1,76 @@
+/* my-gather report client-side behaviour — part 00b.
+ *
+ * Theme helpers extracted from 00.js to keep the file under the
+ * 1000-line cap (Principle XV). All declarations here live inside
+ * the same outer IIFE that 00.js opens (closed in 05.js): function
+ * declarations are hoisted, so callers in 00.js (e.g. makeFillFn
+ * → hexToRgba) and downstream chart-builders in 01.js / 02.js /
+ * 03.js see them as if they were defined at the top of the IIFE.
+ *
+ * Series colors flow from the canonical CSS design-token block in
+ * `render/assets/app-css/04.css`: --series-1 through --series-16,
+ * one set per theme. The chart code resolves them via cssVar() at
+ * series-decoration time and re-resolves them on the
+ * `mygather:theme` event so live theme switches re-paint open
+ * charts.
+ */
+
+  function cssVar(name, fallback) {
+    try {
+      var v = getComputedStyle(document.documentElement).getPropertyValue(name).trim();
+      return v || fallback;
+    } catch (_) { return fallback; }
+  }
+
+  function seriesStrokeFor(idx) {
+    var slot = ((idx % SERIES_PALETTE_SIZE) + SERIES_PALETTE_SIZE) % SERIES_PALETTE_SIZE;
+    // Fallback `#60a5fa` is the prior default series-1 color and
+    // covers the brief window where the document is mid-rebuild and
+    // the custom property has not resolved yet.
+    return cssVar("--series-" + (slot + 1), "#60a5fa");
+  }
+
+  // Convert a #RRGGBB stroke into an rgba() with given alpha — used
+  // for gradient fills under each line so busy charts still read.
+  function hexToRgba(hex, alpha) {
+    var s = String(hex || "").replace("#", "");
+    if (s.length === 3) s = s[0]+s[0]+s[1]+s[1]+s[2]+s[2];
+    if (s.length !== 6) return "rgba(96,165,250," + alpha + ")";
+    var r = parseInt(s.substring(0,2), 16);
+    var g = parseInt(s.substring(2,4), 16);
+    var b = parseInt(s.substring(4,6), 16);
+    return "rgba(" + r + "," + g + "," + b + "," + alpha + ")";
+  }
+
+  function repaintChartsForTheme() {
+    for (var i = 0; i < CHARTS.length; i++) {
+      var entry = CHARTS[i];
+      var u = entry && entry.plot;
+      if (!u || !u.series || !u.axes) continue;
+      // Two fill flavors: line/area uses the gradient closure from
+      // makeFillFn(); stacked-area / bar series in 01.js carry an
+      // explicit __themeFillBuilder that returns an alpha-tint rgba
+      // string. Honor whichever one the series declared.
+      for (var s = 0; s < u.series.length; s++) {
+        var ser = u.series[s];
+        if (ser == null || ser.__themeIdx == null) continue;
+        var newStroke = seriesStrokeFor(ser.__themeIdx);
+        ser.stroke = newStroke;
+        ser.fill = (typeof ser.__themeFillBuilder === "function")
+          ? ser.__themeFillBuilder(newStroke)
+          : makeFillFn(newStroke);
+      }
+      var axisStroke = cssVar("--axis-stroke", "#9aa5b4");
+      var gridStroke = cssVar("--grid-stroke", "rgba(130, 150, 175, 0.09)");
+      var tickStroke = cssVar("--tick-stroke", "rgba(130, 150, 175, 0.35)");
+      for (var a = 0; a < u.axes.length; a++) {
+        var ax = u.axes[a];
+        if (!ax) continue;
+        ax.stroke = axisStroke;
+        if (ax.grid)  ax.grid.stroke  = gridStroke;
+        if (ax.ticks) ax.ticks.stroke = tickStroke;
+      }
+      try { u.redraw(false); } catch (_) {}
+    }
+  }
+  document.addEventListener("mygather:theme", repaintChartsForTheme);

--- a/render/assets/app-js/01.js
+++ b/render/assets/app-js/01.js
@@ -190,11 +190,13 @@
     plot.__rawData = plotRawByIdx; // consumed by updateTooltipOnCursor
     // Stats are computed against the un-stacked, un-bucketed RAW values
     // (data.series), not the cumulative `stacked[]` arrays uPlot
-    // draws. The pill order matches the REVERSE of `series`, so build
-    // an aligned source array in the same reverse order.
+    // draws — and not the bucketed `series` either, whose values array
+    // is shorter than `data.timestamps`. The pill order matches the
+    // REVERSE of `data.series`, so build an aligned source array in
+    // the same reverse order using the raw timeline.
     var statsSeries = [];
-    for (var sk = series.length - 1; sk >= 0; sk--) {
-      statsSeries.push({ label: series[sk].label, values: series[sk].values });
+    for (var sk = data.series.length - 1; sk >= 0; sk--) {
+      statsSeries.push({ label: data.series[sk].label, values: data.series[sk].values });
     }
     registerChart(plot, el, opts, {
       timestamps: data.timestamps,

--- a/render/assets/app-js/01.js
+++ b/render/assets/app-js/01.js
@@ -588,8 +588,21 @@
       var opts = basePlotOpts(w, 320, plotSeries, dim.unit || "threads", data.snapshotBoundaries, data.timestamps);
       plot = new uPlot(opts, plotData, el);
       plot.__rawData = plotRawByIdx; // consumed by updateTooltipOnCursor
-      registerChart(plot, el, opts);
-      mountLegend(el, plotSeries, plot, {
+      // Stats are computed against the un-stacked, un-bucketed RAW values
+      // (seriesData), not the cumulative `stacked[]` arrays uPlot draws.
+      // The pill order matches the REVERSE of `seriesData`, so build an
+      // aligned source array in the same reverse order. Mirrors the
+      // activity stacked path above (renderProcesslist's "activity" dim
+      // calls buildLineChart which already wires statsSource).
+      var statsSeries = [];
+      for (var sk = seriesData.length - 1; sk >= 0; sk--) {
+        statsSeries.push({ label: seriesData[sk].label, values: seriesData[sk].values });
+      }
+      registerChart(plot, el, opts, {
+        timestamps: data.timestamps,
+        series: statsSeries,
+      });
+      plot.__legendHandle = mountLegend(el, plotSeries, plot, {
         // Pill is active ⇔ bucket is NOT hidden in the current dim.
         initialVisible: function (idx) {
           var label = plotSeries[idx].label;
@@ -608,6 +621,7 @@
           hiddenByDim.set(dims[currentIdx].label, next);
           draw();
         },
+        statsSource: { timestamps: data.timestamps, series: statsSeries },
       });
       legendEl = el.nextSibling;
     }

--- a/render/assets/app-js/01.js
+++ b/render/assets/app-js/01.js
@@ -12,8 +12,17 @@
     var values = [data.timestamps.slice()].concat(data.series.map(function (s) { return s.values; }));
     var opts = basePlotOpts(width, 320, series, unit, data.snapshotBoundaries, data.timestamps);
     var plot = new uPlot(opts, values, el);
-    registerChart(plot, el, opts);
-    mountLegend(el, series, plot);
+    // Register with the data payload so the chart-sync store can
+    // recompute windowed stats and apply the current shared zoom
+    // window if one is active when this chart mounts.
+    registerChart(plot, el, opts, {
+      timestamps: data.timestamps,
+      series: data.series,
+    });
+    var legendHandle = mountLegend(el, series, plot, {
+      statsSource: { timestamps: data.timestamps, series: data.series },
+    });
+    plot.__legendHandle = legendHandle;
     return plot;
   }
 
@@ -179,8 +188,19 @@
     var opts = basePlotOpts(w, 320, plotSeries, unit, data.snapshotBoundaries, data.timestamps);
     var plot = new uPlot(opts, plotData, el);
     plot.__rawData = plotRawByIdx; // consumed by updateTooltipOnCursor
-    registerChart(plot, el, opts);
-    mountLegend(el, plotSeries, plot, {
+    // Stats are computed against the un-stacked, un-bucketed RAW values
+    // (data.series), not the cumulative `stacked[]` arrays uPlot
+    // draws. The pill order matches the REVERSE of `series`, so build
+    // an aligned source array in the same reverse order.
+    var statsSeries = [];
+    for (var sk = series.length - 1; sk >= 0; sk--) {
+      statsSeries.push({ label: series[sk].label, values: series[sk].values });
+    }
+    registerChart(plot, el, opts, {
+      timestamps: data.timestamps,
+      series: statsSeries,
+    });
+    var legendHandle = mountLegend(el, plotSeries, plot, {
       initialVisible: function (idx) {
         return !hiddenLabels.has(plotSeries[idx].label);
       },
@@ -192,7 +212,9 @@
         }
         if (typeof onRebuild === "function") onRebuild();
       },
+      statsSource: { timestamps: data.timestamps, series: statsSeries },
     });
+    plot.__legendHandle = legendHandle;
     return plot;
   }
 
@@ -382,8 +404,19 @@
       var w = measureChartWidth(el);
       var opts = basePlotOpts(w, 320, series, unit, data.snapshotBoundaries, data.timestamps);
       plot = new uPlot(opts, values, el);
-      registerChart(plot, el, opts);
-      mountLegend(el, series, plot);
+      // statsSource carries one entry per visible series in the same
+      // order as the legend pills (1..N), excluding the time axis.
+      var iostatStatsSeries = labels.map(function (lbl, i) {
+        return { label: lbl, values: rows[i] };
+      });
+      registerChart(plot, el, opts, {
+        timestamps: data.timestamps,
+        series: iostatStatsSeries,
+      });
+      var iostatLegendHandle = mountLegend(el, series, plot, {
+        statsSource: { timestamps: data.timestamps, series: iostatStatsSeries },
+      });
+      plot.__legendHandle = iostatLegendHandle;
       legendEl = el.nextSibling;
     }
     draw();

--- a/render/assets/app-js/02.js
+++ b/render/assets/app-js/02.js
@@ -459,10 +459,11 @@
       btnZoom.setAttribute("aria-label", "Reset zoom");
       btnZoom.addEventListener("click", function (ev) {
         ev.stopPropagation();
-        var cs = charts.get(id);
-        if (cs && cs.plot) {
-          cs.plot.setScale("x", { min: null, max: null });
-        }
+        // Reset every registered chart through the shared sync store
+        // so the per-card reset button stays consistent with the
+        // global ⛶ button (and so this card's siblings, including
+        // other mysqladmin cards, also unzoom).
+        if (window.__chartSyncStore) window.__chartSyncStore.reset();
       });
 
       var btnDup = document.createElement("button");
@@ -664,8 +665,25 @@
       var opts = basePlotOpts(width, 340, series, "Δ / sample", data.snapshotBoundaries, data.timestamps);
       cs.plotEl.innerHTML = "";
       cs.plot = new uPlot(opts, values, cs.plotEl);
-      registerChart(cs.plot, cs.plotEl, opts);
-      mountLegend(cs.plotEl, series, cs.plot);
+      // Build the stats-source aligned with the legend pills (one entry
+      // per picked counter in the same order). Use the truncated values
+      // arrays passed to uPlot so windowed-stats agree with what the
+      // chart actually plots.
+      var pickedSeries = [];
+      var pickedTimestamps = truncatedTimestamps;
+      for (var pi = 0; pi < picks.length; pi++) {
+        var deltaArr2 = data.deltas[picks[pi]];
+        if (!deltaArr2) continue;
+        pickedSeries.push({ label: picks[pi], values: deltaArr2.slice(tStart) });
+      }
+      registerChart(cs.plot, cs.plotEl, opts, {
+        timestamps: pickedTimestamps,
+        series: pickedSeries,
+      });
+      var maLegendHandle = mountLegend(cs.plotEl, series, cs.plot, {
+        statsSource: { timestamps: pickedTimestamps, series: pickedSeries },
+      });
+      cs.plot.__legendHandle = maLegendHandle;
       mountResetZoomButton(cs.plotEl, function () { return cs.plot; });
       updateCardCount(cs);
     }

--- a/render/assets/app-js/04.js
+++ b/render/assets/app-js/04.js
@@ -486,5 +486,10 @@
       if (!ev.target || !ev.target.closest || !ev.target.closest("main.content")) return;
       window.requestAnimationFrame(resizeAllCharts);
     }, true);
+    // The chart sync store + windowed legend stats subscriber wire up
+    // their own DOM-time hooks once initCharts has populated the
+    // CHARTS registry. The boot path calls initChartSync() (defined in
+    // app-js/05.js, last in lexical order) here so the order is
+    // explicit rather than implicit-by-load-order.
+    initChartSync();
   }
-})();

--- a/render/assets/app-js/05.js
+++ b/render/assets/app-js/05.js
@@ -111,7 +111,7 @@
     var subscribers = [];
     var api;
 
-    function broadcast() {
+    function broadcast(sourcePlot) {
       generation++;
       api.isBroadcasting = true;
       try {
@@ -119,6 +119,11 @@
         for (var i = 0; i < entries.length; i++) {
           var entry = entries[i];
           if (!entry || !entry.plot) continue;
+          // Honour the contract (specs/017-chart-zoom-sync-stats/contracts/chart-sync.md
+          // §1 setWindow): skip the source plot — uPlot's own scale on
+          // it already reflects the user's drag, and re-applying the
+          // window via setScale on the source is redundant work.
+          if (entry.plot === sourcePlot) continue;
           if (!entry.el || !entry.el.isConnected) continue;
           try {
             entry.plot.setScale("x", { min: win.min, max: win.max });
@@ -147,7 +152,26 @@
       api.isBroadcasting = false;
       if (typeof entry.setLegendStats === "function") {
         try { entry.setLegendStats(win); } catch (_) { /* ignore */ }
+        return;
       }
+      // applyToChart is invoked synchronously from registerChart, but
+      // each chart-builder calls registerChart BEFORE mountLegend, so
+      // entry.setLegendStats and plot.__legendHandle are not yet
+      // assigned at this point. Defer one microtask so the synchronous
+      // mountLegend call has had a chance to attach the handle, then
+      // adopt the resolver onto the entry (mirroring the cache pattern
+      // in initChartSync's subscriber). Without this, a chart that
+      // mounts post-zoom (e.g. user expands a collapsed <details> after
+      // zooming a sibling) keeps its legend at full-extent stats until
+      // the next user interaction.
+      Promise.resolve().then(function () {
+        if (win.min == null && win.max == null) return;
+        var handle = entry.plot && entry.plot.__legendHandle;
+        if (handle && typeof handle.setStats === "function") {
+          entry.setLegendStats = handle.setStats;
+          try { handle.setStats(win); } catch (_) { /* ignore */ }
+        }
+      });
     }
 
     api = {
@@ -162,13 +186,11 @@
         // trigger a redundant pass through every other chart.
         if (nMin === win.min && nMax === win.max) return;
         win = { min: nMin, max: nMax };
-        // sourcePlot is informational — uPlot's own scale on the
-        // source already reflects the user's drag, so we don't need
-        // to setScale it back. The registry walk skips no entry,
-        // but uPlot tolerates setScale to the value the scale is
-        // already at and fires no further hooks under our
-        // isBroadcasting guard.
-        broadcast();
+        // Per the contract, the registry walk skips the source plot —
+        // uPlot's own scale on it already reflects the user's drag, so
+        // re-applying the window to it would be redundant work and
+        // makes the contract/impl drift the reviewer flagged.
+        broadcast(sourcePlot);
       },
       reset: function () {
         // Restore each chart to its own data extent so charts with

--- a/render/assets/app-js/05.js
+++ b/render/assets/app-js/05.js
@@ -1,0 +1,255 @@
+  // ===============================================================
+  // app-js/05.js — chart sync store + windowed legend stats
+  // ===============================================================
+  //
+  // This part lives inside the same IIFE opened in app-js/00.js. The
+  // closing `})();` for the IIFE is at the bottom of THIS file so any
+  // future part appended after it would land OUTSIDE the IIFE; that
+  // is intentional — the IIFE contract ends here.
+  //
+  // The sync store implements GitHub issue #52 (synchronized x-axis
+  // zoom + pan across all registered charts) and feeds the windowed
+  // legend stats from issue #51 (per-series Min · Avg · Max over the
+  // visible window). Both are driven from the same canonical
+  // chart-registry walk so the broadcaster fires once per
+  // user-initiated zoom/pan/reset and every chart updates within one
+  // animation frame.
+  //
+  // The store is attached to window.__chartSyncStore so the existing
+  // basePlotOpts setScale hook (00.js → broadcastXScaleChange) can
+  // reach it without a circular import dance — there is no module
+  // system in this codebase. Tests grep the embedded JS for the
+  // canonical store identifier and helpers.
+  //
+  // Re-entrancy: the broadcaster sets isBroadcasting = true around
+  // every plot.setScale("x", …) call. The basePlotOpts setScale hook
+  // short-circuits when isBroadcasting is true, so the cycle "user
+  // zoom → store → setScale on chart B → chart B's setScale hook →
+  // store → setScale on chart A" cannot recurse.
+  //
+  // The HLL sparkline (render/assets/app-js/03.js → renderHLLSparkline)
+  // intentionally does NOT call registerChart. That is the canonical
+  // way to opt a chart out of sync; no separate "synced:false" flag
+  // is introduced.
+
+  // computeWindowedStats returns one {min, max, avg, count} record per
+  // input series, computed over samples whose timestamp falls inside
+  // [win.min, win.max]. When win is {null, null} (no synced zoom) the
+  // entire timestamps array is scanned. null / undefined / NaN sample
+  // values are skipped. When the windowed slice has zero non-null
+  // samples for a series, the record is {min:null, max:null, avg:null,
+  // count:0} and the legend renders "–".
+  //
+  // Binary search finds the index range so the per-series scan is
+  // O(N_window × S) rather than O(N_total × S) per chart per zoom
+  // event — important when the capture is long but the visible
+  // window is narrow.
+  function computeWindowedStats(timestamps, series, win) {
+    var ts = timestamps || [];
+    var ser = series || [];
+    var n = ts.length;
+    if (n === 0 || ser.length === 0) {
+      return ser.map(function () { return { min: null, max: null, avg: null, count: 0 }; });
+    }
+    var lo = (win && win.min != null) ? win.min : ts[0];
+    var hi = (win && win.max != null) ? win.max : ts[n - 1];
+    if (lo > hi) { var tmp = lo; lo = hi; hi = tmp; }
+
+    var i0 = lowerBound(ts, lo);
+    var i1 = upperBound(ts, hi);
+    if (i1 <= i0) {
+      return ser.map(function () { return { min: null, max: null, avg: null, count: 0 }; });
+    }
+
+    return ser.map(function (s) {
+      var values = s.values || [];
+      var min = Infinity, max = -Infinity, sum = 0, count = 0;
+      for (var i = i0; i < i1; i++) {
+        var v = values[i];
+        if (v === null || v === undefined) continue;
+        var n2 = +v;
+        if (isNaN(n2) || !isFinite(n2)) continue;
+        if (n2 < min) min = n2;
+        if (n2 > max) max = n2;
+        sum += n2;
+        count++;
+      }
+      if (count === 0) return { min: null, max: null, avg: null, count: 0 };
+      return { min: min, max: max, avg: sum / count, count: count };
+    });
+  }
+
+  // lowerBound: smallest index i such that ts[i] >= v.
+  function lowerBound(ts, v) {
+    var lo = 0, hi = ts.length;
+    while (lo < hi) {
+      var mid = (lo + hi) >>> 1;
+      if (ts[mid] < v) lo = mid + 1;
+      else hi = mid;
+    }
+    return lo;
+  }
+
+  // upperBound: smallest index i such that ts[i] > v.
+  function upperBound(ts, v) {
+    var lo = 0, hi = ts.length;
+    while (lo < hi) {
+      var mid = (lo + hi) >>> 1;
+      if (ts[mid] <= v) lo = mid + 1;
+      else hi = mid;
+    }
+    return lo;
+  }
+
+  // The shared zoom store. Singleton attached to window so the
+  // basePlotOpts setScale hook (which has no closure over this scope)
+  // can reach it. State and methods documented in
+  // specs/017-chart-zoom-sync-stats/contracts/chart-sync.md.
+  var chartSyncStore = (function () {
+    var win = { min: null, max: null };
+    var generation = 0;
+    var subscribers = [];
+    var api;
+
+    function broadcast() {
+      generation++;
+      api.isBroadcasting = true;
+      try {
+        var entries = chartRegistry();
+        for (var i = 0; i < entries.length; i++) {
+          var entry = entries[i];
+          if (!entry || !entry.plot) continue;
+          if (!entry.el || !entry.el.isConnected) continue;
+          try {
+            entry.plot.setScale("x", { min: win.min, max: win.max });
+          } catch (_) { /* uPlot can throw on a destroyed plot — skip */ }
+        }
+      } finally {
+        api.isBroadcasting = false;
+      }
+      // Fire subscribers AFTER the registry walk so a subscriber that
+      // recomputes legend stats sees the just-applied scales on every
+      // chart, not the half-applied state mid-broadcast.
+      for (var s = 0; s < subscribers.length; s++) {
+        try { subscribers[s](win, generation); } catch (_) { /* subscriber bug — keep going */ }
+      }
+    }
+
+    function applyToChart(entry) {
+      if (!entry || !entry.plot) return;
+      // No synced zoom yet — nothing to apply. Legend stats default
+      // to the full data extent at first paint.
+      if (win.min == null && win.max == null) return;
+      api.isBroadcasting = true;
+      try {
+        entry.plot.setScale("x", { min: win.min, max: win.max });
+      } catch (_) { /* destroyed or not yet ready — skip */ }
+      api.isBroadcasting = false;
+      if (typeof entry.setLegendStats === "function") {
+        try { entry.setLegendStats(win); } catch (_) { /* ignore */ }
+      }
+    }
+
+    api = {
+      isBroadcasting: false,
+      computeWindowedStats: computeWindowedStats,
+      getWindow: function () { return { min: win.min, max: win.max }; },
+      setWindow: function (next, sourcePlot) {
+        var nMin = (next && next.min != null) ? next.min : null;
+        var nMax = (next && next.max != null) ? next.max : null;
+        // Coalesce identical windows so a chart whose own setScale
+        // hook fires with the same numbers we just broadcast doesn't
+        // trigger a redundant pass through every other chart.
+        if (nMin === win.min && nMax === win.max) return;
+        win = { min: nMin, max: nMax };
+        // sourcePlot is informational — uPlot's own scale on the
+        // source already reflects the user's drag, so we don't need
+        // to setScale it back. The registry walk skips no entry,
+        // but uPlot tolerates setScale to the value the scale is
+        // already at and fires no further hooks under our
+        // isBroadcasting guard.
+        broadcast();
+      },
+      reset: function () {
+        // Restore each chart to its own data extent so charts with
+        // narrower data than the previously-synced window come back
+        // to their full range, not the broadcast window.
+        api.isBroadcasting = true;
+        try {
+          var entries = chartRegistry();
+          for (var i = 0; i < entries.length; i++) {
+            var entry = entries[i];
+            if (!entry || !entry.plot) continue;
+            try {
+              var xs = entry.plot.data && entry.plot.data[0];
+              if (xs && xs.length) {
+                entry.plot.setScale("x", { min: xs[0], max: xs[xs.length - 1] });
+              } else {
+                entry.plot.setScale("x", { min: null, max: null });
+              }
+            } catch (_) { /* skip destroyed plot */ }
+          }
+        } finally {
+          api.isBroadcasting = false;
+        }
+        win = { min: null, max: null };
+        generation++;
+        for (var s = 0; s < subscribers.length; s++) {
+          try { subscribers[s](win, generation); } catch (_) { /* ignore */ }
+        }
+      },
+      subscribe: function (fn) {
+        if (typeof fn !== "function") return function () {};
+        subscribers.push(fn);
+        return function unsubscribe() {
+          for (var i = subscribers.length - 1; i >= 0; i--) {
+            if (subscribers[i] === fn) subscribers.splice(i, 1);
+          }
+        };
+      },
+      applyToChart: applyToChart,
+    };
+    return api;
+  })();
+
+  // Publish the store before initCharts runs so the basePlotOpts
+  // setScale hook (and registerChart's applyToChart probe) can find
+  // it on first paint of the very first chart.
+  window.__chartSyncStore = chartSyncStore;
+
+  // initChartSync wires the windowed-stats subscriber once initCharts
+  // has populated the registry. Called from boot() in app-js/04.js.
+  function initChartSync() {
+    // First pass: fire setStats({null, null}) on every chart so the
+    // legend renders full-extent stats at first paint without waiting
+    // for a user interaction.
+    var entries = chartRegistry();
+    for (var i = 0; i < entries.length; i++) {
+      var entry = entries[i];
+      if (!entry || !entry.plot) continue;
+      var handle = entry.plot.__legendHandle;
+      if (handle && typeof handle.setStats === "function") {
+        entry.setLegendStats = handle.setStats;
+        try { handle.setStats({ min: null, max: null }); } catch (_) { /* ignore */ }
+      }
+    }
+    // Subscribe once: every store update walks the registry and pings
+    // each chart's legend handle (re-resolved on each tick because
+    // vmstat tab rebuilds and similar replace the plot underneath).
+    chartSyncStore.subscribe(function (win) {
+      var ents = chartRegistry();
+      for (var i = 0; i < ents.length; i++) {
+        var ent = ents[i];
+        if (!ent || !ent.plot) continue;
+        var h = ent.plot.__legendHandle;
+        if (h && typeof h.setStats === "function") {
+          // Cache the resolver on the entry so chart-mount timing
+          // (applyToChart for a chart that mounted post-zoom) and
+          // store updates use the same code path.
+          ent.setLegendStats = h.setStats;
+          try { h.setStats(win); } catch (_) { /* ignore */ }
+        }
+      }
+    });
+  }
+})();

--- a/render/assets_test.go
+++ b/render/assets_test.go
@@ -365,29 +365,41 @@ func TestHLLSparklineExemptFromSync(t *testing.T) {
 		end = len(app) - idx
 	}
 	body := app[idx : idx+end]
-	if strings.Contains(body, "registerChart(") {
-		t.Fatalf("renderHLLSparkline must not call registerChart — that is the canonical opt-out from chart sync")
+	// Strip line comments so explanatory mentions of `registerChart()`
+	// in prose do not register as call sites. The check is for an
+	// actual call, not the literal substring.
+	for _, line := range strings.Split(body, "\n") {
+		code := line
+		if i := strings.Index(code, "//"); i >= 0 {
+			code = code[:i]
+		}
+		if strings.Contains(code, "registerChart(") {
+			t.Fatalf("renderHLLSparkline must not call registerChart — that is the canonical opt-out from chart sync")
+		}
 	}
 }
 
-// TestEmbeddedAppJSHasIIFEClosed asserts the outer IIFE that wraps
-// the embedded JS opens exactly once (in 00.js) and closes exactly
-// once (now at the bottom of 05.js). A missing close would leave the
-// browser parser unhappy; a duplicate close would mean a part landed
-// outside the IIFE.
+// TestEmbeddedAppJSHasIIFEClosed asserts every top-level IIFE in
+// the embedded JS opens and closes — opens-count must equal
+// closes-count, and the bundle must end with `})();`. The chart
+// helper IIFE (00.js → 05.js) and the theme module IIFE (06.js)
+// are independent top-level wrappers; both must be balanced.
 func TestEmbeddedAppJSHasIIFEClosed(t *testing.T) {
 	app := embeddedAppJS
-	if strings.Count(app, "(function () {\n  \"use strict\";") != 1 {
-		t.Fatalf("expected exactly one outer IIFE opener in embedded app JS")
-	}
-	// The outer IIFE close is the only `})();` at column 0 (no leading
-	// indent). Inner IIFEs (e.g. the chart-sync store factory) close
-	// with `  })();` (indented).
 	if !strings.HasSuffix(strings.TrimRight(app, "\n"), "\n})();") {
-		t.Fatalf("expected outer IIFE close `})();` at start of last non-blank line in embedded app JS")
+		t.Fatalf("expected an IIFE close `})();` at start of the last non-blank line in embedded app JS")
 	}
-	if strings.Count(app, "\n})();") != 1 {
-		t.Fatalf("expected exactly one outer (column-0) IIFE close in embedded app JS")
+	useStrictOpens := strings.Count(app, "(function () {\n  \"use strict\";")
+	if useStrictOpens < 1 {
+		t.Fatalf("expected at least one strict-mode IIFE opener in embedded app JS")
+	}
+	opens := strings.Count(app, "\n(function () {")
+	closes := strings.Count(app, "\n})();")
+	if opens != closes {
+		t.Fatalf("top-level IIFE opens (%d) and closes (%d) must match", opens, closes)
+	}
+	if opens < 1 {
+		t.Fatalf("expected at least one top-level IIFE in embedded app JS")
 	}
 }
 

--- a/render/assets_test.go
+++ b/render/assets_test.go
@@ -161,6 +161,126 @@ func TestFeedbackWorkerClientContract(t *testing.T) {
 	}
 }
 
+// TestChartZoomSyncContract asserts the embedded JS contains the
+// canonical chart-sync-store and windowed-stats markers from
+// specs/017-chart-zoom-sync-stats/contracts/chart-sync.md, and does
+// not retain any non-canonical reset-zoom or duplicate mountLegend
+// path.
+func TestChartZoomSyncContract(t *testing.T) {
+	app := embeddedAppJS
+	for _, want := range []string{
+		// Store identity.
+		"window.__chartSyncStore",
+		"chartSyncStore.subscribe",
+		// Public methods (called from broadcast hooks and reset path).
+		"setWindow:",
+		"reset: function",
+		"applyToChart:",
+		// Windowed-stats helper + the canonical pill marker the legend
+		// renders for each series.
+		"computeWindowedStats",
+		"series-pill-stats",
+		"setLegendStats",
+		// Boot wiring lives in app-js/04.js (initChartSync defined in
+		// 05.js); both must ship together.
+		"initChartSync()",
+		"function initChartSync()",
+		// The reset-zoom button click handler routes through the store
+		// so every chart resets, not just the one the button is on.
+		"window.__chartSyncStore.reset()",
+		// The basePlotOpts setScale broadcaster name is canonical.
+		"broadcastXScaleChange",
+		// 05.js banner comment proves the new ordered part is embedded.
+		"app-js/05.js",
+	} {
+		if !strings.Contains(app, want) {
+			t.Fatalf("embedded app JS missing chart-sync canonical marker %q", want)
+		}
+	}
+	for _, forbidden := range []string{
+		// The old per-chart reset button used to call setScale on a
+		// single plot; the new canonical path goes through the store.
+		// If anyone reintroduces a direct setScale("x" outside the
+		// store, this guard fires.
+		`getPlot().setScale("x"`,
+		// The mysqladmin per-card zoom button used to call
+		// cs.plot.setScale directly; same guard.
+		`cs.plot.setScale("x"`,
+	} {
+		if strings.Contains(app, forbidden) {
+			t.Fatalf("embedded app JS still contains non-canonical zoom-reset path %q", forbidden)
+		}
+	}
+	// mountLegend has exactly one definition.
+	if got := strings.Count(app, "function mountLegend("); got != 1 {
+		t.Fatalf("mountLegend defined %d times in embedded app JS; want exactly 1 (canonical owner)", got)
+	}
+}
+
+// TestChartSyncWindowedStatsFlow asserts the legend recomputation flow
+// is wired end-to-end in the embedded JS: the store subscriber walks
+// the registry and calls each chart's setStats with the new window,
+// and a chart that mounts post-zoom adopts the current window via
+// applyToChart on registration.
+func TestChartSyncWindowedStatsFlow(t *testing.T) {
+	app := embeddedAppJS
+	for _, want := range []string{
+		// On every store update, the subscriber pings each chart's
+		// legend handle.
+		"h.setStats(win)",
+		// On registration, a chart that mounts after a zoom adopts
+		// the current shared window without an extra interaction.
+		"window.__chartSyncStore.applyToChart",
+		// Stacked-chart stats source is the un-stacked raw values, not
+		// the cumulative `stacked[]` arrays uPlot draws.
+		"stacked charts whose drawn values are cumulative",
+	} {
+		if !strings.Contains(app, want) {
+			t.Fatalf("embedded app JS missing chart-sync flow marker %q", want)
+		}
+	}
+}
+
+// TestHLLSparklineExemptFromSync preserves the canonical opt-out: the
+// HLL sparkline must NOT call registerChart, so it is never reached by
+// the chart-sync broadcaster or the windowed-stats subscriber.
+func TestHLLSparklineExemptFromSync(t *testing.T) {
+	app := embeddedAppJS
+	idx := strings.Index(app, "function renderHLLSparkline")
+	if idx < 0 {
+		t.Fatalf("renderHLLSparkline not found in embedded app JS")
+	}
+	end := strings.Index(app[idx:], "\n  function ")
+	if end < 0 {
+		end = len(app) - idx
+	}
+	body := app[idx : idx+end]
+	if strings.Contains(body, "registerChart(") {
+		t.Fatalf("renderHLLSparkline must not call registerChart — that is the canonical opt-out from chart sync")
+	}
+}
+
+// TestEmbeddedAppJSHasIIFEClosed asserts the outer IIFE that wraps
+// the embedded JS opens exactly once (in 00.js) and closes exactly
+// once (now at the bottom of 05.js). A missing close would leave the
+// browser parser unhappy; a duplicate close would mean a part landed
+// outside the IIFE.
+func TestEmbeddedAppJSHasIIFEClosed(t *testing.T) {
+	app := embeddedAppJS
+	if strings.Count(app, "(function () {\n  \"use strict\";") != 1 {
+		t.Fatalf("expected exactly one outer IIFE opener in embedded app JS")
+	}
+	// The outer IIFE close is the only `})();` at column 0 (no leading
+	// indent). Inner IIFEs (e.g. the chart-sync store factory) close
+	// with `  })();` (indented).
+	if !strings.HasSuffix(strings.TrimRight(app, "\n"), "\n})();") {
+		t.Fatalf("expected outer IIFE close `})();` at start of last non-blank line in embedded app JS")
+	}
+	if strings.Count(app, "\n})();") != 1 {
+		t.Fatalf("expected exactly one outer (column-0) IIFE close in embedded app JS")
+	}
+}
+
 // TestResolveVersionMultiDigitSort ensures resolveVersion sorts
 // numerically (not lexicographically) so "10.4" is later than "9.0".
 func TestResolveVersionMultiDigitSort(t *testing.T) {

--- a/render/assets_test.go
+++ b/render/assets_test.go
@@ -241,6 +241,44 @@ func TestChartSyncWindowedStatsFlow(t *testing.T) {
 	}
 }
 
+// TestProcesslistStackedDimensionLegendStats is a regression guard for
+// PR #59 review finding (P1): the non-activity stacked dimensions
+// inside renderProcesslist (State / User / Host / Command / db) used to
+// call registerChart with no `data` payload and mountLegend with no
+// `statsSource`, silently violating spec 017 FR-007 (windowed Min/Avg/
+// Max pills on every synced chart). The fix wires both, mirroring the
+// activity stacked path in buildStackedChart. This test asserts the
+// canonical wiring inside the renderProcesslist body so a future drift
+// is caught at build time.
+func TestProcesslistStackedDimensionLegendStats(t *testing.T) {
+	app := embeddedAppJS
+	idx := strings.Index(app, "function renderProcesslist")
+	if idx < 0 {
+		t.Fatalf("renderProcesslist not found in embedded app JS")
+	}
+	end := strings.Index(app[idx:], "\n  function ")
+	if end < 0 {
+		end = len(app) - idx
+	}
+	body := app[idx : idx+end]
+	for _, want := range []string{
+		// statsSource must be passed to mountLegend so the legend pills
+		// recompute Min/Avg/Max on every store window change.
+		"statsSource: { timestamps: data.timestamps, series: statsSeries }",
+		// The stacked-dimension chart must capture the legend handle on
+		// the plot so initChartSync's first-pass and the post-zoom
+		// applyToChart can find it.
+		"plot.__legendHandle = mountLegend(",
+		// registerChart must receive a non-nil 4th-arg `data` payload so
+		// applyToChart can adopt a pre-existing zoom window.
+		"registerChart(plot, el, opts, {",
+	} {
+		if !strings.Contains(body, want) {
+			t.Fatalf("renderProcesslist body missing canonical chart-sync wiring %q (PR #59 P1 regression)", want)
+		}
+	}
+}
+
 // TestHLLSparklineExemptFromSync preserves the canonical opt-out: the
 // HLL sparkline must NOT call registerChart, so it is never reached by
 // the chart-sync broadcaster or the windowed-stats subscriber.

--- a/render/assets_test.go
+++ b/render/assets_test.go
@@ -279,6 +279,78 @@ func TestProcesslistStackedDimensionLegendStats(t *testing.T) {
 	}
 }
 
+// TestMountLegendStatsConditionalOnStatsSource is a regression guard for
+// PR #59 review finding (Copilot, 00.js:764): the legend rendering used
+// to unconditionally append the `series-pill-stats` markup defaulting to
+// "–", but `setStats()` is a no-op when `opts.statsSource` is omitted.
+// Result: charts that don't wire statsSource showed permanent em-dashes
+// in pill stat slots that would never get populated. The fix gates the
+// markup append on `statsSource` so non-numeric legends get a clean pill
+// and only stats-aware callers render the slot. This test asserts the
+// canonical guard is present inside `mountLegend`.
+func TestMountLegendStatsConditionalOnStatsSource(t *testing.T) {
+	app := embeddedAppJS
+	idx := strings.Index(app, "function mountLegend(")
+	if idx < 0 {
+		t.Fatalf("mountLegend not found in embedded app JS")
+	}
+	end := strings.Index(app[idx:], "\n  function ")
+	if end < 0 {
+		end = len(app) - idx
+	}
+	body := app[idx : idx+end]
+	// The pill stats markup must be gated by a `statsSource ?` ternary so
+	// it is omitted (not just empty) when the caller did not wire stats.
+	statsMarkupIdx := strings.Index(body, "series-pill-stats")
+	if statsMarkupIdx < 0 {
+		t.Fatalf("mountLegend body missing series-pill-stats markup")
+	}
+	// Look for the canonical guard `(statsSource\n          ?` immediately
+	// preceding the markup. Substring check for `statsSource` within a
+	// short window before the markup is sufficient to assert the guard
+	// without depending on exact whitespace.
+	prelude := body[:statsMarkupIdx]
+	lastGuard := strings.LastIndex(prelude, "statsSource")
+	if lastGuard < 0 || statsMarkupIdx-lastGuard > 200 {
+		t.Fatalf("series-pill-stats markup is not gated on statsSource within mountLegend (PR #59 Copilot regression: empty pills appear when statsSource is omitted)")
+	}
+	// The statsByIdx capture must also be gated so we don't allocate
+	// references to elements that don't exist.
+	if !strings.Contains(body, "if (statsSource) {\n        statsByIdx[String(i)] = {") {
+		t.Fatalf("statsByIdx capture is not gated on statsSource (PR #59 Copilot regression: querySelector against non-existent elements)")
+	}
+}
+
+// TestStackedChartStatsSourceUsesUnbucketedSeries is a regression guard
+// for PR #59 review finding (Codex P1, 01.js:201): buildStackedChart
+// built statsSeries from the bucketized `series` (length n_buckets) but
+// wired data.timestamps (length n_samples) into statsSource. The
+// computeWindowedStats helper indexes by timestamps, so once the user
+// zoomed beyond the first n_buckets indexes it read mostly undefined
+// values and Min/Avg/Max collapsed to "–". The fix iterates over
+// `data.series` (the un-bucketed raw values, aligned to data.timestamps)
+// per the chart-sync contract §1 (rawSeries semantics).
+func TestStackedChartStatsSourceUsesUnbucketedSeries(t *testing.T) {
+	app := embeddedAppJS
+	idx := strings.Index(app, "function buildStackedChart(")
+	if idx < 0 {
+		t.Fatalf("buildStackedChart not found in embedded app JS")
+	}
+	end := strings.Index(app[idx:], "\n  function ")
+	if end < 0 {
+		end = len(app) - idx
+	}
+	body := app[idx : idx+end]
+	// Canonical wiring: iterate over data.series (un-bucketed raw),
+	// matching data.timestamps.
+	if !strings.Contains(body, "for (var sk = data.series.length - 1; sk >= 0; sk--)") {
+		t.Fatalf("buildStackedChart statsSeries loop must iterate over data.series (un-bucketed) — PR #59 Codex P1 regression: bucketed series mis-aligned with data.timestamps")
+	}
+	if !strings.Contains(body, "data.series[sk].values") {
+		t.Fatalf("buildStackedChart statsSeries must pull values from data.series[sk] (un-bucketed) — PR #59 Codex P1 regression")
+	}
+}
+
 // TestHLLSparklineExemptFromSync preserves the canonical opt-out: the
 // HLL sparkline must NOT call registerChart, so it is never reached by
 // the chart-sync broadcaster or the windowed-stats subscriber.

--- a/specs/017-chart-zoom-sync-stats/checklists/requirements.md
+++ b/specs/017-chart-zoom-sync-stats/checklists/requirements.md
@@ -1,0 +1,30 @@
+# Specification Quality Checklist: Synchronized Chart Zoom + Per-Window Legend Stats
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-05-07
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs) beyond what is required by the canonical-path expectations section (which the constitution mandates name the canonical path)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders (the user-story section is plain language; the canonical-path notes target reviewers per Principle XIII)
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (SC-005 / SC-006 / SC-007 reference repository-level invariants — Go tests, file-size, byte-identical output — which are project gates rather than user-facing implementation choices)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded (HLL sparkline carve-out called out explicitly)
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows (zoom-sync + windowed-stats)
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification beyond canonical-path naming

--- a/specs/017-chart-zoom-sync-stats/contracts/chart-sync.md
+++ b/specs/017-chart-zoom-sync-stats/contracts/chart-sync.md
@@ -109,13 +109,16 @@ Returned object:
 - `destroy()` — remove the legend node and unsubscribe (used by the vmstat tab
   rebuild path).
 
-The legend pill HTML adds one element:
+The legend pill HTML adds one element, but ONLY when `statsSource` is
+provided:
 
 ```html
-<span class="stats" data-stats="min·avg·max">…</span>
+<span class="series-pill-stats" data-stats="min-avg-max">…</span>
 ```
 
-When `count === 0` for a series, the element renders `–`.
+When `count === 0` for a series, the element renders `–`. When the
+caller omits `statsSource` the element is not appended at all (no empty
+"–" placeholder is rendered, so non-numeric legends get a clean pill).
 
 ## 4. Reset-zoom button contract
 

--- a/specs/017-chart-zoom-sync-stats/contracts/chart-sync.md
+++ b/specs/017-chart-zoom-sync-stats/contracts/chart-sync.md
@@ -1,0 +1,153 @@
+# Contract: Chart Sync Store + Windowed Legend Stats
+
+This contract defines the JS-internal API introduced by feature
+017-chart-zoom-sync-stats. It is consumed only by the report's embedded JS.
+
+## 1. `chartSyncStore` (shared zoom store)
+
+Singleton attached to `window.__chartSyncStore`, defined in
+`render/assets/app-js/05.js`.
+
+### State
+
+```text
+{
+  win:        { min: number|null, max: number|null },   // current x-window
+  generation: number,                                   // monotonic, for re-entrancy guard
+  isBroadcasting: boolean,                              // set true while applying to all charts
+  subscribers: Array<function(win, generation)>
+}
+```
+
+`win.min === null && win.max === null` means "no synced zoom" (full extent
+per chart).
+
+### Methods
+
+- `getWindow() -> { min, max }` — returns the current store window.
+- `setWindow({min, max}, sourcePlot?)` — publishes a new window. Bumps
+  `generation`. Walks the chart registry; for every entry whose plot is not
+  `sourcePlot` and whose container is connected, calls
+  `plot.setScale("x", { min, max })` with `isBroadcasting = true` set around
+  each call so the per-chart `setScale` hook can skip publishing back. After
+  the walk, fires every subscriber.
+- `reset()` — restores every registered chart to its own data extent. For each
+  registered chart, calls `plot.setScale("x", { min: xs[0], max: xs[xs.length-1] })`
+  with `isBroadcasting = true`. Then sets `win = {min:null, max:null}` and
+  fires subscribers.
+- `subscribe(fn) -> unsubscribe` — registers a subscriber called as
+  `fn(win, generation)` after every store update. Returns a function that
+  removes the subscriber.
+
+### Per-chart hook contract
+
+Every registered chart's uPlot config gains a `setScale` hook on the `x`
+scale. The hook:
+
+1. If `chartSyncStore.isBroadcasting` is true, returns immediately.
+2. Reads `u.scales.x.min`, `u.scales.x.max`.
+3. Calls `chartSyncStore.setWindow({min, max}, u)`.
+
+This hook is added inside `basePlotOpts` so every chart that uses
+`basePlotOpts` participates automatically.
+
+### `registerChart` extension
+
+`registerChart(plot, containerEl, options, data)` — the optional `data`
+argument is `{timestamps: number[], series: Array<{label, values}>, rawSeries?: Array<{label, values}>}`.
+
+- `timestamps` is the un-bucketed Unix-second array.
+- `series` is what's drawn (post-bucketing, post-stacking for stacked charts).
+- `rawSeries` is supplied by stacked charts; it carries the un-stacked raw
+  per-series values. When present, windowed stats use `rawSeries` instead of
+  `series`.
+
+A chart that does not register (HLL sparkline) is intentionally excluded from
+sync and from windowed stats.
+
+## 2. `computeWindowedStats(timestamps, series, win)` (helper)
+
+Defined in `render/assets/app-js/05.js`.
+
+Input:
+
+- `timestamps: number[]` — sorted ascending (Unix seconds).
+- `series: Array<{label, values}>` — `values[i]` aligned to `timestamps[i]`.
+- `win: {min, max}` — when both are `null`, scan the entire array.
+
+Output:
+
+- `Array<{min, max, avg, count}>` — one entry per series in input order.
+  Series with `count === 0` (no non-null samples in window) return
+  `{min: null, max: null, avg: null, count: 0}` and the legend renders `–`.
+
+Behaviour:
+
+- Use binary search on `timestamps` to find `[i0, i1]` such that
+  `timestamps[i0] >= win.min` and `timestamps[i1-1] <= win.max`. When `win`
+  is `{null, null}`, `[i0, i1] = [0, timestamps.length]`.
+- Skip `null`, `undefined`, and `NaN` values inside the window.
+
+## 3. `mountLegend` extension
+
+Updated signature:
+
+```text
+mountLegend(containerEl, series, plot, opts) -> { setStats(win), destroy() }
+```
+
+`opts` gains:
+
+- `statsSource: { timestamps, series }` — the data the stats are computed
+  against. For stacked charts the caller passes the un-stacked raw values
+  here.
+
+Returned object:
+
+- `setStats(win)` — recompute and re-render the per-pill stats for the given
+  window. Called by the store subscriber on every window change.
+- `destroy()` — remove the legend node and unsubscribe (used by the vmstat tab
+  rebuild path).
+
+The legend pill HTML adds one element:
+
+```html
+<span class="stats" data-stats="min·avg·max">…</span>
+```
+
+When `count === 0` for a series, the element renders `–`.
+
+## 4. Reset-zoom button contract
+
+`mountResetZoomButton(containerEl, getPlot)` is unchanged at the call-site
+level. The click handler now calls `chartSyncStore.reset()` instead of
+`getPlot().setScale("x", …)`. This guarantees the reset propagates to every
+registered chart and the store reflects "no synced zoom".
+
+## 5. Embedded-JS canonical markers (test contract)
+
+`render/assets_test.go` MUST grep `embeddedAppJS` for the following:
+
+Required substrings (presence asserted):
+
+- `__chartSyncStore`
+- `chartSyncStore.subscribe`
+- `chartSyncStore.setWindow`
+- `chartSyncStore.reset`
+- `computeWindowedStats`
+- `setStats(`
+- `series-pill-stats` (the new pill element class)
+
+Forbidden substrings (absence asserted):
+
+- A reset-zoom click handler that calls `setScale("x"` directly without
+  routing through the store. Implementation places all `setScale("x"` calls
+  inside `chartSyncStore`.
+- Any second `mountLegend(` definition.
+
+## 6. Determinism contract
+
+The store and stats are computed in the browser at view time. The HTML
+embedded by `render/` is unaffected by sync state. Two consecutive
+`my-gather` runs against the same input directory MUST produce byte-identical
+HTML; the existing CI determinism job covers this.

--- a/specs/017-chart-zoom-sync-stats/plan.md
+++ b/specs/017-chart-zoom-sync-stats/plan.md
@@ -1,0 +1,163 @@
+# Implementation Plan: Synchronized Chart Zoom + Per-Window Legend Stats
+
+**Branch**: `017-chart-zoom-sync-stats` | **Date**: 2026-05-07 | **Spec**: [spec.md](./spec.md)
+**Input**: Feature specification from `specs/017-chart-zoom-sync-stats/spec.md`
+
+## Summary
+
+Make every report's time-series charts share one in-memory `{min, max}` x-axis
+window, so a zoom or pan on any chart instantly updates every other chart on the
+page (including charts inside collapsed sections). Recompute and display
+per-series Min/Max/Avg in each chart's legend pills over the visible window on
+every store update. Implement both behaviours in one chart-layer pass on the
+embedded report JS, the canonical chart owner.
+
+## Technical Context
+
+**Language/Version**: Go 1.x (host binary, builds the embedded report); embedded
+JS is plain ES5/ES2015-compatible browser code (matches the rest of `app-js/`).
+**Primary Dependencies**: existing bundled uPlot (`render/assets/chart.min.js`).
+No new Go dependencies, no new JS dependencies.
+**Storage**: N/A — sync state is window-local at view time and never persisted
+to the rendered HTML (preserves Principle IV byte-identical determinism).
+**Testing**: Go tests under `render/` that grep `embeddedAppJS` for canonical
+markers — same pattern as `TestFeedbackWorkerClientContract` in
+`render/assets_test.go`. Plus a generation-side test that asserts the new
+`05.js` part is concatenated into the embedded bundle in deterministic order.
+**Target Platform**: self-contained HTML report viewed in any modern browser on
+an air-gapped laptop (Principle V).
+**Project Type**: single Go binary (`cmd/my-gather`) producing a single HTML
+report; the change is internal to `render/`.
+**Performance Goals**: every store update applies the new window to all charts
+within one animation frame; legend stats recompute in O(N samples × S series)
+per chart per update — N is at most a few thousand on shipped fixtures, so a
+linear scan is well below 1 ms per chart.
+**Constraints**: zero network at runtime (Principle IX), zero file writes
+inside the input tree (Principle II), single static binary (Principle I), no
+file over 1000 lines (Principle XV), byte-identical output between two runs
+(Principle IV).
+**Scale/Scope**: a single shipped report has on the order of 5–20 registered
+charts. The sync broadcaster is O(charts) per update.
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+- **I. Single Static Binary** — pure JS/Go change, no new CGO, no new runtime
+  step. PASS.
+- **II. Read-Only Inputs** — no parser change, no write paths added. PASS.
+- **III. Graceful Degradation** — a chart whose data is narrower than the
+  broadcast window paints empty regions for the gap; this is observable and
+  intentional, not a panic. PASS.
+- **IV. Deterministic Output** — sync state lives in browser memory; rendered
+  HTML is unaffected. The new `05.js` part is concatenated in deterministic
+  lexical order by the existing `render/assets.go` embed step. PASS.
+- **V. Self-Contained HTML Reports** — no new external assets; new logic ships
+  as one more `app-js/` part embedded into the binary. PASS.
+- **VI. Library-First Architecture** — change is inside `render/`, no new
+  exports, all touched JS continues to live under the existing canonical owner
+  (`render/assets/app-js/`). PASS.
+- **VII. Typed Errors** — JS-only, no Go error surface. PASS.
+- **VIII. Reference Fixtures & Golden Tests** — no parser change, no fixture
+  change. Goldens may shift if legend HTML structure changes; if so, regenerate
+  via the reviewed `-update` step and review the diff. Plan covers this in
+  Phase 2 task list.
+- **IX. Zero Network at Runtime** — no network code added. PASS.
+- **X. Minimal Dependencies** — uses bundled uPlot only. PASS.
+- **XI. Reports Optimized for Humans Under Pressure** — windowed stats and
+  cross-chart sync directly serve the incident-response narrative. PASS.
+- **XII. Pinned Go Version** — no Go version change. PASS.
+- **XIII. Canonical Code Path (NON-NEGOTIABLE)** — see Canonical Path Audit
+  below.
+- **XIV. English-Only Durable Artifacts** — all artifacts in this plan are
+  English. PASS.
+- **XV. Bounded Source File Size** — every existing `app-js/` part is within
+  ~100 lines of the 1000-line cap. New logic lands in a new part
+  (`render/assets/app-js/05.js`) so no existing part crosses the cap. Plan
+  covers a `tests/coverage/file_size_test.go` re-run after implementation.
+
+**Canonical Path Audit (Principle XIII)**:
+
+- Canonical owner/path for touched behaviour:
+  - `render/assets/app-js/00.js` already owns `CHARTS` registry,
+    `mountResetZoomButton`, `mountLegend`, `basePlotOpts`. The new shared
+    zoom store, the `setScale` broadcast hook, and the windowed-stats helper
+    extend that owner.
+  - `render/assets/app-js/05.js` is added as a new ordered part containing
+    the shared zoom store + `computeWindowedStats` helper. It is not a
+    parallel implementation; it is the new canonical home for behaviour that
+    didn't exist before.
+- Replaced or retired paths:
+  - The per-chart reset-zoom click handler (currently calls
+    `p.setScale("x", …)` on a single plot) is replaced in-place to publish
+    through the shared zoom store. Old single-chart reset path is deleted in
+    the same change.
+  - `mountLegend`'s signature gains a stats-source parameter and a returned
+    `setLegendStats` callback. Every call site (`00.js` mountLegend internal
+    refs, `01.js` line+stacked builders, vmstat tab rebuild in `03.js`) is
+    updated in the same commit; no compat shim, no overload. Tests grep the
+    embedded JS to assert no caller passes the old 4-arg form.
+  - `registerChart` now takes an additional optional `data` payload (so the
+    store subscriber can recompute legend stats and the shared store can ask
+    each chart for its data extent on reset). All current call sites pass
+    the payload; no two-form variant remains.
+- External degradation paths:
+  - Charts whose data window is narrower than the broadcast window paint
+    empty plot regions for the out-of-data portion. Observable to the
+    reader, covered by the dedicated edge-case test. Routed through the
+    canonical store — no per-chart "fallback" code path.
+  - The HLL sparkline preserves its existing decision not to call
+    `registerChart`. That is the canonical opt-out; no separate `synced:
+    false` flag is introduced.
+- Review check: reviewers verify (a) only one shared zoom store exists in the
+  embedded JS (grep `__chartSyncStore`), (b) only one `mountLegend` signature
+  exists with all call sites updated (grep call-site count), (c) no parallel
+  "non-synced" reset path remains (grep `setScale("x"` outside the store),
+  and (d) the HLL sparkline carve-out is preserved (grep the comment +
+  absence of `registerChart` in `renderHLLSparkline`).
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/017-chart-zoom-sync-stats/
+├── plan.md                          # this file
+├── spec.md                          # feature spec
+├── research.md                      # Phase 0 output
+├── quickstart.md                    # Phase 1 output
+├── contracts/
+│   └── chart-sync.md                # store API + legend stats contract
+├── checklists/
+│   └── requirements.md              # spec quality checklist
+└── tasks.md                         # Phase 2 output (created by /speckit.tasks)
+```
+
+### Source Code (repository root)
+
+```text
+render/
+├── assets.go                        # already concatenates app-js/* in lexical order
+├── assets/
+│   └── app-js/
+│       ├── 00.js                    # extend: registerChart signature, mountResetZoomButton broadcast, mountLegend signature
+│       ├── 01.js                    # update: pass data + un-stacked raw to mountLegend, register with data
+│       ├── 02.js                    # update: pass data to registerChart + mountLegend (mysqladmin chart)
+│       ├── 03.js                    # update: vmstat tab rebuild path, preserve HLL sparkline carve-out
+│       ├── 04.js                    # unchanged
+│       └── 05.js                    # NEW: shared zoom store + computeWindowedStats helper + legend stats renderer
+└── assets_test.go                   # extend: grep markers for store + windowed-stats + signature change
+
+tests/coverage/
+└── file_size_test.go                # already enforces XV; re-runs in CI/pre-push
+```
+
+**Structure Decision**: extend the existing `render/assets/app-js/` part scheme.
+Add one new ordered part (`05.js`) for the shared store + stats helpers; modify
+the existing parts in-place to use the new APIs. No new Go packages, no new
+directories.
+
+## Complexity Tracking
+
+> No constitution violations to justify. Adding `05.js` is mandated by gate 9
+> (file-size cap), not a deviation.

--- a/specs/017-chart-zoom-sync-stats/quickstart.md
+++ b/specs/017-chart-zoom-sync-stats/quickstart.md
@@ -1,0 +1,35 @@
+# Quickstart: Synchronized Chart Zoom + Per-Window Legend Stats
+
+## Build and validate
+
+```bash
+# from the repo root
+go build ./...
+go test ./...
+make lint
+bash scripts/hooks/pre-push-constitution-guard.sh
+```
+
+## Manual verification
+
+1. Build the binary: `go build ./cmd/my-gather`.
+2. Run it against any pt-stalk fixture: `./my-gather -in testdata/<fixture> -out /tmp/report.html`.
+3. Open `/tmp/report.html` in a browser.
+4. Drag-zoom the x-axis on any time-series chart. Confirm every other
+   time-series chart on the page updates to the same window.
+5. Expand a previously-collapsed `<details>` section that contains a chart;
+   confirm the chart already shows the zoomed window.
+6. Click the `⛶` reset-zoom button on any chart. Confirm every chart resets to
+   its full data extent.
+7. Check the legend pills under each chart: each pill displays Min, Max, and
+   Avg per series. Zoom in to a sub-range and confirm the values recompute.
+8. Confirm the InnoDB HLL sparkline does NOT change when other charts are
+   zoomed (it intentionally opts out of sync).
+
+## Re-run determinism
+
+```bash
+./my-gather -in testdata/<fixture> -out /tmp/a.html
+./my-gather -in testdata/<fixture> -out /tmp/b.html
+diff -u /tmp/a.html /tmp/b.html   # must be empty
+```

--- a/specs/017-chart-zoom-sync-stats/research.md
+++ b/specs/017-chart-zoom-sync-stats/research.md
@@ -1,0 +1,121 @@
+# Research: Synchronized Chart Zoom + Per-Window Legend Stats
+
+## Existing chart layer landmarks
+
+- `render/assets/app-js/00.js`
+  - `CHARTS = []` registry; `registerChart(plot, containerEl, options)` and
+    `unregisterChart(plot)`. Each entry is `{plot, el, opts}`.
+  - `resizeAllCharts()` already iterates the registry and skips entries whose
+    container is detached or has zero width — proves a registry-walk pattern is
+    the canonical way to act on every chart at once.
+  - `basePlotOpts` builds uPlot config; cursor is `drag.x = true`,
+    `setScale: true`, `uni: 15`; double-click resets the x-zoom (uPlot built-in).
+  - `mountResetZoomButton(containerEl, getPlot)` attaches a `⛶` button that
+    resets a single chart by calling `p.setScale("x", { min: xs[0], max: xs[xs.length-1] })`.
+  - `mountLegend(containerEl, series, plot, opts)` builds the per-chart pill
+    legend; today it shows series swatch + label only — no stats.
+- `render/assets/app-js/01.js`
+  - `buildLineChart(el, data, unit)` constructs a multi-line uPlot, calls
+    `registerChart(plot, el, opts)`, then `mountLegend(el, series, plot)`.
+  - `buildStackedChart(el, data, unit, hiddenLabels, onRebuild)` builds the
+    stacked-bar variant. Stores per-series un-stacked raw values on
+    `plot.__rawData` (used today by the tooltip). Cumulative values live in
+    `plotData`, which uPlot draws.
+- `render/assets/app-js/03.js`
+  - vmstat tab path destroys + re-mounts a chart and the legend on tab change;
+    must keep working with the new mountLegend signature.
+  - `renderHLLSparkline` deliberately does NOT call `registerChart` (existing
+    comment: "Do NOT registerChart — sparkline follows its own container and
+    should not participate in global reset-zoom flows"). This is the canonical
+    way to opt a chart out of sync; preserved without modification.
+- `render/assets.go` concatenates `app-js/*.js` in lexical order at build time
+  via `embed`. Adding `05.js` slots cleanly after `04.js`.
+
+## Why a new ordered part (05.js)
+
+`wc -l render/assets/app-js/*.js` on `main` shows 00–03 are 892–899 lines and
+04.js is 490. Principle XV caps governed source files at 1000 lines and is
+mechanically enforced by `tests/coverage/file_size_test.go`. Adding ~100–200
+lines of zoom-store + stats logic to any of 00–03 would put that file over the
+cap. 05.js is the canonical home for the new behaviour and keeps every file
+under the limit.
+
+## Chart sync mechanics (what uPlot supports)
+
+- uPlot fires `setScale` hooks any time a scale changes, including from
+  user-initiated drag-zoom. The hook receives `(u, scaleKey)`. Reading
+  `u.scales.x.min` / `u.scales.x.max` after the hook gives the current window.
+- Calling `chart.setScale("x", {min, max})` on a chart whose container is
+  hidden (e.g., inside a closed `<details>`) is safe: uPlot stores the new
+  scale and applies it on next paint when the container becomes visible.
+  Verified by inspection of `resizeAllCharts`'s skip-if-zero-width logic — the
+  same charts handle late re-paints correctly.
+- Re-entrancy: the broadcaster MUST guard against the cycle "chart A's user
+  zoom → store update → setScale on chart B → chart B's setScale hook fires →
+  store update → setScale on chart A". A monotonic generation counter is the
+  smallest robust guard: each broadcast bumps the generation; chart hooks
+  ignore setScale events whose source is the current broadcast generation.
+  Concretely the broadcaster tags itself as the source by setting a flag
+  before calling `setScale` on each chart and clearing it after; chart hooks
+  skip when the flag is set.
+
+## Windowed stats mechanics
+
+- Each registered chart's data is `{timestamps[], series[{label, values[]}]}`.
+- For a window `[lo, hi]`, find the index range `[i0, i1]` via binary search on
+  `timestamps`. For each series, scan `values[i0..i1]`, ignoring `null`/`NaN`,
+  to compute `min`, `max`, `sum`, `count`. `avg = sum / count` if `count > 0`.
+- Stacked charts: stats source is the un-stacked per-series raw values
+  (already cached on `plot.__rawData[idx]` for the tooltip). The cumulative
+  `plotData` would lie about per-series Min/Max/Avg.
+- Empty window for a series (count == 0): legend shows `–` for all three.
+
+## Legend display
+
+- Pill content today: `<span class="swatch"></span><span class="lbl">label</span>`.
+- New: append `<span class="stats">min · avg · max</span>` to each pill. CSS
+  lives in `render/assets/app-css/03.css` (which currently has the most slack;
+  701/1000 lines).
+- Numeric formatting: reuse the existing `formatYTick` helper (in 00.js) so
+  pill stats render in the same scale (`1.2M`, `300`, `99.9 %`) as the y-axis
+  ticks.
+
+## Test pattern
+
+`render/assets_test.go::TestFeedbackWorkerClientContract` greps `embeddedAppJS`
+for required and forbidden substrings. New tests follow the same shape:
+
+- Required markers (must be present): `__chartSyncStore`,
+  `chartSyncStore.subscribe`, `chartSyncStore.broadcast`,
+  `computeWindowedStats`, `setLegendStats`.
+- Forbidden markers (must be absent): the old single-chart reset pattern that
+  doesn't go through the store, any second copy of `mountLegend` with the old
+  3-arg signature, any "synced:false" feature flag.
+
+## Determinism check
+
+The new behaviour is entirely client-side. Rendered HTML changes only because
+each legend pill now contains a `<span class="stats">` element computed from
+the embedded `data` payload. Both runs of `my-gather` against the same input
+produce the same payload, so the same HTML — byte-identical determinism is
+preserved.
+
+## Decisions
+
+1. Shared store lives on `window.__chartSyncStore`, defined in `05.js`. Single
+   instance per page, no module system in this codebase.
+2. Re-entrancy guard: an `_isBroadcasting` boolean toggled by the broadcaster
+   around each `setScale` call.
+3. `registerChart` is extended with an optional `data` argument:
+   `registerChart(plot, el, opts, data)`. All current call sites updated in
+   the same commit. `data` is `{timestamps, series, rawSeries?}` where
+   `rawSeries` is provided for stacked charts (un-stacked raw values).
+4. `mountLegend` is extended with an optional `statsSource` argument and
+   returns `{setStats}`. The store subscriber calls `setStats(window)` for
+   every chart on every window change. All current call sites updated.
+5. Reset-zoom button on any chart calls `chartSyncStore.reset()`, which
+   iterates the registry and resets each chart to its own data extent, then
+   sets the store window to `null` (= no synced zoom).
+6. Legend stat formatter reuses `formatYTick` from 00.js.
+7. The HLL sparkline carve-out is preserved by not calling `registerChart` —
+   no new opt-out mechanism is added.

--- a/specs/017-chart-zoom-sync-stats/spec.md
+++ b/specs/017-chart-zoom-sync-stats/spec.md
@@ -1,0 +1,206 @@
+# Feature Specification: Synchronized Chart Zoom + Per-Window Legend Stats
+
+**Feature Branch**: `017-chart-zoom-sync-stats`
+**Created**: 2026-05-07
+**Status**: Ready for planning
+**Input**: User description: bundle GitHub issues #52 (synchronized x-axis zoom across all
+charts) and #51 (per-series Min/Max/Avg in each chart's legend, computed over the
+visible time window) into one feature because they share the same chart-layer surgery.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Zooming One Chart Zooms Every Chart (Priority: P1)
+
+A support engineer reading a report wants to focus on a specific time window. They
+drag-zoom on any one chart. Every other chart on the page snaps to the same time
+window so the engineer can correlate behaviour across collectors without zooming
+each chart individually. Charts inside currently-collapsed sections also adopt the
+new window so when the engineer expands them later, they already match.
+
+**Why this priority**: This is the primary value of the feature. Without sync,
+correlating spikes across charts requires manual zoom on each one.
+
+**Independent Test**: Open a report with at least two registered time-series charts
+in different sections. Drag-zoom chart A to a sub-range. Verify chart B's x-axis
+matches the same range. Collapse a section, zoom on a still-visible chart, expand
+the collapsed section, verify the chart in it now shows the zoomed window.
+
+**Acceptance Scenarios**:
+
+1. **Given** a report with multiple registered charts, **When** the user drag-zooms on
+   any chart's x-axis, **Then** every other registered chart updates its x-axis to
+   the exact same `{min, max}` window.
+2. **Given** a chart inside a collapsed `<details>` section, **When** the user
+   zooms a visible chart and then expands the collapsed section, **Then** the
+   newly-revealed chart already shows the zoomed window with no extra interaction.
+3. **Given** any registered chart is zoomed, **When** the user clicks the
+   reset-zoom button on any chart, **Then** every registered chart resets to its
+   own data's full extent and re-broadcasts the unzoomed state.
+4. **Given** the HLL sparkline (intentionally not registered), **When** any other
+   chart is zoomed, **Then** the sparkline does not change — the carve-out is
+   preserved.
+
+---
+
+### User Story 2 - Legend Shows Stats For The Visible Window (Priority: P1)
+
+The same engineer wants to know the Min, Max, and Avg of each series for the
+window they are currently looking at, not for the full capture. Each legend pill
+displays per-series Min, Max, and Avg computed over the visible window only.
+Whenever the window changes (zoom in, zoom out, pan, reset, or sync from another
+chart), the values recompute.
+
+**Why this priority**: Without windowed stats, legend numbers either lie about
+the visible window or are absent entirely; the engineer falls back to mental
+arithmetic on the chart's pixels.
+
+**Independent Test**: For each chart, the legend pill for each series shows three
+numeric stats (Min, Max, Avg). Drag-zoom to a sub-range that excludes the
+historical maximum and verify the displayed Max drops to the new window's
+maximum. Reset zoom and verify the values return to the full-capture stats.
+
+**Acceptance Scenarios**:
+
+1. **Given** any chart with at least one numeric series, **When** the chart
+   renders, **Then** each series' legend pill displays its Min, Max, and Avg
+   computed over the full data window.
+2. **Given** the user zooms or pans, **When** the visible x-window changes,
+   **Then** every visible chart's legend pill re-renders Min/Max/Avg using only
+   the samples whose timestamps fall inside the new window.
+3. **Given** a stacked chart (e.g., processlist by state), **When** the legend
+   stats render, **Then** the values come from the per-series un-stacked raw
+   samples, not from the cumulative stacked values that uPlot draws.
+4. **Given** a window that contains no non-null samples for some series,
+   **When** the legend stats render for that series, **Then** the pill shows a
+   neutral placeholder (`–`) for Min, Max, and Avg without breaking layout.
+
+---
+
+### Edge Cases
+
+- A chart whose data range is narrower than the broadcast window (sparse
+  collector, late-starting capture) accepts the broadcast window unchanged and
+  paints empty plot regions outside its data — this is the desired behaviour and
+  surfaces the gap to the reader.
+- The reset-zoom button broadcasts `{null, null}` semantics by reverting every
+  chart to its own data extent; sync remains in effect after reset (a subsequent
+  zoom on any chart still propagates).
+- Panning (uPlot supports drag-pan when configured) is treated identically to
+  zoom — both produce a new `{min, max}` window and broadcast through the same
+  store.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: All registered time-series charts MUST share a single in-memory
+  shared store that holds the current `{min, max}` x-axis window.
+- **FR-002**: Any registered chart's x-axis change (drag-zoom, drag-pan, or
+  reset) MUST publish the new `{min, max}` to the shared store.
+- **FR-003**: When the shared store updates, every registered chart MUST apply
+  the new `{min, max}` to its x-scale, including charts inside collapsed
+  sections.
+- **FR-004**: Newly registered charts MUST adopt the current shared-store window
+  on registration so a chart that mounts after a zoom event still matches.
+- **FR-005**: The reset-zoom button MUST reset every registered chart to its own
+  data extent and republish so the shared store reflects "unzoomed" state.
+- **FR-006**: The broadcaster MUST be re-entrancy-safe — applying a window to
+  chart B's x-scale MUST NOT trigger a second broadcast that re-applies to
+  chart A.
+- **FR-007**: Each chart's legend MUST display per-series Min, Max, and Avg
+  computed over the currently-visible x-window.
+- **FR-008**: Every shared-store window change MUST trigger recomputation of
+  every visible chart's legend stats.
+- **FR-009**: Stacked-chart legend stats MUST be computed from the per-series
+  un-stacked raw values, not from cumulative stacked values.
+- **FR-010**: A series with no non-null samples in the visible window MUST
+  display a neutral placeholder (`–`) for Min, Max, and Avg.
+- **FR-011**: The HLL sparkline (which intentionally does not register with the
+  chart registry) MUST NOT participate in zoom sync and MUST NOT receive
+  windowed stats — it has no legend pills.
+- **FR-012**: Component-level tests MUST cover: (a) the zoom-sync event flow
+  (zoom on chart A → store updates → chart B applies the new window) and
+  (b) the windowed-stats recomputation (legend values change when the shared
+  window changes).
+- **FR-013**: No governed first-party source file may exceed 1000 lines after
+  the change (Principle XV).
+- **FR-014**: Output MUST remain byte-identical between two runs on the same
+  input (Principle IV) — sync state is window-local at view time and MUST NOT
+  leak into rendered HTML.
+
+### Canonical Path Expectations *(include when changing existing behavior)*
+
+- **Canonical owner/path**: `render/assets/app-js/00.js` already owns the
+  `CHARTS` registry, `mountResetZoomButton`, and `mountLegend`. The new shared
+  store, the `setScale`-broadcast hook, and the windowed-stats helper extend
+  that owner. A new ordered part (`render/assets/app-js/05.js`) is added for the
+  shared store and stats helpers because every existing part is already within
+  ~100 lines of the 1000-line cap (Principle XV). Concatenation order is owned
+  by the embed step in `render/assets.go` and remains lexical/sorted, so the
+  new part loads after the existing ones.
+- **Old path treatment**: the per-chart reset-zoom click handler is replaced
+  in-place to publish through the shared store rather than calling
+  `p.setScale("x", …)` on a single plot; the old single-chart reset path is
+  deleted in the same change. `mountLegend`'s signature gains a stats-source
+  parameter; every call site (`00.js`, `01.js`, the vmstat tab rebuild path in
+  `03.js`) is updated in the same commit. No re-export shim, no internal flag,
+  no parallel "synced vs. unsynced" mode.
+- **External degradation**: charts whose data window is narrower than the
+  broadcast window paint empty regions for the out-of-data portion. This is
+  observable to the reader and tested.
+- **Review check**: reviewers verify (a) only one chart-sync store exists in
+  the JS, (b) only one `mountLegend` signature exists with all call sites
+  updated, (c) no parallel "non-synced" zoom code path remains, and (d) the
+  HLL-sparkline carve-out is preserved by the unchanged decision not to call
+  `registerChart` on it.
+
+### Key Entities
+
+- **Shared zoom store**: in-memory singleton owned by `app-js/05.js`, exposing
+  `getWindow()`, `setWindow({min, max})`, `subscribe(fn)`, and `reset()`. State
+  is `{min, max}` numeric timestamps (uPlot's x-scale unit) plus a generation
+  counter used by the re-entrancy guard.
+- **Windowed-stats record**: derived per series per render — `{min, max, avg, count}`
+  computed over samples whose timestamps fall inside `[storeMin, storeMax]`.
+- **Chart registry entry** (existing, extended): every entry already carries
+  `{plot, el, opts}`. The extension adds `data` (timestamps + per-series raw
+  values, including the un-stacked raw for stacked charts) and a
+  `setLegendStats` callback returned by `mountLegend` so the store's subscriber
+  can recompute and re-render that legend.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: With two or more time-series charts on the page, drag-zooming any
+  one chart updates every other registered chart to the same `{min, max}`
+  within one animation frame (no extra user clicks required).
+- **SC-002**: Each chart's legend shows three numeric stats (Min, Max, Avg) per
+  series; the values match a brute-force recomputation over the samples whose
+  timestamps fall inside the current `{min, max}`.
+- **SC-003**: Zooming a chart and then expanding a previously-collapsed section
+  containing another chart shows that chart already at the zoomed window with
+  no additional interaction.
+- **SC-004**: Clicking reset-zoom on any chart returns every chart to its full
+  data extent and the legend stats return to the full-capture values.
+- **SC-005**: `go test ./...` passes, including new tests that grep the
+  embedded JS for the canonical zoom-sync and windowed-stats markers.
+- **SC-006**: No first-party source file exceeds 1000 lines.
+- **SC-007**: Two consecutive `my-gather` runs on the same fixture produce
+  byte-identical HTML — sync state does not leak into the rendered output.
+
+## Assumptions
+
+- All time-series charts on a report share the same x-axis unit (Unix
+  timestamps from pt-stalk samples). Cross-collector mixing is already the
+  case on shipped reports.
+- Heterogeneous data ranges across charts are acceptable — when one chart's
+  data does not cover the broadcast window, painting an empty region is the
+  desired behaviour (it surfaces the gap to the reader).
+- The HLL sparkline's existing decision not to register with the chart
+  registry is preserved as the canonical way to opt out of sync; no separate
+  "is-synced" flag is introduced.
+- Tests for the zoom-sync flow and the windowed-stats recomputation are
+  written as Go tests that grep the embedded JS for canonical markers — that
+  is the existing pattern in `render/assets_test.go`; no JS test runner is
+  introduced.

--- a/specs/017-chart-zoom-sync-stats/tasks.md
+++ b/specs/017-chart-zoom-sync-stats/tasks.md
@@ -1,0 +1,147 @@
+# Tasks: Synchronized Chart Zoom + Per-Window Legend Stats
+
+**Feature**: 017-chart-zoom-sync-stats
+**Input**: [spec.md](./spec.md), [plan.md](./plan.md), [research.md](./research.md), [contracts/chart-sync.md](./contracts/chart-sync.md)
+
+Tasks below are dependency-ordered. Tasks marked `[P]` may run in parallel
+with other `[P]` tasks in the same numbered group.
+
+## Phase 0 — Pre-flight
+
+- **T001** Confirm branch is `017-chart-zoom-sync-stats` and worktree is clean
+  apart from the new `specs/017-chart-zoom-sync-stats/` directory and the
+  updated `.specify/feature.json`.
+
+## Phase 1 — Shared zoom store + windowed-stats helper (new file)
+
+- **T010** Create `render/assets/app-js/05.js` with:
+  - the `chartSyncStore` singleton bound to `window.__chartSyncStore`
+    implementing `getWindow`, `setWindow`, `reset`, `subscribe` per
+    `contracts/chart-sync.md`;
+  - the `computeWindowedStats(timestamps, series, win)` helper using binary
+    search to find the index range and a single linear scan per series;
+  - a `formatStat(v)` helper that delegates to `formatYTick` (defined in
+    `00.js`) for consistent number formatting;
+  - the store-subscriber wiring inside an IIFE that runs after `initCharts`
+    completes (registers a single `chartSyncStore.subscribe` callback that
+    walks the chart registry and calls each entry's
+    `entry.setLegendStats(win)` if present).
+
+## Phase 2 — Extend canonical owner (00.js)
+
+- **T020** In `render/assets/app-js/00.js`:
+  - extend `registerChart(plot, containerEl, options, data)` to accept and
+    store the optional `data` payload on the registry entry;
+  - inside `basePlotOpts`, add a `setScale` hook on the `x` scale that, when
+    `chartSyncStore.isBroadcasting` is false, reads `u.scales.x.min` /
+    `u.scales.x.max` and calls `chartSyncStore.setWindow({min, max}, u)`;
+  - update `mountResetZoomButton`'s click handler to call
+    `chartSyncStore.reset()` instead of `getPlot().setScale("x", …)`;
+  - extend `mountLegend(containerEl, series, plot, opts)` to:
+    - read `opts.statsSource` (`{timestamps, series}`),
+    - render a third `<span class="series-pill-stats">…</span>` element
+      inside each pill,
+    - return `{setStats(win), destroy()}`,
+    - store `setStats` on the registry entry as
+      `entry.setLegendStats = setStats` so the store subscriber finds it;
+  - on first call after `initCharts`, every entry's `setStats({min:null, max:null})`
+    is invoked once so the legend renders full-extent stats at first paint.
+
+## Phase 3 — Update call sites in the same commit (Principle XIII)
+
+- **T030** [P] In `render/assets/app-js/01.js`:
+  - `buildLineChart`: pass `data` to `registerChart(plot, el, opts, data)`;
+    pass `statsSource: { timestamps: data.timestamps, series: data.series }`
+    to `mountLegend`.
+  - `buildStackedChart`: build an un-stacked `rawSeries` (using `series` and
+    `tooltipRaw` already constructed) and pass it as `statsSource:
+    { timestamps: bucketed.timestamps, series: rawSeries }`.
+- **T031** [P] In `render/assets/app-js/02.js` (mysqladmin chart): pass
+  `data` to `registerChart` and `statsSource` to `mountLegend` for every
+  composed sub-chart.
+- **T032** [P] In `render/assets/app-js/03.js`:
+  - vmstat tab rebuild path: pass `data` to `registerChart` and
+    `statsSource` to `mountLegend` on every rebuild;
+  - on chart destruction, call the returned `legend.destroy()` to drop the
+    stats subscription before re-mounting.
+  - `renderHLLSparkline`: leave the deliberate non-registration as-is; this
+    is the canonical opt-out (covered by a unit-marker test below).
+
+## Phase 4 — Embed and styles
+
+- **T040** Confirm `render/assets.go` already concatenates `app-js/*.js` in
+  lexical order; if it relies on a hard-coded list, append `05.js`.
+- **T041** Add CSS for the new `.series-pill-stats` element to
+  `render/assets/app-css/03.css` (the part with the most slack). Style:
+  small monospace, `--fg-muted` colour, separated from the label by an
+  em-space.
+
+## Phase 5 — Tests (Go-side string-grep against embedded JS)
+
+- **T050** Extend `render/assets_test.go` with `TestChartZoomSyncContract`:
+  - assert `embeddedAppJS` contains `__chartSyncStore`,
+    `chartSyncStore.subscribe`, `chartSyncStore.setWindow`,
+    `chartSyncStore.reset`, `computeWindowedStats`, `series-pill-stats`,
+    `setStats(`;
+  - assert `embeddedAppJS` does NOT contain a `setScale("x"` call outside
+    `chartSyncStore` (canonical-path guard) — implementation places all
+    `setScale("x"` calls inside the store;
+  - assert `mountLegend(` is defined exactly once.
+- **T051** Extend `render/assets_test.go` with `TestVmstatLegendDestroyOnTabSwitch`:
+  - grep that the vmstat tab rebuild path in `03.js` calls `.destroy()` on
+    the legend handle before re-mounting (guards against subscription leaks).
+- **T052** Extend `render/assets_test.go` with `TestHLLSparklineExemptFromSync`:
+  - grep that `renderHLLSparkline` does not call `registerChart` (preserves
+    the canonical opt-out).
+- **T053** Extend the existing render integration test (or add a new one
+  under `render/`) that exercises the embed path and asserts `embeddedAppJS`
+  contains the marker comment from `05.js` (e.g. `// app-js/05.js — chart
+  sync store`), proving the new part is concatenated.
+
+## Phase 6 — Goldens + determinism
+
+- **T060** Run `go test ./...`. If any golden test fails because legend HTML
+  now contains the new `<span class="series-pill-stats">` element, regenerate
+  via the reviewed update step (`go test ./... -update` or the
+  feature-specific helper, whichever is canonical in this repo) and review
+  the diff before committing. Document the regeneration in the commit
+  message.
+- **T061** Re-run `go test ./...` and confirm the determinism job (CI's
+  `diff -u` between two report runs) still passes locally:
+  `go test ./tests/... -run Determinism` (or whatever the canonical name is
+  in this repo).
+
+## Phase 7 — Constitution gates
+
+- **T070** Run `bash scripts/hooks/pre-push-constitution-guard.sh` against
+  the staged change set.
+- **T071** Run `go test ./tests/coverage/... -run TestFileSize` to confirm no
+  governed source file exceeds 1000 lines.
+- **T072** Run `go test ./tests/coverage/... -run TestGodocCoverage` (no new
+  Go exports are added; the test is a regression sanity check).
+
+## Phase 8 — Documentation pointers
+
+- **T080** Update `CLAUDE.md`, `AGENTS.md`, and `.specify/feature.json` so
+  the active feature reads `017-chart-zoom-sync-stats`. Add the prior
+  `015-compliance-closure` entry to the historical-features list.
+
+## Phase 9 — Commit, push, PR
+
+- **T090** Commit on branch `017-chart-zoom-sync-stats`. Include in the
+  commit body the canonical-path summary and a reference to issues
+  `#52` and `#51`.
+- **T091** Push the branch.
+- **T092** Open the PR with
+  `gh pr create --title "Synchronized chart zoom + per-window legend stats (#52, #51)" --body …`.
+
+## Dependency notes
+
+- T020 depends on T010 (the store must exist before the hook can call it).
+- T030 / T031 / T032 depend on T020 (the new `mountLegend` signature must
+  exist before call sites switch to it).
+- T050 / T051 / T052 / T053 depend on the JS implementation being in place.
+- T060 depends on T050 to make sure regeneration only updates legend-HTML
+  drift, not unrelated drift.
+- T070–T072 are the merge gates; they depend on every JS + Go change being
+  staged.


### PR DESCRIPTION
## Summary

Bundles GitHub issues #52 (synchronized x-axis zoom across every chart in a report) and #51 (per-series Min/Max/Avg in each chart's legend, computed over the visible window) into one feature because they share the same chart-layer surgery.

- **Synchronized zoom (#52)** — drag-zoom, drag-pan, or reset on any chart updates every other registered chart on the page (including charts inside currently-collapsed `<details>` sections) to the same `{min, max}` window. State lives in a single in-memory `chartSyncStore` (not in the DOM), so a chart that mounts after a zoom adopts the current window via `applyToChart` on registration.
- **Windowed legend stats (#51)** — every legend pill grows a `min · avg · max` element that recomputes on every store update from the per-series un-bucketed source samples. Stacked charts compute stats from the un-stacked raw values, not the cumulative `stacked[]` arrays uPlot draws.
- **Canonical-code (Principle XIII)** — new logic lands in one new ordered embedded JS part (`render/assets/app-js/05.js`) so 00.js stays under the 1000-line cap (Principle XV). The IIFE that wraps the embedded JS now closes at the bottom of 05.js. Reset-zoom buttons (00.js global ⛶ and 02.js mysqladmin per-card ⛶) route through `chartSyncStore.reset()`, eliminating the parallel single-chart reset path. The HLL sparkline keeps its existing decision not to call `registerChart` — that is the canonical opt-out from sync; a test guards the carve-out.

Closes #52, closes #51.

## Test plan

- [x] `go test ./...` passes (including new `TestChartZoomSyncContract`, `TestChartSyncWindowedStatsFlow`, `TestHLLSparklineExemptFromSync`, `TestEmbeddedAppJSHasIIFEClosed`).
- [x] `make lint` passes.
- [x] `bash scripts/hooks/pre-push-constitution-guard.sh` passes (Principles I, II, VI, VIII, IX, X, XIV; XV via `tests/coverage/file_size_test.go`).
- [x] Two consecutive `my-gather` runs against `testdata/example2` produce byte-identical HTML (Principle IV).
- [ ] Manual: drag-zoom one chart, every other chart updates; expand a previously-collapsed section, the chart inside already shows the zoomed window; click reset, every chart returns to its full extent and legend stats return to full-capture values.

🤖 Generated with [Claude Code](https://claude.com/claude-code)