### PR TITLE
Required Author field on Report Feedback (#56)

### DIFF
--- a/.specify/feature.json
+++ b/.specify/feature.json
@@ -1,3 +1,3 @@
 {
-  "feature_directory": "specs/015-compliance-closure"
+  "feature_directory": "specs/021-feedback-author-field"
 }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,18 +1,19 @@
 <!-- SPECKIT START -->
-Active feature: **015-compliance-closure**
+Active feature: **021-feedback-author-field**
 
 For technologies, project structure, constitution gates, data model,
 contracts, and shell commands, read the current plan:
 
-- Plan: `specs/015-compliance-closure/plan.md`
-- Spec: `specs/015-compliance-closure/spec.md`
-- Research: `specs/015-compliance-closure/research.md`
-- Contracts: `specs/015-compliance-closure/contracts/audit.md`
-- Quickstart: `specs/015-compliance-closure/quickstart.md`
-- Tasks: `specs/015-compliance-closure/tasks.md`
+- Plan: `specs/021-feedback-author-field/plan.md`
+- Spec: `specs/021-feedback-author-field/spec.md`
+- Research: `specs/021-feedback-author-field/research.md`
+- Contracts: `specs/021-feedback-author-field/contracts/author-field.md`
+- Quickstart: `specs/021-feedback-author-field/quickstart.md`
+- Tasks: `specs/021-feedback-author-field/tasks.md`
 - Constitution: `.specify/memory/constitution.md`
 
 Prior features:
+- **015-compliance-closure** - `specs/015-compliance-closure/plan.md`
 - **014-reconciliation-cleanup** - `specs/014-reconciliation-cleanup/plan.md`
 - **013-full-compliance-fixes** - `specs/013-full-compliance-fixes/plan.md`
 - **012-repo-alignment-audit** - `specs/012-repo-alignment-audit/plan.md`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,18 +1,19 @@
 <!-- SPECKIT START -->
-Active feature: **015-compliance-closure**
+Active feature: **021-feedback-author-field**
 
 For technologies, project structure, constitution gates, data model,
 contracts, and shell commands, read the current plan:
 
-- Plan: `specs/015-compliance-closure/plan.md`
-- Spec: `specs/015-compliance-closure/spec.md`
-- Research: `specs/015-compliance-closure/research.md`
-- Contracts: `specs/015-compliance-closure/contracts/audit.md`
-- Quickstart: `specs/015-compliance-closure/quickstart.md`
-- Tasks: `specs/015-compliance-closure/tasks.md`
+- Plan: `specs/021-feedback-author-field/plan.md`
+- Spec: `specs/021-feedback-author-field/spec.md`
+- Research: `specs/021-feedback-author-field/research.md`
+- Contracts: `specs/021-feedback-author-field/contracts/author-field.md`
+- Quickstart: `specs/021-feedback-author-field/quickstart.md`
+- Tasks: `specs/021-feedback-author-field/tasks.md`
 - Constitution: `.specify/memory/constitution.md`
 
 Prior features:
+- **015-compliance-closure** - `specs/015-compliance-closure/plan.md`
 - **014-reconciliation-cleanup** - `specs/014-reconciliation-cleanup/plan.md`
 - **013-full-compliance-fixes** - `specs/013-full-compliance-fixes/plan.md`
 - **012-repo-alignment-audit** - `specs/012-repo-alignment-audit/plan.md`

--- a/feedback-worker/src/body.ts
+++ b/feedback-worker/src/body.ts
@@ -14,6 +14,12 @@ export function buildIssueBody(input: BuildIssueBodyInput): string {
   const { payload, imageUrl, voiceUrl } = input;
   const parts: string[] = [];
 
+  // Spec 021-feedback-author-field: triagers need to know who
+  // reported the issue. Author is a required validated field, so
+  // this line is always present and always first.
+  parts.push(`Submitted by: ${payload.author}`);
+  parts.push("");
+
   if (payload.category) {
     parts.push(`> Category: ${payload.category}`);
     parts.push("");

--- a/feedback-worker/src/feedback-contract.ts
+++ b/feedback-worker/src/feedback-contract.ts
@@ -13,6 +13,7 @@ interface FeedbackContract {
     legacyUrlMaxChars: number;
     workerTimeoutMs: number;
     requestMaxBytes: number;
+    authorMaxChars: number;
   };
 }
 

--- a/feedback-worker/src/validate.ts
+++ b/feedback-worker/src/validate.ts
@@ -17,6 +17,7 @@ export interface ValidatedVoice {
 
 export interface ValidatedPayload {
   title: string;
+  author: string;
   body: string;
   category?: Category;
   image?: ValidatedImage;
@@ -29,6 +30,8 @@ export type ValidationError =
   | "malformed_payload"
   | "title_required"
   | "title_too_long"
+  | "author_required"
+  | "author_too_long"
   | "body_too_long"
   | "category_invalid"
   | "image_bad_mime"
@@ -123,6 +126,21 @@ export function validatePayload(raw: unknown): ValidationResult {
     return fail("title_too_long", `Title exceeds ${feedbackContract.limits.titleMaxChars} characters.`);
   }
 
+  // Author (required, trimmed, length-capped). Spec
+  // 021-feedback-author-field FR-008: rejected with the same 400
+  // shape used for the existing required fields.
+  const authorRaw = raw["author"];
+  if (typeof authorRaw !== "string") {
+    return fail("author_required", "Author is required.");
+  }
+  const author = authorRaw.trim();
+  if (author.length === 0) {
+    return fail("author_required", "Author is required.");
+  }
+  if (author.length > feedbackContract.limits.authorMaxChars) {
+    return fail("author_too_long", `Author exceeds ${feedbackContract.limits.authorMaxChars} characters.`);
+  }
+
   // Body (may be empty).
   const bodyRaw = raw["body"];
   let body = "";
@@ -184,6 +202,7 @@ export function validatePayload(raw: unknown): ValidationResult {
     ok: true,
     data: {
       title,
+      author,
       body,
       category,
       image,

--- a/feedback-worker/test/body.test.ts
+++ b/feedback-worker/test/body.test.ts
@@ -6,6 +6,7 @@ import type { ValidatedPayload } from "../src/validate";
 function mkPayload(overrides: Partial<ValidatedPayload> = {}): ValidatedPayload {
   return {
     title: "Anything",
+    author: "Jane Doe",
     body: "A short description of the problem.",
     idempotencyKey: "550e8400-e29b-41d4-a716-446655440000",
     reportVersion: "0.3.1-54-g29734aa",
@@ -14,20 +15,24 @@ function mkPayload(overrides: Partial<ValidatedPayload> = {}): ValidatedPayload 
 }
 
 describe("buildIssueBody", () => {
-  it("renders just the body + footer when no attachments and no category", () => {
+  it("renders attribution + body + footer when no attachments and no category", () => {
     const out = buildIssueBody({ payload: mkPayload() });
     expect(out).toMatchInlineSnapshot(`
-      "A short description of the problem.
+      "Submitted by: Jane Doe
+
+      A short description of the problem.
 
       ---
       _Submitted via my-gather Report Feedback (v0.3.1-54-g29734aa)._"
     `);
   });
 
-  it("prepends the category blockquote when set", () => {
+  it("places attribution before the category blockquote when category is set", () => {
     const out = buildIssueBody({ payload: mkPayload({ category: "UI" }) });
     expect(out).toMatchInlineSnapshot(`
-      "> Category: UI
+      "Submitted by: Jane Doe
+
+      > Category: UI
 
       A short description of the problem.
 
@@ -42,7 +47,9 @@ describe("buildIssueBody", () => {
       imageUrl: "https://assets.test/attachments/abc.png",
     });
     expect(out).toMatchInlineSnapshot(`
-      "A short description of the problem.
+      "Submitted by: Jane Doe
+
+      A short description of the problem.
 
       ### Attached screenshot
 
@@ -59,7 +66,9 @@ describe("buildIssueBody", () => {
       voiceUrl: "https://assets.test/attachments/def.webm",
     });
     expect(out).toMatchInlineSnapshot(`
-      "A short description of the problem.
+      "Submitted by: Jane Doe
+
+      A short description of the problem.
 
       ### Attached voice note
 
@@ -70,14 +79,16 @@ describe("buildIssueBody", () => {
     `);
   });
 
-  it("orders category, body, screenshot, voice, footer", () => {
+  it("orders attribution, category, body, screenshot, voice, footer", () => {
     const out = buildIssueBody({
       payload: mkPayload({ category: "Parser" }),
       imageUrl: "https://assets.test/attachments/abc.png",
       voiceUrl: "https://assets.test/attachments/def.webm",
     });
     expect(out).toMatchInlineSnapshot(`
-      "> Category: Parser
+      "Submitted by: Jane Doe
+
+      > Category: Parser
 
       A short description of the problem.
 
@@ -92,5 +103,11 @@ describe("buildIssueBody", () => {
       ---
       _Submitted via my-gather Report Feedback (v0.3.1-54-g29734aa)._"
     `);
+  });
+
+  it("uses the validated author verbatim in the attribution line", () => {
+    const out = buildIssueBody({ payload: mkPayload({ author: "Alex (Triage)" }) });
+    expect(out.split("\n")[0]).toBe("Submitted by: Alex (Triage)");
+    expect(out.split("\n")[1]).toBe("");
   });
 });

--- a/feedback-worker/test/index.test.ts
+++ b/feedback-worker/test/index.test.ts
@@ -92,6 +92,7 @@ function feedbackRequest(
     },
     body: JSON.stringify({
       title: "Parser feedback",
+      author: "Test Author",
       body: "Please inspect this sample.",
       image: {
         mime: "image/png",
@@ -118,6 +119,7 @@ function minimalFeedbackRequest(idempotencyKey: string): Request {
     },
     body: JSON.stringify({
       title: "Parser feedback",
+      author: "Test Author",
       body: "Please inspect this sample.",
       idempotencyKey,
       reportVersion: "v0.3.1-test",

--- a/feedback-worker/test/validate.test.ts
+++ b/feedback-worker/test/validate.test.ts
@@ -23,6 +23,7 @@ function bigBase64(size: number): string {
 function goodPayload(overrides: Record<string, unknown> = {}): Record<string, unknown> {
   return {
     title: "A sensible title",
+    author: "Jane Doe",
     body: "Some body text",
     idempotencyKey: UUID,
     reportVersion: "v0.3.1-54-g29734aa",
@@ -219,5 +220,47 @@ describe("validatePayload", () => {
     const res = validatePayload(goodPayload({ reportVersion: "x".repeat(limits.reportVersionMaxChars + 1) }));
     expect(res.ok).toBe(false);
     if (!res.ok) expect(res.error).toBe("report_version_invalid");
+  });
+
+  // Spec 021-feedback-author-field FR-008: Author is a required,
+  // trimmed, length-capped string. Missing / non-string / empty /
+  // whitespace-only values are rejected as author_required;
+  // over-cap values as author_too_long. The validated payload
+  // carries the trimmed value.
+  it("rejects missing author as author_required", () => {
+    const res = validatePayload(goodPayload({ author: undefined }));
+    expect(res.ok).toBe(false);
+    if (!res.ok) expect(res.error).toBe("author_required");
+  });
+
+  it("rejects non-string author as author_required", () => {
+    const res = validatePayload(goodPayload({ author: 42 }));
+    expect(res.ok).toBe(false);
+    if (!res.ok) expect(res.error).toBe("author_required");
+  });
+
+  it("rejects empty author as author_required", () => {
+    const res = validatePayload(goodPayload({ author: "" }));
+    expect(res.ok).toBe(false);
+    if (!res.ok) expect(res.error).toBe("author_required");
+  });
+
+  it("rejects whitespace-only author as author_required", () => {
+    const res = validatePayload(goodPayload({ author: "   \t\n" }));
+    expect(res.ok).toBe(false);
+    if (!res.ok) expect(res.error).toBe("author_required");
+  });
+
+  it("rejects author longer than the canonical cap as author_too_long", () => {
+    const res = validatePayload(goodPayload({ author: "x".repeat(limits.authorMaxChars + 1) }));
+    expect(res.ok).toBe(false);
+    if (!res.ok) expect(res.error).toBe("author_too_long");
+  });
+
+  it("accepts an author at the canonical cap and trims surrounding whitespace", () => {
+    const padded = "  " + "x".repeat(limits.authorMaxChars) + "  ";
+    const res = validatePayload(goodPayload({ author: padded }));
+    expect(res.ok).toBe(true);
+    if (res.ok) expect(res.data.author).toBe("x".repeat(limits.authorMaxChars));
   });
 });

--- a/render/assets/app-css/03.css
+++ b/render/assets/app-css/03.css
@@ -554,6 +554,12 @@ dd.env-meter:has(.sev-crit) .env-meter-pct { color: var(--err); }
   font-size: 10px; font-weight: 400; color: var(--fg-dim, var(--fg-muted));
   text-transform: none; letter-spacing: 0; margin-left: 4px; opacity: 0.7;
 }
+.feedback-field-req {
+  font-size: 10px; font-weight: 600;
+  color: var(--accent, var(--fg-muted));
+  text-transform: uppercase; letter-spacing: 0.04em;
+  margin-left: 4px;
+}
 
 .feedback-dialog input[type="text"],
 .feedback-dialog textarea,

--- a/render/assets/app-js/03.js
+++ b/render/assets/app-js/03.js
@@ -633,6 +633,14 @@
             typeof limits.reportVersionMaxChars !== "number" ||
             typeof limits.legacyUrlMaxChars !== "number" ||
             typeof limits.workerTimeoutMs !== "number") return null;
+        // Spec 021-feedback-author-field FR-009: authorMaxChars is a
+        // single-source contract limit; reject contracts that omit
+        // it or carry a non-positive integer so the Submit gate
+        // never silently degrades to "no cap" via NaN comparisons.
+        if (typeof limits.authorMaxChars !== "number" ||
+            !isFinite(limits.authorMaxChars) ||
+            Math.floor(limits.authorMaxChars) !== limits.authorMaxChars ||
+            limits.authorMaxChars <= 0) return null;
         return contract;
       } catch (_) {
         return null;

--- a/render/assets/app-js/03.js
+++ b/render/assets/app-js/03.js
@@ -605,6 +605,7 @@
     var openBtn = document.getElementById("feedback-open");
     if (!dialog || !openBtn || typeof dialog.showModal !== "function") return;
     var form = document.getElementById("feedback-form");
+    var authorInput = document.getElementById("feedback-field-author");
     var titleInput = document.getElementById("feedback-field-title");
     var bodyInput = document.getElementById("feedback-field-body");
     var catSelect = document.getElementById("feedback-field-category");
@@ -731,8 +732,34 @@
              ((Math.floor(Math.random() * 4) + 8).toString(16)) + rhex(3) + "-" + rhex(12);
     }
     function maybePrefixBody() {
+      // Spec 021-feedback-author-field: the legacy window.open
+      // GitHub-prefill fallback path mirrors the worker body
+      // composer so both submission paths produce equivalent issue
+      // bodies (Principle XIII canonical observable behaviour).
+      // Author is required by the Submit gate, so it is always
+      // present at this point.
+      var attribution = "Submitted by: " + authorInput.value.trim() + "\n\n";
       var cat = catSelect.value;
-      return cat ? "> Category: " + cat + "\n\n" + bodyInput.value : bodyInput.value;
+      var rest = cat ? "> Category: " + cat + "\n\n" + bodyInput.value : bodyInput.value;
+      return attribution + rest;
+    }
+    // localStorage helpers for the Author field. Wrapped in try/catch
+    // so a private window, quota error, or browser security policy
+    // silently degrades to "no persistence" — the field stays empty,
+    // the user types their name, the submission still succeeds (spec
+    // 021 US2 acceptance scenario 3, R4/R5/R6).
+    function loadPersistedAuthor() {
+      try {
+        var v = window.localStorage.getItem("mygather.feedback.lastAuthor") || "";
+        return v.length > LIMITS.authorMaxChars ? v.slice(0, LIMITS.authorMaxChars) : v;
+      } catch (_) {
+        return "";
+      }
+    }
+    function savePersistedAuthor(v) {
+      try {
+        if (v) window.localStorage.setItem("mygather.feedback.lastAuthor", v);
+      } catch (_) { /* persistence is best-effort */ }
     }
     function buildURL() {
       var sep = BASE_URL.indexOf("?") === -1 ? "?" : "&";
@@ -760,6 +787,12 @@
       // length there would block genuinely-valid submissions whose
       // bodies fit the Worker but bloat past the URL budget (long
       // paragraphs, code blocks, etc). Gate by the runtime path.
+      // Spec 021-feedback-author-field FR-002: Author is required.
+      // Mirrors the title trim-empty + length-cap pattern; both
+      // gates feed the same Submit-disabled outcome.
+      var authorLen = authorInput.value.trim().length;
+      if (authorLen === 0) { submitBtn.disabled = true; return; }
+      if (authorInput.value.length > LIMITS.authorMaxChars) { submitBtn.disabled = true; return; }
       var titleLen = titleInput.value.trim().length;
       if (titleLen === 0) { submitBtn.disabled = true; return; }
       if (typeof window.fetch === "function") {

--- a/render/assets/app-js/04.js
+++ b/render/assets/app-js/04.js
@@ -330,13 +330,20 @@
           // is only for the fallback GitHub URL, where the worker
           // isn't in the loop. Sending the prefixed body here would
           // double-prepend the category block in worker submissions.
+          // Snapshot the trimmed author at payload-construction time
+          // so the value persisted on success matches the value sent
+          // in the POST. Reading authorInput.value on the success arm
+          // would race against user edits made while the request is
+          // in flight, leaving localStorage out of sync with the
+          // "Submitted by:" line on the actual GitHub issue.
+          var authorAtSubmit = authorInput.value.trim();
           var payload = {
             title: titleInput.value,
             // Spec 021-feedback-author-field FR-006: Author is a
             // dedicated required field on the worker payload, not
             // folded into the body. The worker composes the
             // "Submitted by:" line in feedback-worker/src/body.ts.
-            author: authorInput.value.trim(),
+            author: authorAtSubmit,
             body: bodyInput.value,
             idempotencyKey: idempotencyKey,
             reportVersion: reportVersion
@@ -359,8 +366,8 @@
           }).then(function (res) {
             clearTimeout(timer);
             return res.json().then(function (data) {
-              return { res: res, data: data, retryAfter: res.headers.get("Retry-After") };
-            }, function () { return { res: res, data: null, retryAfter: res.headers.get("Retry-After") }; });
+              return { res: res, data: data, retryAfter: res.headers.get("Retry-After"), authorAtSubmit: authorAtSubmit };
+            }, function () { return { res: res, data: null, retryAfter: res.headers.get("Retry-After"), authorAtSubmit: authorAtSubmit }; });
           }, function (err) {
             clearTimeout(timer);
             throw err;
@@ -372,7 +379,11 @@
           // Spec 021-feedback-author-field US2 / R5: persist on
           // definitive worker success only, so a half-typed
           // abandoned name does not pollute the next session.
-          savePersistedAuthor(authorInput.value.trim());
+          // Persist the snapshot captured at submit time (sent in
+          // the payload), not the live input — the user may have
+          // edited the field while the request was in flight, and
+          // the persisted value must match what the issue body says.
+          savePersistedAuthor(r.authorAtSubmit);
           renderSuccess(data.issueUrl, data.issueNumber);
           return;
         }

--- a/render/assets/app-js/04.js
+++ b/render/assets/app-js/04.js
@@ -85,8 +85,18 @@
       setErr(""); hide(fallback); hide(hint);
       if (successEl) hide(successEl);
       form.hidden = false;
+      // Spec 021-feedback-author-field US2: pre-fill the Author
+      // field from the last successful submission. Read at open
+      // time (not boot time) because closeDialog resets the field
+      // between cycles. R6: re-evaluate the cap on each load so a
+      // stale value from a release with a higher cap is silently
+      // truncated rather than blocking the Submit gate.
+      if (authorInput.value === "") {
+        authorInput.value = loadPersistedAuthor();
+      }
       dialog.showModal();
       try { titleInput.focus(); } catch (_) {}
+      updateSubmitEnabled();
     }
     function closeDialog() {
       // Invalidate any in-flight getUserMedia permission prompt so its
@@ -108,6 +118,7 @@
         stopRecording();
       }
       clearAttachment("image"); clearAttachment("voice");
+      authorInput.value = "";
       titleInput.value = ""; bodyInput.value = ""; catSelect.value = "";
       setErr(""); hide(fallback); hide(hint);
       // Dialog dismissal ends the current logical submission. The
@@ -321,6 +332,11 @@
           // double-prepend the category block in worker submissions.
           var payload = {
             title: titleInput.value,
+            // Spec 021-feedback-author-field FR-006: Author is a
+            // dedicated required field on the worker payload, not
+            // folded into the body. The worker composes the
+            // "Submitted by:" line in feedback-worker/src/body.ts.
+            author: authorInput.value.trim(),
             body: bodyInput.value,
             idempotencyKey: idempotencyKey,
             reportVersion: reportVersion
@@ -353,6 +369,10 @@
       }).then(function (r) {
         var res = r.res, data = r.data || {};
         if (res.status === 200 && data && data.ok && data.issueUrl) {
+          // Spec 021-feedback-author-field US2 / R5: persist on
+          // definitive worker success only, so a half-typed
+          // abandoned name does not pollute the next session.
+          savePersistedAuthor(authorInput.value.trim());
           renderSuccess(data.issueUrl, data.issueNumber);
           return;
         }
@@ -438,6 +458,7 @@
       idempotencyKey = null;
       updateSubmitEnabled();
     }
+    authorInput.addEventListener("input", onFormContentChange);
     titleInput.addEventListener("input", onFormContentChange);
     bodyInput.addEventListener("input", onFormContentChange);
     catSelect.addEventListener("change", onFormContentChange);

--- a/render/assets/feedback-contract.json
+++ b/render/assets/feedback-contract.json
@@ -10,6 +10,7 @@
     "reportVersionMaxChars": 64,
     "legacyUrlMaxChars": 7500,
     "workerTimeoutMs": 15000,
-    "requestMaxBytes": 30000000
+    "requestMaxBytes": 30000000,
+    "authorMaxChars": 80
   }
 }

--- a/render/feedback.go
+++ b/render/feedback.go
@@ -32,6 +32,13 @@ type FeedbackView struct {
 	// to the browser. The client JS reads validation limits from this
 	// value instead of keeping duplicate constants.
 	ContractJSON string
+
+	// AuthorMaxChars is the maximum length, in characters, of the
+	// required Author display name in the dialog. Mirrored from the
+	// canonical feedback contract so the rendered <input
+	// maxlength="..."> attribute matches the worker's validation
+	// limit (single source of truth, Principle XIII).
+	AuthorMaxChars int
 }
 
 //go:embed assets/feedback-contract.json
@@ -50,6 +57,7 @@ type feedbackContract struct {
 		LegacyURLMaxChars     int `json:"legacyUrlMaxChars"`
 		WorkerTimeoutMS       int `json:"workerTimeoutMs"`
 		RequestMaxBytes       int `json:"requestMaxBytes"`
+		AuthorMaxChars        int `json:"authorMaxChars"`
 	} `json:"limits"`
 }
 
@@ -67,7 +75,8 @@ func loadFeedbackContract() (feedbackContract, string) {
 	if limits.TitleMaxChars <= 0 || limits.BodyMaxBytes <= 0 ||
 		limits.ImageMaxBytes <= 0 || limits.VoiceMaxBytes <= 0 ||
 		limits.ReportVersionMaxChars <= 0 || limits.LegacyURLMaxChars <= 0 ||
-		limits.WorkerTimeoutMS <= 0 || limits.RequestMaxBytes <= 0 {
+		limits.WorkerTimeoutMS <= 0 || limits.RequestMaxBytes <= 0 ||
+		limits.AuthorMaxChars <= 0 {
 		panic("render/assets/feedback-contract.json: feedback limits must be positive")
 	}
 
@@ -86,7 +95,8 @@ func BuildFeedbackView() FeedbackView {
 	cats := make([]string, len(canonicalFeedbackContract.Categories))
 	copy(cats, canonicalFeedbackContract.Categories)
 	return FeedbackView{
-		Categories:   cats,
-		ContractJSON: canonicalFeedbackContractJSON,
+		Categories:     cats,
+		ContractJSON:   canonicalFeedbackContractJSON,
+		AuthorMaxChars: canonicalFeedbackContract.Limits.AuthorMaxChars,
 	}
 }

--- a/render/feedback_test.go
+++ b/render/feedback_test.go
@@ -46,10 +46,43 @@ func TestFeedbackClientReadsCanonicalContract(t *testing.T) {
 		"LIMITS.reportVersionMaxChars",
 		"LIMITS.legacyUrlMaxChars",
 		"LIMITS.workerTimeoutMs",
+		"LIMITS.authorMaxChars",
 	}
 	for _, snippet := range wantSnippets {
 		if !strings.Contains(embeddedAppJS, snippet) {
 			t.Errorf("embedded app JS does not consume feedback contract snippet %q", snippet)
 		}
+	}
+}
+
+// TestFeedbackViewExposesAuthorMaxChars: spec 021-feedback-author-field
+// FR-009 — the Author character cap MUST be expressed exactly once
+// in the canonical contract JSON and surfaced by the Go view so the
+// rendered <input maxlength="..."> matches the worker's validation
+// limit. Asserts both that the view carries the value and that it
+// equals the parsed contract field (no hardcoded constant).
+func TestFeedbackViewExposesAuthorMaxChars(t *testing.T) {
+	v := BuildFeedbackView()
+	if v.AuthorMaxChars <= 0 {
+		t.Fatalf("FeedbackView.AuthorMaxChars must be positive, got %d", v.AuthorMaxChars)
+	}
+	if v.AuthorMaxChars != canonicalFeedbackContract.Limits.AuthorMaxChars {
+		t.Errorf("FeedbackView.AuthorMaxChars = %d, want canonical contract %d",
+			v.AuthorMaxChars, canonicalFeedbackContract.Limits.AuthorMaxChars)
+	}
+}
+
+// TestFeedbackPersistedAuthorKeyReferencedConsistently: spec
+// 021-feedback-author-field US2 — the localStorage key
+// "mygather.feedback.lastAuthor" must appear in the embedded JS
+// for both the read (loadPersistedAuthor) and the write
+// (savePersistedAuthor). A typo on either side would silently break
+// pre-fill. Counts the literal occurrences and asserts >= 2 so a
+// future code-comment mentioning the key does not over-flag.
+func TestFeedbackPersistedAuthorKeyReferencedConsistently(t *testing.T) {
+	const key = `"mygather.feedback.lastAuthor"`
+	count := strings.Count(embeddedAppJS, key)
+	if count < 2 {
+		t.Fatalf("embedded app JS must reference %s at least twice (read + write), got %d", key, count)
 	}
 }

--- a/render/feedback_test.go
+++ b/render/feedback_test.go
@@ -72,17 +72,84 @@ func TestFeedbackViewExposesAuthorMaxChars(t *testing.T) {
 	}
 }
 
+// TestFeedbackContractParserValidatesAuthorMaxChars: spec
+// 021-feedback-author-field FR-009 / Copilot review on PR #61 —
+// parseFeedbackContract must validate limits.authorMaxChars as a
+// positive integer alongside the other limits.* fields. Without
+// this, a malformed embedded contract could leave LIMITS.authorMaxChars
+// undefined and the Submit gate's `> LIMITS.authorMaxChars`
+// comparison would silently degrade (NaN comparisons evaluate
+// false, disabling the cap entirely).
+func TestFeedbackContractParserValidatesAuthorMaxChars(t *testing.T) {
+	mustContain := func(snippet string) {
+		t.Helper()
+		if !strings.Contains(embeddedAppJS, snippet) {
+			t.Errorf("embedded app JS missing parser-validation snippet %q", snippet)
+		}
+	}
+	// The parser must reject contracts whose authorMaxChars is
+	// missing, non-numeric, non-finite, non-integer, or non-positive.
+	mustContain(`typeof limits.authorMaxChars !== "number"`)
+	mustContain(`!isFinite(limits.authorMaxChars)`)
+	mustContain(`Math.floor(limits.authorMaxChars) !== limits.authorMaxChars`)
+	mustContain(`limits.authorMaxChars <= 0`)
+}
+
+// TestFeedbackPersistsSubmittedAuthorSnapshot: spec
+// 021-feedback-author-field US2 / Codex review on PR #61 — the
+// success arm of doSubmit must persist the author value captured
+// at submit time (and sent in the POST), not whatever is sitting
+// in authorInput.value when the worker's response arrives. If the
+// user edits the field between Submit and the success callback,
+// the persisted value would otherwise diverge from the issue
+// body's "Submitted by:" line.
+//
+// Asserts structural facts in the embedded JS:
+//
+//  1. doSubmit captures the trimmed author into a local snapshot
+//     before constructing the payload (`authorAtSubmit = ...trim()`).
+//  2. The payload's `author:` field is sourced from that snapshot,
+//     not from a fresh `authorInput.value` read.
+//  3. savePersistedAuthor is invoked with the snapshot
+//     (`r.authorAtSubmit`), not `authorInput.value`.
+func TestFeedbackPersistsSubmittedAuthorSnapshot(t *testing.T) {
+	mustContain := func(label, snippet string) {
+		t.Helper()
+		if !strings.Contains(embeddedAppJS, snippet) {
+			t.Errorf("%s: embedded app JS missing required snippet %q", label, snippet)
+		}
+	}
+	mustNotContain := func(label, snippet string) {
+		t.Helper()
+		if strings.Contains(embeddedAppJS, snippet) {
+			t.Errorf("%s: embedded app JS still contains forbidden snippet %q", label, snippet)
+		}
+	}
+	mustContain("snapshot capture", `var authorAtSubmit = authorInput.value.trim();`)
+	mustContain("payload uses snapshot", `author: authorAtSubmit,`)
+	mustContain("success arm uses snapshot", `savePersistedAuthor(r.authorAtSubmit);`)
+	// The pre-fix bug was savePersistedAuthor(authorInput.value.trim())
+	// inside the success arm. Guard against regression.
+	mustNotContain("success arm reads live input",
+		`savePersistedAuthor(authorInput.value.trim());`)
+}
+
 // TestFeedbackPersistedAuthorKeyReferencedConsistently: spec
 // 021-feedback-author-field US2 — the localStorage key
 // "mygather.feedback.lastAuthor" must appear in the embedded JS
-// for both the read (loadPersistedAuthor) and the write
-// (savePersistedAuthor). A typo on either side would silently break
-// pre-fill. Counts the literal occurrences and asserts >= 2 so a
-// future code-comment mentioning the key does not over-flag.
+// for both the read (loadPersistedAuthor → getItem) AND the write
+// (savePersistedAuthor → setItem). A typo on either side would
+// silently break pre-fill. Asserts a structural pairing rather
+// than a substring count so an unrelated comment mentioning the
+// key cannot satisfy the test.
 func TestFeedbackPersistedAuthorKeyReferencedConsistently(t *testing.T) {
 	const key = `"mygather.feedback.lastAuthor"`
-	count := strings.Count(embeddedAppJS, key)
-	if count < 2 {
-		t.Fatalf("embedded app JS must reference %s at least twice (read + write), got %d", key, count)
+	getCall := `getItem(` + key + `)`
+	setCall := `setItem(` + key + `,`
+	if !strings.Contains(embeddedAppJS, getCall) {
+		t.Errorf("embedded app JS must read the persisted author via %s", getCall)
+	}
+	if !strings.Contains(embeddedAppJS, setCall) {
+		t.Errorf("embedded app JS must write the persisted author via %s<value>)", setCall)
 	}
 }

--- a/render/report_feedback_test.go
+++ b/render/report_feedback_test.go
@@ -121,22 +121,56 @@ func TestFeedbackDialogMarkupPresent(t *testing.T) {
 	// be marked HTML-required and carry the maxlength attribute
 	// rendered from the canonical contract value, so the browser-
 	// native length cap matches the worker's validation cap.
-	authorIdx := strings.Index(out, `id="feedback-field-author"`)
-	if authorIdx == -1 {
-		t.Fatalf("feedback-field-author id not found")
+	// Extract the entire <input ...> opening tag (HTML attribute
+	// order is not significant, so anchor on the element start and
+	// match the whole tag rather than scanning forward from the id).
+	authorTag := extractAuthorInputTag(t, out)
+	if !feedbackAuthorRequiredRE.MatchString(authorTag) {
+		t.Errorf("feedback-field-author must carry the `required` attribute; tag was %q", authorTag)
 	}
-	authorTagEnd := strings.Index(out[authorIdx:], ">")
-	if authorTagEnd == -1 {
-		t.Fatalf("feedback-field-author tag not closed")
+	wantMaxlen := strconv.Itoa(render.BuildFeedbackView().AuthorMaxChars)
+	gotMaxlen := feedbackAuthorMaxlenRE.FindStringSubmatch(authorTag)
+	if gotMaxlen == nil {
+		t.Errorf("feedback-field-author must carry a maxlength attribute; tag was %q", authorTag)
+	} else if gotMaxlen[1] != wantMaxlen {
+		t.Errorf("feedback-field-author maxlength = %q, want %q; tag was %q", gotMaxlen[1], wantMaxlen, authorTag)
 	}
-	authorTag := out[authorIdx : authorIdx+authorTagEnd]
-	if !strings.Contains(authorTag, "required") {
-		t.Errorf("feedback-field-author must carry the `required` attribute")
+}
+
+// feedbackAuthorInputRE captures the <input ...> opening tag whose
+// id attribute is "feedback-field-author", regardless of where the
+// id sits in the attribute list. The (?s) flag lets the tag span
+// line breaks; [^>]* stops at the closing '>' before any other tag.
+var feedbackAuthorInputRE = regexp.MustCompile(
+	`(?s)<input\b[^>]*\bid="feedback-field-author"[^>]*>`,
+)
+
+// feedbackAuthorRequiredRE matches the boolean `required` attribute
+// as a standalone token (not part of an unrelated word like
+// "required-name"). HTML allows both bare `required` and
+// `required=""`/`required="required"`.
+var feedbackAuthorRequiredRE = regexp.MustCompile(
+	`\brequired(?:\s|=|>|/)`,
+)
+
+// feedbackAuthorMaxlenRE captures the maxlength integer regardless
+// of attribute position within the tag.
+var feedbackAuthorMaxlenRE = regexp.MustCompile(
+	`\bmaxlength="(\d+)"`,
+)
+
+// extractAuthorInputTag returns the full <input ...> opening tag
+// for the Author field. Uses an HTML-attribute-order-insensitive
+// regex anchored to the input element rather than scanning forward
+// from the id substring (the previous approach silently missed
+// attributes preceding `id` and broke when attribute order changed).
+func extractAuthorInputTag(t *testing.T, out string) string {
+	t.Helper()
+	tag := feedbackAuthorInputRE.FindString(out)
+	if tag == "" {
+		t.Fatalf("feedback-field-author <input> tag not found")
 	}
-	wantMaxlen := `maxlength="` + strconv.Itoa(render.BuildFeedbackView().AuthorMaxChars) + `"`
-	if !strings.Contains(authorTag, wantMaxlen) {
-		t.Errorf("feedback-field-author must carry %s; tag was %q", wantMaxlen, authorTag)
-	}
+	return tag
 }
 
 // TestFeedbackAuthorAppearsBeforeTitle: spec 021-feedback-author-field

--- a/render/report_feedback_test.go
+++ b/render/report_feedback_test.go
@@ -17,6 +17,7 @@ import (
 	"encoding/json"
 	"html"
 	"regexp"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -69,11 +70,14 @@ func TestFeedbackDialogMarkupPresent(t *testing.T) {
 
 	wantSubstrings := []string{
 		`id="feedback-dialog"`,
+		// Spec 021-feedback-author-field FR-001: the Author input
+		// must be present in the dialog markup.
+		`id="feedback-field-author"`,
 		`id="feedback-field-title"`,
 		`id="feedback-field-body"`,
 		`id="feedback-field-category"`,
 		// The submit button starts disabled until the client JS
-		// validates a non-empty title.
+		// validates a non-empty title and a non-empty author.
 		`id="feedback-submit"`,
 		`disabled`,
 		// Fallback is hidden until the dialog's submit handler
@@ -111,6 +115,45 @@ func TestFeedbackDialogMarkupPresent(t *testing.T) {
 	fallbackTagEnd := strings.Index(out[fallbackIdx:], ">")
 	if fallbackTagEnd == -1 || !strings.Contains(out[fallbackIdx:fallbackIdx+fallbackTagEnd], "hidden") {
 		t.Errorf("feedback-fallback must carry the `hidden` attribute on first paint")
+	}
+
+	// Spec 021-feedback-author-field FR-001: the Author input must
+	// be marked HTML-required and carry the maxlength attribute
+	// rendered from the canonical contract value, so the browser-
+	// native length cap matches the worker's validation cap.
+	authorIdx := strings.Index(out, `id="feedback-field-author"`)
+	if authorIdx == -1 {
+		t.Fatalf("feedback-field-author id not found")
+	}
+	authorTagEnd := strings.Index(out[authorIdx:], ">")
+	if authorTagEnd == -1 {
+		t.Fatalf("feedback-field-author tag not closed")
+	}
+	authorTag := out[authorIdx : authorIdx+authorTagEnd]
+	if !strings.Contains(authorTag, "required") {
+		t.Errorf("feedback-field-author must carry the `required` attribute")
+	}
+	wantMaxlen := `maxlength="` + strconv.Itoa(render.BuildFeedbackView().AuthorMaxChars) + `"`
+	if !strings.Contains(authorTag, wantMaxlen) {
+		t.Errorf("feedback-field-author must carry %s; tag was %q", wantMaxlen, authorTag)
+	}
+}
+
+// TestFeedbackAuthorAppearsBeforeTitle: spec 021-feedback-author-field
+// FR-001 — the Author input must be positioned above the Title field
+// in document order so users see the attribution control first.
+func TestFeedbackAuthorAppearsBeforeTitle(t *testing.T) {
+	out := renderFeedbackFixture(t)
+	authorIdx := strings.Index(out, `id="feedback-field-author"`)
+	titleIdx := strings.Index(out, `id="feedback-field-title"`)
+	if authorIdx == -1 {
+		t.Fatalf("feedback-field-author id not found")
+	}
+	if titleIdx == -1 {
+		t.Fatalf("feedback-field-title id not found")
+	}
+	if authorIdx >= titleIdx {
+		t.Errorf("Author input must precede Title input (author at %d, title at %d)", authorIdx, titleIdx)
 	}
 }
 

--- a/render/templates/report.html.tmpl
+++ b/render/templates/report.html.tmpl
@@ -154,6 +154,11 @@
     </p>
 
     <div class="feedback-field">
+      <label for="feedback-field-author">Author <span class="feedback-field-req">required</span></label>
+      <input id="feedback-field-author" name="author" type="text" autocomplete="name" placeholder="Your name" required maxlength="{{ .Feedback.AuthorMaxChars }}">
+    </div>
+
+    <div class="feedback-field">
       <label for="feedback-field-title">Title</label>
       <input id="feedback-field-title" name="title" type="text" autocomplete="off" placeholder="Short summary…" required>
     </div>

--- a/specs/021-feedback-author-field/checklists/requirements.md
+++ b/specs/021-feedback-author-field/checklists/requirements.md
@@ -1,0 +1,42 @@
+# Specification Quality Checklist: Required Author field on Report Feedback
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-05-07
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- Spec necessarily references existing concrete implementation files in
+  the Canonical Path Expectations section because Principle XIII
+  requires identifying canonical owners for touched behaviour. This
+  references existing structure rather than prescribing new
+  implementation.
+- The Author cap value (80) and localStorage key namespace are documented
+  as Assumptions (defaults silently chosen per the no-questions
+  constraint), not requirements; the planner is free to revisit them
+  with justification.

--- a/specs/021-feedback-author-field/contracts/author-field.md
+++ b/specs/021-feedback-author-field/contracts/author-field.md
@@ -1,0 +1,170 @@
+# Contract: Author field on Report Feedback
+
+This contract is the single source of truth for the Author field
+behaviour across the dialog UI, the JSON payload sent to the worker,
+the worker's validation, and the issue body composition.
+
+## C1: Shared contract JSON (`render/assets/feedback-contract.json`)
+
+The `limits` object gains exactly one new field:
+
+```json
+{
+  "limits": {
+    "...": "...existing fields unchanged...",
+    "authorMaxChars": 80
+  }
+}
+```
+
+- Type: positive integer.
+- Both `render/feedback.go` and `feedback-worker/src/feedback-contract.ts`
+  MUST consume it from this file. Neither side may hard-code the
+  value.
+
+## C2: Dialog markup (`render/templates/report.html.tmpl`)
+
+A new field block is inserted IMMEDIATELY before the existing
+`feedback-field-title` block:
+
+```html
+<div class="feedback-field">
+  <label for="feedback-field-author">Author <span class="feedback-field-req">required</span></label>
+  <input id="feedback-field-author" name="author" type="text"
+         autocomplete="name" placeholder="Your name" required
+         maxlength="{{ .Feedback.AuthorMaxChars }}">
+</div>
+```
+
+- The element ID `feedback-field-author` is part of the UI contract
+  and stable (the JS wiring keys off it).
+- `maxlength` is rendered from the contract value via the new
+  `FeedbackView.AuthorMaxChars` field.
+- The `required` HTML attribute is present so screen readers announce
+  the requirement; the canonical Submit gate is JS, the canonical
+  rejection gate is the worker.
+
+## C3: Go view (`render/feedback.go`)
+
+`FeedbackView` gains one exported field:
+
+```go
+type FeedbackView struct {
+    Categories      []string
+    ContractJSON    string
+    AuthorMaxChars  int
+}
+```
+
+`feedbackContract.Limits` gains `AuthorMaxChars int` with JSON tag
+`authorMaxChars`. `loadFeedbackContract` extends the positivity
+check to include the new field. `BuildFeedbackView` populates
+`AuthorMaxChars` from the parsed contract.
+
+## C4: Worker payload (`feedback-worker/src/validate.ts`)
+
+`ValidatedPayload` gains a required `author: string` field.
+`ValidationError` gains two new literals: `"author_required"` and
+`"author_too_long"`.
+
+Validation order: `author` is validated immediately after `title`
+(both required strings) and before `body`.
+
+Rejection rules:
+- Missing field, non-string, empty string, or whitespace-only string:
+  `fail("author_required", "Author is required.")`.
+- `value.length > feedbackContract.limits.authorMaxChars`:
+  `fail("author_too_long", "Author exceeds N characters.")`.
+- Otherwise: stored as `value.trim()` on the validated payload.
+
+## C5: Worker contract type (`feedback-worker/src/feedback-contract.ts`)
+
+The `FeedbackContract.limits` interface gains
+`authorMaxChars: number`. The existing `assertPositiveInteger` walk
+covers the new field automatically because it iterates
+`Object.entries(contract.limits)`.
+
+## C6: Worker body composer (`feedback-worker/src/body.ts`)
+
+The first lines of `buildIssueBody` output become:
+
+```text
+Submitted by: <author>
+
+```
+
+(That is: the literal `Submitted by: ` prefix + the validated author +
+newline + blank line.) The remainder of the composition is unchanged.
+
+The line is ALWAYS present (Author is required by C4).
+
+## C7: Frontend payload (`render/assets/app-js/04.js`)
+
+`doSubmit` adds exactly one line to the payload object construction:
+
+```js
+payload.author = authorInput.value.trim();
+```
+
+The field is required; there is no conditional inclusion.
+
+## C8: Frontend Submit gate (`render/assets/app-js/03.js`)
+
+`updateSubmitEnabled` adds an Author check immediately after the
+existing Title trim-empty check:
+
+- If `authorInput.value.trim().length === 0`, disable Submit.
+- If `authorInput.value.length > LIMITS.authorMaxChars`, disable Submit.
+
+The `closeDialog` reset assigns `authorInput.value = ""` (or the
+persisted value if any — see C10).
+
+The `onFormContentChange` event wiring includes `authorInput` so
+edits invalidate the in-flight `idempotencyKey`, mirroring how
+`titleInput` / `bodyInput` / `catSelect` already do.
+
+## C9: Legacy fallback URL builder (`render/assets/app-js/03.js`)
+
+`maybePrefixBody` is extended so its output is:
+
+```text
+Submitted by: <author>
+
+[> Category: <cat>\n\n   if category]
+<user-typed body>
+```
+
+(Same `Submitted by:` line shape as C6.) The Author value is read
+from the same `authorInput` ref. Because Author is the canonical
+required field, the fallback path also has Author present at submit
+time (the Submit button is disabled otherwise — see C8).
+
+## C10: localStorage persistence (`render/assets/app-js/03.js`)
+
+Two helpers, both wrapped in `try/catch` so a `localStorage`
+exception silently degrades to "no persistence":
+
+- `loadPersistedAuthor()`: returns the stored string truncated to
+  `LIMITS.authorMaxChars`, or `""` on absence/error.
+- `savePersistedAuthor(value)`: writes the trimmed value if non-empty;
+  no-op otherwise.
+
+Lifecycle (R5, R6):
+- `openDialog`: if `authorInput.value === ""`, set it from
+  `loadPersistedAuthor()`.
+- Worker success arm of `doSubmit` (`renderSuccess` callsite): call
+  `savePersistedAuthor(authorInput.value.trim())`.
+
+The localStorage key is the literal string
+`mygather.feedback.lastAuthor`.
+
+## C11: Backwards compatibility
+
+This contract change is forward-only. Reports built before this
+feature lands do not POST `author` and will receive 400
+`author_required` from the worker after this contract ships. The
+existing legacy `window.open` fallback handles those clients
+gracefully with a pre-filled GitHub URL (which lacks the
+`Submitted by:` line because the older binary doesn't know about
+Author — that's acceptable graceful degradation, not a forbidden
+fallback, since the binary itself is the boundary).

--- a/specs/021-feedback-author-field/data-model.md
+++ b/specs/021-feedback-author-field/data-model.md
@@ -1,0 +1,111 @@
+# Data Model: Required Author field on Report Feedback
+
+## Entities
+
+### FeedbackContract.limits.authorMaxChars (NEW field)
+
+| Field | Type | Constraints | Description |
+|---|---|---|---|
+| `authorMaxChars` | positive integer | > 0 | Maximum length of the Author display name in characters. Single source of truth for both the frontend Submit gate and the worker validator. |
+
+**Storage**: `render/assets/feedback-contract.json` (existing
+embedded asset, consumed by both Go and TypeScript).
+
+**Value (R1)**: `80`.
+
+**Validation**:
+- `render/feedback.go#loadFeedbackContract` MUST panic at startup if
+  `authorMaxChars <= 0` (mirrors the existing positivity check on the
+  other limits).
+- `feedback-worker/src/feedback-contract.ts#assertFeedbackContract`
+  MUST throw at module load if `authorMaxChars` is not a positive
+  integer (mirrors the existing `assertPositiveInteger` walk over
+  `limits`).
+
+### FeedbackPayload.author (NEW required field)
+
+| Field | Type | Constraints | Description |
+|---|---|---|---|
+| `author` | string (required) | `trim(value).length >= 1`, `value.length <= contract.limits.authorMaxChars` | Display name of the user submitting the feedback. Worker uses it to compose the `Submitted by: <name>` line. |
+
+**Wire location**: Top-level field on the JSON body POSTed to
+`/feedback`.
+
+**Frontend gate** (`render/assets/app-js/03.js#updateSubmitEnabled`):
+- If `authorInput.value.trim().length === 0`, Submit is disabled.
+- If `authorInput.value.length > LIMITS.authorMaxChars`, Submit is
+  disabled and the inline error reads "Author must be N characters or
+  fewer" (matches the title-too-long pattern).
+
+**Worker validation** (`feedback-worker/src/validate.ts#validatePayload`):
+- Adds `author_required` and `author_too_long` to `ValidationError`.
+- Adds `author: string` to `ValidatedPayload`.
+- Rejects payloads where `author` is missing, not a string, an empty
+  string, or trims to empty: `fail("author_required", "Author is required.")`.
+- Rejects payloads where `author.length > authorMaxChars`:
+  `fail("author_too_long", "Author exceeds N characters.")`.
+- The validated `author` carried forward is `value.trim()` (no
+  internal-whitespace collapsing).
+
+### PersistedAuthor (browser localStorage entry)
+
+| Field | Type | Constraints | Description |
+|---|---|---|---|
+| key | string literal | `mygather.feedback.lastAuthor` | Stable per-origin storage key. |
+| value | string | `length >= 1`, `length <= contract.limits.authorMaxChars` (read-time enforced) | The trimmed Author value from the most recent successful submission. |
+
+**Lifecycle**:
+- WRITE: in the success arm of `doSubmit` (right next to
+  `renderSuccess`), after the worker returns 200. The value written is
+  `authorInput.value.trim()`.
+- READ: in `openDialog`, before `dialog.showModal()`. If a stored
+  value exists and is within `authorMaxChars`, assign to
+  `authorInput.value`. If it exceeds the cap (e.g. cap was lowered in
+  a later release), truncate to the cap silently rather than refuse to
+  load.
+- ABSENT (private window, quota error, browser policy): caught with
+  `try/catch` around both `getItem` and `setItem`; the field stays
+  empty (read failure) or the persistence is skipped (write failure).
+  No user-visible error.
+
+### Issue Body shape (extension to existing composition)
+
+The `feedback-worker/src/body.ts#buildIssueBody` output gains one
+leading line + a blank separator. New shape:
+
+```text
+Submitted by: <author>
+
+> Category: <category>          (only if category present)
+
+<user-typed body>
+
+### Attached screenshot         (only if image)
+
+![screenshot](<imageUrl>)
+
+### Attached voice note         (only if voice)
+
+<voiceUrl>
+
+---
+_Submitted via my-gather Report Feedback (v<reportVersion>)._
+```
+
+**Ordering rationale (R3)**: Author attribution is the most-relevant
+context for triage routing; it earns the top slot. Category quote
+moves down by exactly one block. The existing trailer is unchanged.
+
+### Legacy fallback URL body (extension to existing composition)
+
+The `render/assets/app-js/03.js#maybePrefixBody` output gains the
+same leading `Submitted by: <author>` line + blank separator,
+followed by the existing optional `> Category:` block, followed by
+the user-typed body. This is the body GitHub sees when the worker
+path is unavailable and the report falls back to `window.open` on a
+GitHub new-issue URL with title+body query parameters.
+
+**Same observable shape** as the worker path's body for the same
+input (Principle XIII canonical observable behaviour). The only
+difference is that the URL-pre-fill body cannot embed attachments;
+the existing clipboard/download handoff covers that.

--- a/specs/021-feedback-author-field/plan.md
+++ b/specs/021-feedback-author-field/plan.md
@@ -1,0 +1,112 @@
+# Implementation Plan: Required Author field on Report Feedback
+
+**Branch**: `021-feedback-author-field` | **Date**: 2026-05-07 | **Spec**: [spec.md](spec.md)
+**Input**: Feature specification from `specs/021-feedback-author-field/spec.md`
+
+## Summary
+
+Closes GitHub issue #56. The Report Feedback dialog gains a required
+"Author" input field positioned above Title. The Submit button is gated
+by Author non-emptiness in addition to the existing Title gates. The
+trimmed Author value rides as a dedicated `author` JSON field in the
+worker payload (and as part of the prefilled body in the legacy
+`window.open` GitHub fallback). The Cloudflare Worker validates Author
+as required + length-capped, and its issue-body composer prepends a
+single `Submitted by: <name>` line so triagers can attribute every
+issue. The last successfully submitted Author is persisted in
+`localStorage` under a stable key and rehydrated on the next dialog
+open. The new character cap lives in the canonical
+`render/assets/feedback-contract.json` and is consumed by both the Go
+renderer's frontend gate and the worker's validator (no duplication).
+
+## Technical Context
+
+**Language/Version**: Go (pinned, see `go.mod`) for the renderer; TypeScript on Cloudflare Workers for the feedback worker; vanilla ES5-style browser JS in the embedded report assets.
+**Primary Dependencies**: Standard library on the Go side. On the worker: `vitest` for tests, `wrangler` for deploy. Browser-side: native `localStorage`, `fetch`, `crypto.randomUUID`. No new dependency added by this feature.
+**Storage**: Browser `localStorage` (single key, plain text). No server-side persistence beyond the GitHub issue itself.
+**Testing**: `go test ./...` for the Go renderer (including `render/feedback_test.go`, `render/report_feedback_test.go`, and the cross-cutting size/godoc/determinism coverage tests). `vitest` for the worker (`feedback-worker/test/*.test.ts`).
+**Target Platform**: Single embedded HTML report rendered by the My-gather CLI; opened in a modern browser with `<dialog>`, `localStorage`, and `fetch` available. Cloudflare Workers runtime for the backend.
+**Project Type**: CLI tool that emits a self-contained HTML report (`render/`) plus a small companion HTTP backend (`feedback-worker/`).
+**Performance Goals**: Dialog open + pre-fill MUST remain visually instant (< 16 ms). Worker payload validation overhead negligible (string length check). No new render-time cost.
+**Constraints**: Principle IV (deterministic byte-identical HTML output) — the Author field DOM is a static template element with no clock/random/env input. Principle V (self-contained report) — no new external assets. Principle IX (zero network) — only the existing named-exception POST on Submit. Principle XV (1000-line cap) — keep `render/assets/app-js/03.js` and `04.js` under 1000 lines after edits.
+**Scale/Scope**: One frontend dialog edit, one Worker contract edit, one body composer edit. ~10-15 LOC of incremental JS, ~10 LOC of incremental Go, ~20 LOC of incremental TypeScript, plus tests.
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+- **I. Single Static Binary**: No CGO, no new runtime deps in the Go binary. PASS.
+- **II. Read-Only Inputs**: No filesystem writes added. PASS.
+- **III. Graceful Degradation**: localStorage absence (private mode, quota, security policy) is observable browser-boundary degradation; field still works, only the next-time pre-fill is skipped. Worker reachability degradation continues to use the existing `window.open` fallback path which now also carries the `Submitted by:` line. PASS.
+- **IV. Deterministic Output**: New DOM element is a template literal; the contract JSON is embedded; no clock or randomness. The Go view returns DeepEqual values across calls (existing test in `render/feedback_test.go` covers this; the existing tests will fail loudly if a new non-deterministic input slips in). PASS.
+- **V. Self-Contained HTML Reports**: No external fetch at view-time. The Author input is plain HTML, no new asset. PASS.
+- **VI. Library-First Architecture**: Changes touch `render/` only via new fields on `FeedbackContract` + template; no `cmd/` coupling introduced. Godoc covers the one new exported field on the contract limits struct. PASS.
+- **VII. Typed Errors**: Worker adds one new `ValidationError` literal `author_required` / `author_too_long` matching the existing pattern. No bare `fmt.Errorf` for branchable conditions on the Go side. PASS.
+- **VIII. Reference Fixtures & Golden Tests**: This feature does not add a new pt-stalk parser. Render-side determinism is exercised by the existing report golden test, which will refresh in this PR with `-update` after explicit review. PASS.
+- **IX. Zero Network at Runtime**: No new network call. Reuses the existing named-exception Submit POST. PASS.
+- **X. Minimal Dependencies**: No new direct dependency in `go.mod` or `feedback-worker/package.json`. PASS.
+- **XI. Reports Optimized for Humans Under Pressure**: The new field appears only inside the Report Feedback dialog (a user-initiated overlay), not in the report's main narrative. PASS.
+- **XII. Pinned Go Version**: Unchanged. PASS.
+- **XIII. Canonical Code Path**: See Canonical Path Audit below. PASS.
+- **XIV. English-Only Durable Artifacts**: All spec text, code identifiers, comments, commit message, and PR text are English-only. PASS.
+- **XV. Bounded Source File Size**: Pre-edit, `render/assets/app-js/03.js` is 898 lines and `04.js` is 490 lines. Author wiring lives entirely in `03.js` (input ref, gate, persistence) and `04.js` (payload field). Estimated added LOC: ~25 in `03.js` (still < 1000), ~3 in `04.js`. If a future iteration approaches the cap, the dialog wiring will be extracted into `app-js/05.js`; not required for this feature. PASS.
+
+**Canonical Path Audit (Principle XIII)**:
+- Canonical owner/path for touched behaviour:
+  - Frontend dialog markup: `render/templates/report.html.tmpl` (the existing static `<dialog>` element).
+  - Frontend dialog wiring: `render/assets/app-js/03.js#initFeedbackDialog` (refs, gate, persistence) and `render/assets/app-js/04.js#doSubmit` (payload composition).
+  - Shared contract: `render/assets/feedback-contract.json` consumed by both `render/feedback.go#loadFeedbackContract` and `feedback-worker/src/feedback-contract.ts#assertFeedbackContract`.
+  - Worker payload validator: `feedback-worker/src/validate.ts#validatePayload`.
+  - Worker issue body composer: `feedback-worker/src/body.ts#buildIssueBody`.
+- Replaced or retired paths: None. This feature adds one canonical Author field end-to-end. The legacy `window.open` GitHub-prefill body composer (`maybePrefixBody` in `app-js/03.js`) is updated in-place to also emit the `Submitted by:` line so the worker and fallback paths produce equivalent observable bodies; no parallel composer is introduced.
+- External degradation paths: (a) `localStorage` absence — observable as an empty Author field on next open, no error shown, covered by US2 acceptance scenario 3. (b) Worker unreachable — existing fallback fires; the Author is included in the prefilled GitHub URL via the updated `maybePrefixBody`, covered by US1 acceptance via the same body line on both paths.
+- Review check: Reviewer verifies (i) `authorMaxChars` is defined exactly once in `feedback-contract.json` and consumed by both Go and TypeScript; (ii) the `Submitted by:` literal appears exactly once in `feedback-worker/src/body.ts` and exactly once in the legacy URL builder, with identical formatting; (iii) no shim defaults `payload.author` to `""` or `"Anonymous"` — the worker rejects with 400 `author_required` for missing/empty/whitespace-only; (iv) `closeDialog` resets the Author field to its persisted value (or empty), not to a hardcoded default.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/021-feedback-author-field/
+├── plan.md              # This file
+├── research.md          # Phase 0 output
+├── data-model.md        # Phase 1 output
+├── quickstart.md        # Phase 1 output
+├── contracts/
+│   └── author-field.md  # Phase 1 output
+├── checklists/
+│   └── requirements.md  # Spec quality checklist
+└── tasks.md             # Phase 2 output (created by /speckit.tasks)
+```
+
+### Source Code (repository root)
+
+```text
+render/
+├── assets/
+│   ├── feedback-contract.json   # +limits.authorMaxChars
+│   ├── app-js/
+│   │   ├── 03.js                # +author input ref, gate, persistence
+│   │   └── 04.js                # +author field on payload
+│   └── ...
+├── templates/
+│   └── report.html.tmpl         # +<input id="feedback-field-author"> above title
+├── feedback.go                  # +AuthorMaxChars on contract limits + validation
+├── feedback_test.go             # +author cap loaded from contract
+└── report_feedback_test.go      # +author input present + above title
+
+feedback-worker/
+├── src/
+│   ├── feedback-contract.ts     # +authorMaxChars in type + assert
+│   ├── validate.ts              # +author required + length cap
+│   └── body.ts                  # +Submitted by: line
+└── test/
+    ├── validate.test.ts         # +author_required + author_too_long
+    └── body.test.ts             # +Submitted by line ordering
+```
+
+**Structure Decision**: The renderer (`render/`) and the Cloudflare Worker (`feedback-worker/`) remain separate sub-projects sharing one canonical contract JSON file. This is the existing layout; no new top-level directory is introduced.
+
+## Complexity Tracking
+
+> No Constitution Check violations to justify; this section is intentionally empty.

--- a/specs/021-feedback-author-field/quickstart.md
+++ b/specs/021-feedback-author-field/quickstart.md
@@ -1,0 +1,119 @@
+# Quickstart: Required Author field on Report Feedback
+
+This is the implementer's checklist. Steps are ordered to keep the
+build green at each step. Tests come first per repo convention.
+
+## Prereqs
+
+- Branch `021-feedback-author-field` (already created).
+- `go test ./...` passes on `main`.
+- `cd feedback-worker && npm test` passes on `main`.
+
+## Step 1 — Extend the canonical contract
+
+1. Edit `render/assets/feedback-contract.json`: add
+   `"authorMaxChars": 80` inside `limits`.
+2. Edit `render/feedback.go`:
+   - Add `AuthorMaxChars int` (JSON tag `authorMaxChars`) to
+     `feedbackContract.Limits`.
+   - Extend the positivity panic in `loadFeedbackContract` to include
+     `limits.AuthorMaxChars <= 0`.
+   - Add `AuthorMaxChars int` to `FeedbackView`.
+   - Set it in `BuildFeedbackView`.
+3. Edit `feedback-worker/src/feedback-contract.ts`: add
+   `authorMaxChars: number;` to `FeedbackContract.limits` type.
+
+## Step 2 — Worker validation + body composition
+
+4. Edit `feedback-worker/src/validate.ts`:
+   - Add `author_required` and `author_too_long` to `ValidationError`.
+   - Add `author: string` to `ValidatedPayload`.
+   - In `validatePayload`, immediately after the title block, add an
+     author block: required + length-cap, returning the trimmed value
+     on success.
+5. Edit `feedback-worker/src/body.ts`:
+   - Prepend `Submitted by: <author>` followed by a blank line as the
+     first two lines of the output.
+
+## Step 3 — Worker tests
+
+6. Edit `feedback-worker/test/validate.test.ts`:
+   - Cover missing `author` => `author_required`.
+   - Cover empty / whitespace-only `author` => `author_required`.
+   - Cover over-cap `author` => `author_too_long`.
+   - Cover happy path stores trimmed author.
+7. Edit `feedback-worker/test/body.test.ts`:
+   - Assert the first body line is `Submitted by: <name>`.
+   - Assert exactly one blank line separates it from the next block.
+8. Update any existing fixtures in
+   `feedback-worker/test/{validate,body,index}.test.ts` to include a
+   valid `author` field (otherwise existing tests now fail
+   `author_required`).
+
+## Step 4 — Frontend dialog markup + view test
+
+9. Edit `render/templates/report.html.tmpl`: insert the new
+   `feedback-field-author` block immediately before
+   `feedback-field-title`.
+10. Edit `render/feedback_test.go` (or add the assertion to the
+    existing test) to verify `BuildFeedbackView().AuthorMaxChars`
+    matches the contract value.
+11. Edit `render/report_feedback_test.go`: add an HTML assertion that
+    a tag with `id="feedback-field-author"` is present and that it
+    appears before the `feedback-field-title` tag in the rendered
+    output.
+
+## Step 5 — Frontend wiring
+
+12. Edit `render/assets/app-js/03.js#initFeedbackDialog`:
+    - Add `var authorInput = document.getElementById("feedback-field-author");`.
+    - In `updateSubmitEnabled`, gate Submit on
+      `authorInput.value.trim().length > 0` AND
+      `authorInput.value.length <= LIMITS.authorMaxChars`.
+    - In `closeDialog`, reset `authorInput.value = ""`.
+    - Add `authorInput.addEventListener("input", onFormContentChange);`.
+    - Add `loadPersistedAuthor()` and `savePersistedAuthor()` helpers
+      (both `try/catch` wrapped).
+    - In `openDialog`, after the existing reset of other fields, if
+      `authorInput.value === ""` call `loadPersistedAuthor()` and
+      assign.
+    - Update `maybePrefixBody` to prepend the `Submitted by: <name>`
+      line.
+13. Edit `render/assets/app-js/04.js#doSubmit`:
+    - In the payload-building block, add
+      `payload.author = authorInput.value.trim();`.
+    - In the success arm (right where `renderSuccess` is called), call
+      `savePersistedAuthor(payload.author);`.
+    - To get a reference to `authorInput` from `04.js`, hoist it (it's
+      a closure-captured local in the same `initFeedbackDialog` scope
+      as `titleInput`, so it is already in scope inside `doSubmit`).
+
+## Step 6 — Cross-cutting checks
+
+14. Run `go test ./...` from the repo root. The
+    `tests/coverage/file_size_test.go` will fail loudly if 03.js or
+    04.js exceeds 1000 lines. The determinism test will fail if the
+    new DOM is non-deterministic. The godoc coverage will fail if the
+    new `AuthorMaxChars` field on `FeedbackView` is missing a doc
+    comment.
+15. From `feedback-worker/`, run `npm test`.
+16. Run the pre-push guard manually:
+    `bash scripts/hooks/pre-push-constitution-guard.sh`.
+17. Update CLAUDE.md, AGENTS.md, and `.specify/feature.json` to point
+    at this feature.
+
+## Acceptance walk
+
+1. Build the binary, generate a report against any pt-stalk fixture,
+   open the report in a browser.
+2. Click "Report feedback" — the new Author field appears at the top,
+   marked required, empty (no prior submission). Submit is disabled.
+3. Type a name; Submit becomes enabled (Title is also required so
+   complete it too).
+4. Submit successfully. Verify the GitHub issue body starts with
+   `Submitted by: <name>`.
+5. Close the dialog, reopen it — the Author field is pre-filled with
+   the value you typed.
+6. Open a private window, generate the same report, open dialog —
+   Author is empty (private mode blocks localStorage). Type, submit,
+   verify the worker still creates the issue.

--- a/specs/021-feedback-author-field/research.md
+++ b/specs/021-feedback-author-field/research.md
@@ -1,0 +1,159 @@
+# Research: Required Author field on Report Feedback
+
+## R1: Author character cap value
+
+**Decision**: 80 characters.
+
+**Rationale**: The existing `titleMaxChars` is 200; an Author display
+name does not need anywhere near that. 80 fits "First Last (Team
+Name)" comfortably and matches the conventional terminal/title row
+width that triagers scan in a GitHub issue list. Smaller than 200
+also tightens the inline-validation surface for a clearer user error
+message ("Author must be 80 characters or fewer").
+
+**Alternatives considered**:
+- 64: too tight for "First Middle Last (Long Team Name)" patterns.
+- 200 (mirror title): wasteful; an author isn't free-form prose.
+- Unbounded: violates the existing payload-discipline pattern in the
+  worker contract. Every other string field has an explicit cap.
+
+## R2: Where the "Submitted by:" line is composed
+
+**Decision**: Compose the line in `feedback-worker/src/body.ts`
+(worker side), and mirror it in the legacy `maybePrefixBody` in
+`render/assets/app-js/03.js` (the `window.open` GitHub fallback URL
+builder).
+
+**Rationale**: The worker is already the single canonical body
+composer (it injects the `> Category:` quote and the
+`_Submitted via my-gather Report Feedback (v...)._` trailer). Putting
+the `Submitted by:` line there keeps the canonical owner intact
+(Principle XIII). The legacy fallback bypasses the worker entirely
+(it pre-fills GitHub via URL params), so its body builder
+(`maybePrefixBody`) MUST emit the same line itself; this is documented
+external degradation under Principle III, and the same observable line
+format makes the two paths converge.
+
+**Alternatives considered**:
+- Compose on the frontend, send a pre-baked body to the worker:
+  rejected because it would split the canonical composer across two
+  places (worker still adds category + trailer) and break the existing
+  pattern. Also makes worker-side validation fragile (would have to
+  parse author back out of the body string).
+- Compose only on the worker, leave fallback bare: rejected because
+  the same input would produce two different observable issue bodies
+  depending on whether the worker was reachable, breaking Principle
+  XIII canonical observable behaviour.
+
+## R3: Line position within the issue body
+
+**Decision**: `Submitted by: <name>` is the FIRST line of the body,
+placed before the existing `> Category: <cat>` quote (when present)
+and before the user-typed body. A trailing blank line separates the
+attribution block from the user content, mirroring the existing blank
+line after `> Category:`.
+
+**Rationale**: Triagers scan the top of the issue body first. Author
+attribution is the most-relevant context for triage routing
+("who do I follow up with?"), so it earns the top slot. The category
+quote stays where it is, just one line lower.
+
+**Alternatives considered**:
+- Put it in the GitHub issue title: rejected — the title is
+  user-controlled and short; mixing identity into it pollutes search
+  ("show me all 'index missing' bugs" would not match
+  "Mati: index missing"). Body line keeps title clean.
+- Put it in the trailer next to the version footer: rejected —
+  triagers need it BEFORE they read the body, not after.
+
+## R4: Persistence storage choice
+
+**Decision**: Browser `localStorage` under the single key
+`mygather.feedback.lastAuthor`, plain text (the Author value as-is).
+
+**Rationale**: `localStorage` is universally available in modern
+browsers, persists across tab close, and is scoped per origin — but
+the report is a single static `file://` document, so each
+report-on-disk shares localStorage with itself across opens; an
+operator who saves multiple reports under the same `file://` host gets
+shared persistence, which is the desired behaviour for "don't retype
+my name". `sessionStorage` would lose the value across tab closes.
+IndexedDB is overkill for a single string. A cookie is meaningless on
+`file://`.
+
+**Alternatives considered**:
+- `sessionStorage`: rejected — defeats the cross-session "remember me"
+  goal.
+- A cookie or query-string parameter: rejected — file:// origins do
+  not behave as expected for cookies, and query params would require
+  re-emitting the report.
+- No persistence (always type fresh): rejected — explicit user
+  decision that persistence is required.
+
+## R5: Persistence trigger
+
+**Decision**: Persist on definitive worker submit success
+(`renderSuccess` path), not on every keystroke and not on
+`closeDialog`.
+
+**Rationale**: Mirrors the "definitive logical attempt" boundary the
+existing code already uses for `idempotencyKey` lifecycle. Persisting
+on every keystroke pollutes localStorage with abandoned drafts.
+Persisting on `closeDialog` would memorise an Author the user typed
+but explicitly cancelled (e.g. typed "test", changed their mind, hit
+Esc). Persisting on success guarantees the stored name was actually
+attached to a real GitHub issue.
+
+**Alternatives considered**:
+- On every input event: rejected — pollutes storage with abandoned
+  drafts, including impersonation typos (user starts typing one name,
+  changes it).
+- On dialog open with the field pre-cached: not applicable; we want
+  the value at submit time, not at open time.
+- On `closeDialog`: rejected — captures cancelled drafts.
+
+## R6: Pre-fill timing
+
+**Decision**: Read `localStorage.getItem('mygather.feedback.lastAuthor')`
+inside `openDialog`, and (a) if non-empty and within `authorMaxChars`,
+assign it to `authorInput.value`; (b) otherwise leave the input empty.
+Read on EACH open (not once at boot) so a value persisted in a prior
+dialog cycle within the same page session is visible on the next
+open.
+
+**Rationale**: `closeDialog` clears every form field today; reading at
+open time matches that lifecycle and avoids "the input was cleared
+between open events" surprises. Validating against `authorMaxChars`
+defends against a stale localStorage entry left by a future build with
+a higher cap; we silently truncate a too-long persisted value to the
+current cap rather than throwing or leaving the Submit button stuck
+disabled.
+
+**Alternatives considered**:
+- Pre-fill once at boot: would not survive `closeDialog`'s
+  `authorInput.value = ""` reset.
+- Pre-fill at `closeDialog` time: would race with the user reopening.
+
+## R7: Worker contract version compatibility
+
+**Decision**: Forward-only contract change. After this PR ships, an
+older report binary that does not POST `author` is rejected by the
+worker with 400 `author_required`. There is no back-compat shim.
+
+**Rationale**: Principle XIII forbids fallbacks for an internal
+contract field. The graceful degradation path is the existing
+`window.open` GitHub fallback that the older binary's frontend
+already routes to on a 4xx response. Users with an old binary will
+see the GitHub URL pop open (with no `Submitted by:` line — that
+binary doesn't know about Author), which is the documented
+non-network fallback. Once they refresh the report binary, the
+worker path resumes.
+
+**Alternatives considered**:
+- Worker treats missing `author` as legacy and synthesises
+  `Submitted by: (unknown)`: rejected — would be a silent fallback
+  (Principle XIII), and would mask a real client bug after rollout.
+- Bump the contract URL/version: rejected — no precedent in the
+  existing codebase, and the named-exception POST URL is a build-time
+  constant; adding a versioned alias path in the worker would be a
+  parallel route (Principle XIII).

--- a/specs/021-feedback-author-field/spec.md
+++ b/specs/021-feedback-author-field/spec.md
@@ -1,0 +1,216 @@
+# Feature Specification: Required Author field on Report Feedback
+
+**Feature Branch**: `021-feedback-author-field`
+**Created**: 2026-05-07
+**Status**: Draft
+**Input**: User description: "Add a required \"Author\" input field to the Report Feedback dialog. Submission is blocked with inline validation until the user enters a non-empty author name. The submitted GitHub issue body must include a \"Submitted by: <name>\" line so triagers can identify the reporter. The last-used author value is persisted in browser localStorage and pre-fills the field on subsequent dialog opens."
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Sign your feedback before sending it (Priority: P1)
+
+A support engineer viewing a generated report opens the "Report feedback"
+dialog to flag a parser issue. The dialog now shows an "Author" field at
+the top. The user types their name, fills the Title and Body, and clicks
+Submit. The created GitHub issue body carries a "Submitted by: <name>"
+line so the triager knows who reported it without scrolling git blame or
+opening Slack.
+
+**Why this priority**: This is the entire feature - without an author on
+the issue, triagers cannot tell who reported it, which today is the
+single concrete pain point closing GitHub issue #56.
+
+**Independent Test**: Open the dialog, type an Author + Title + Body,
+Submit. The created GitHub issue body includes a "Submitted by: <name>"
+line attributable to the typed value.
+
+**Acceptance Scenarios**:
+
+1. **Given** the report is open and the user has never submitted
+   feedback before, **When** they click "Report feedback", **Then** the
+   dialog shows an Author field labelled "Author" that is empty and
+   marked required.
+2. **Given** the dialog is open with all other fields filled, **When**
+   the user leaves Author empty, **Then** the Submit button is disabled
+   and an inline validation hint indicates Author is required.
+3. **Given** the user has typed a non-empty Author plus a non-empty
+   Title, **When** they click Submit and the worker accepts the
+   request, **Then** the resulting GitHub issue body contains a line
+   "Submitted by: <typed-name>".
+
+---
+
+### User Story 2 - Don't retype your name every time (Priority: P2)
+
+A support engineer who already submitted feedback once opens the dialog
+again later (same browser, same machine) to file another report. The
+Author field is pre-filled with the name they used last time. They can
+edit it, clear it, or accept it as-is.
+
+**Why this priority**: Eliminates the "type your own name again on every
+submission" papercut for users who file multiple reports per incident.
+
+**Independent Test**: Submit feedback once with a chosen Author. Close
+the dialog. Reopen the dialog. Author field is pre-filled with that
+value.
+
+**Acceptance Scenarios**:
+
+1. **Given** the user has previously submitted feedback successfully
+   with Author "Jane", **When** they reopen the dialog in the same
+   browser, **Then** the Author field is pre-filled with "Jane".
+2. **Given** the field is pre-filled with "Jane", **When** the user
+   edits it to "J. Doe" and submits, **Then** the next dialog open
+   shows "J. Doe".
+3. **Given** the user's browser blocks or has no localStorage (e.g.,
+   private window), **When** they open the dialog, **Then** the Author
+   field is empty and the user can still type a value and submit; no
+   error is shown about persistence.
+
+---
+
+### Edge Cases
+
+- Author entered as whitespace only (spaces/tabs): treated as empty,
+  Submit stays disabled (mirrors the existing Title trim-empty rule).
+- Author longer than the field length cap: Submit is disabled with the
+  same inline validation pattern used for Title-too-long today.
+- localStorage write fails (quota exceeded, security exception): the
+  current submission still succeeds; the persistence failure is
+  silently ignored (the next dialog open will simply not pre-fill).
+- Worker receives a payload missing or empty `author`: rejected with a
+  400 validation error (mirrors `title_required`); the frontend gate
+  should normally have prevented this but the worker is still the
+  authoritative gate.
+- Legacy `window.open` GitHub fallback path (when the worker is
+  unavailable or fetch is missing): the pre-filled GitHub URL body
+  also carries the "Submitted by: <name>" line so both submission
+  paths produce equivalent issue bodies.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: The Report Feedback dialog MUST display an Author input
+  field positioned above the Title field, labelled "Author", marked
+  visibly as required.
+- **FR-002**: The Submit button MUST be disabled while the Author
+  field's trimmed value is empty, in addition to the existing
+  Title-empty and length-cap gates.
+- **FR-003**: The dialog MUST show inline validation indicating the
+  Author field is required when it is empty (consistent with the
+  existing inline error surface used for other validation failures -
+  no separate alert dialog, no submission attempt).
+- **FR-004**: The submitted GitHub issue body composed by the feedback
+  worker MUST include a single line "Submitted by: <name>" derived
+  from the trimmed Author value, attributable to the dialog input.
+- **FR-005**: The last-used non-empty Author value MUST be persisted
+  in browser localStorage on successful submission and used to
+  pre-fill the Author field the next time the dialog is opened in the
+  same browser profile.
+- **FR-006**: The Author value MUST be carried in the payload sent to
+  the feedback worker as a dedicated, required field - not folded into
+  the body string by the frontend - so the worker is the canonical
+  composer of the "Submitted by:" line.
+- **FR-007**: The legacy `window.open` GitHub-prefill fallback path
+  MUST also include the "Submitted by: <name>" line in the prefilled
+  body so both submission paths produce equivalent GitHub issue bodies
+  (Principle XIII canonical observable behaviour across the worker and
+  the documented external-degradation path).
+- **FR-008**: The feedback worker MUST validate Author as a required,
+  non-empty, trimmed string with a published maximum character length,
+  and MUST reject payloads missing or violating that contract with the
+  same 400 error shape used by the existing required-field
+  validations.
+- **FR-009**: The Author character cap MUST be expressed once, in the
+  shared feedback contract JSON consumed by both the Go renderer and
+  the worker, so the frontend Submit gate and the worker validator
+  enforce identical limits.
+
+### Canonical Path Expectations
+
+- **Canonical owner/path**: The Report Feedback dialog UI lives in
+  `render/templates/report.html.tmpl` (markup), `render/feedback.go`
+  (Go view + contract loading), `render/assets/feedback-contract.json`
+  (single source of truth for limits and categories), and the dialog
+  JavaScript split across `render/assets/app-js/03.js` and
+  `render/assets/app-js/04.js`. The submit-time worker path lives in
+  `feedback-worker/src/validate.ts` (payload validation),
+  `feedback-worker/src/feedback-contract.ts` (shared contract import),
+  and `feedback-worker/src/body.ts` (issue body composition).
+- **Old path treatment**: The current dialog has no Author field. This
+  feature adds one canonical Author input + payload field + worker
+  validation rule + body-composition line; nothing is replaced or
+  duplicated. The legacy GitHub `window.open` fallback's body
+  composer (`maybePrefixBody` in `app-js/03.js`) is updated to also
+  emit the "Submitted by:" line so the two submission paths converge
+  on a single observable body shape; no parallel composer is added.
+- **External degradation**: localStorage absence (private window,
+  quota error, browser policy) is a genuine external browser-boundary
+  outcome - the field still works, the user types their name, the
+  submission still succeeds, only the next-time pre-fill is skipped.
+  This degradation is observable in the dialog (empty field on next
+  open) and explicitly tested.
+- **Review check**: Reviewer verifies (a) the Author cap is read from
+  the shared contract JSON in both Go and TypeScript, not duplicated;
+  (b) the "Submitted by:" line is composed exactly once, on the worker
+  body composer, and the legacy fallback URL builder mirrors the same
+  line format; (c) no shim defaults the worker payload's `author`
+  field to an empty string or "Anonymous" - a missing or empty
+  `author` is a 400.
+
+### Key Entities
+
+- **FeedbackPayload (extension)**: The JSON payload POSTed to the
+  worker gains a required string field `author` (trimmed,
+  non-empty, length-capped per the contract).
+- **FeedbackContract (extension)**: The shared contract JSON gains a
+  `limits.authorMaxChars` integer used by both the Go renderer's
+  Submit-gate validation and the worker's payload validation.
+- **PersistedAuthor**: A localStorage entry under a stable key holding
+  the last successfully-submitted non-empty Author value as plain text.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: 100% of GitHub issues created via the Report Feedback
+  dialog after this feature ships carry a "Submitted by: <name>"
+  attribution line in the issue body.
+- **SC-002**: The dialog blocks Submit when Author is empty in 100%
+  of attempts; no submission lacking an Author can reach the worker
+  via the normal UI gate.
+- **SC-003**: A user who submits feedback once and reopens the dialog
+  in the same browser session sees their previous name pre-filled
+  without retyping, in 100% of cases where browser localStorage is
+  writable.
+- **SC-004**: Both the Worker submission path and the legacy GitHub
+  `window.open` fallback path produce GitHub issue bodies that contain
+  the same "Submitted by: <name>" line for the same input.
+
+## Assumptions
+
+- The display name typed into the Author field is plain text - not
+  required to match a GitHub handle, email, or SSO identity. Triagers
+  use it as a free-form attribution.
+- Author character cap is set to 80 - long enough for "First Last
+  (Team)" style names, short enough to fit on the GitHub issue title
+  preview row when surfaced inline. Encoded in the contract JSON.
+- The localStorage key namespace is `mygather.feedback.lastAuthor`
+  (single key, plain text value).
+- Persistence happens on definitive submit success (worker 200), not
+  on every keystroke and not on dialog cancel - so a half-typed,
+  abandoned name does not pollute the next session.
+- The dialog already has a single inline error surface
+  (`#feedback-error`); no new visual surface is introduced for the
+  Author validation message.
+- The worker contract version is forward-only: older report binaries
+  that lack the Author field will be unable to POST successfully (the
+  worker will 400 them) once this contract change ships. There is no
+  back-compat shim; this is intentional under Principle XIII.
+- File-size budget under Principle XV: the JS files
+  `render/assets/app-js/03.js` (~898 lines) and `04.js` (~490 lines)
+  are close to the 1000-line cap; the Author wiring is small enough
+  to land within budget. If the diff would push 03.js over the cap,
+  the planner extracts the dialog wiring into a new ordered
+  `render/assets/app-js/05.js` rather than merging a violation.

--- a/specs/021-feedback-author-field/tasks.md
+++ b/specs/021-feedback-author-field/tasks.md
@@ -1,0 +1,138 @@
+# Tasks: Required Author field on Report Feedback
+
+**Feature**: 021-feedback-author-field
+**Branch**: `021-feedback-author-field`
+**Plan**: [plan.md](plan.md) | **Spec**: [spec.md](spec.md) | **Contracts**: [contracts/author-field.md](contracts/author-field.md)
+
+---
+
+## Phase 1 — Setup
+
+(No project initialization needed; the renderer and worker exist.)
+
+- [ ] T001 Confirm clean baseline: `go test ./...` and `cd feedback-worker && npm test` both pass on the current branch tip.
+
+---
+
+## Phase 2 — Foundational (blocking prerequisites)
+
+These wire the new Author cap into the canonical contract JSON
+consumed by both Go and TypeScript. Both user stories depend on
+this.
+
+- [ ] T010 Add `"authorMaxChars": 80` inside `limits` in `render/assets/feedback-contract.json` (canonical single source of truth, contract C1).
+- [ ] T011 Extend `feedbackContract.Limits` in `render/feedback.go` with `AuthorMaxChars int` (JSON tag `authorMaxChars`); extend the positivity panic in `loadFeedbackContract`; add `AuthorMaxChars int` (godoc-commented) to `FeedbackView`; populate it in `BuildFeedbackView` (contract C3).
+- [ ] T012 [P] Extend `FeedbackContract.limits` interface in `feedback-worker/src/feedback-contract.ts` with `authorMaxChars: number` (the existing `assertPositiveInteger` walk catches it automatically) (contract C5).
+
+---
+
+## Phase 3 — User Story 1: Sign your feedback before sending it (Priority: P1)
+
+**Goal**: An Author field appears in the dialog, gates Submit, rides
+on the worker payload, and produces a `Submitted by: <name>` line in
+the GitHub issue body. Both the worker and the legacy
+`window.open` fallback paths emit the same line.
+
+**Independent Test**: Open the dialog, type Author + Title + Body,
+Submit. The created GitHub issue body's first line is
+`Submitted by: <typed-name>`. With Author empty, Submit is disabled.
+
+### Worker side (validation + body composition)
+
+- [ ] T020 [US1] Add `author_required` and `author_too_long` to `ValidationError`; add `author: string` to `ValidatedPayload`; insert a required+length-cap author block immediately after the title block in `validatePayload` in `feedback-worker/src/validate.ts`. Reject missing/non-string/empty/whitespace-only as `author_required`; reject over-cap as `author_too_long`; store `value.trim()` on success (contract C4).
+- [ ] T021 [US1] In `feedback-worker/src/body.ts#buildIssueBody`, prepend two lines to the output: `Submitted by: ${payload.author}` followed by an empty line, before the existing `> Category:` block (contract C6, R3).
+- [ ] T022 [US1] Update `feedback-worker/test/validate.test.ts`: (a) add cases for missing/empty/whitespace-only/over-cap author returning the new error codes; (b) update every existing happy-path test fixture to include a valid `author` field so they still pass (contract C4, quickstart Step 3 #6, #8).
+- [ ] T023 [P] [US1] Update `feedback-worker/test/body.test.ts`: assert the first line of the composed body is `Submitted by: <author>`, followed by exactly one blank line; update existing test fixtures to pass an `author` (contract C6, quickstart Step 3 #7).
+- [ ] T024 [P] [US1] Update `feedback-worker/test/index.test.ts` and any other worker test that constructs a payload to include a valid `author` field (so existing tests do not regress on `author_required`).
+- [ ] T025 [P] [US1] Update `feedback-worker/test/github-app.test.ts` and `feedback-worker/test/ratelimit.test.ts` payload fixtures to include `author` if they construct full request bodies.
+
+### Frontend side (markup + wiring)
+
+- [ ] T030 [US1] Edit `render/templates/report.html.tmpl` to insert the Author field block immediately before the `feedback-field-title` block. The input MUST have id `feedback-field-author`, name `author`, type `text`, autocomplete `name`, placeholder `Your name`, attribute `required`, and `maxlength="{{ .Feedback.AuthorMaxChars }}"`. The label reads `Author` with a visible `<span class="feedback-field-req">required</span>` adornment (contract C2).
+- [ ] T031 [US1] Edit `render/assets/app-js/03.js#initFeedbackDialog`:
+  - Add `var authorInput = document.getElementById("feedback-field-author");`.
+  - In `updateSubmitEnabled`, add Author check after the existing `titleLen === 0` gate: disable Submit if `authorInput.value.trim().length === 0` OR `authorInput.value.length > LIMITS.authorMaxChars`.
+  - In `closeDialog`, after the existing `titleInput.value = ""; bodyInput.value = ""; catSelect.value = "";`, add `authorInput.value = "";`.
+  - Add `authorInput.addEventListener("input", onFormContentChange);` next to the existing input listeners.
+  - Update `maybePrefixBody`: prepend `"Submitted by: " + authorInput.value.trim() + "\n\n"` before the existing optional `> Category:` block (contract C8, C9).
+- [ ] T032 [US1] Edit `render/assets/app-js/04.js#doSubmit`: in the payload-building block, add `payload.author = authorInput.value.trim();` (contract C7).
+- [ ] T033 [US1] Edit `render/feedback_test.go`: add an assertion that `BuildFeedbackView().AuthorMaxChars` equals the value in the embedded `feedback-contract.json` (proves the Go side reads from the canonical source, not a hardcoded constant).
+- [ ] T034 [US1] Edit `render/report_feedback_test.go`: add assertions that the rendered HTML contains an element with `id="feedback-field-author"` AND that this element appears before the `feedback-field-title` element (substring index check on the rendered output).
+
+**Checkpoint**: After T020–T034, run `go test ./...` and
+`cd feedback-worker && npm test`. Both must pass. Manual smoke: build,
+generate report, open dialog — Author field visible above Title,
+Submit disabled until Author + Title both non-empty, successful
+submission produces issue body whose first line is
+`Submitted by: <name>`.
+
+---
+
+## Phase 4 — User Story 2: Don't retype your name every time (Priority: P2)
+
+**Goal**: The last successfully submitted Author value is stored in
+`localStorage` and pre-fills the field on next dialog open. Private
+mode / quota errors degrade silently to "field is empty".
+
+**Independent Test**: Submit feedback once with Author "Jane". Close
+dialog. Reopen — Author field shows "Jane". Open in a private window
+where localStorage is blocked — Author field is empty, submission
+still works.
+
+- [ ] T040 [US2] In `render/assets/app-js/03.js#initFeedbackDialog`, add two helpers (both `try/catch`-wrapped so a localStorage exception silently degrades to "no persistence"):
+  - `function loadPersistedAuthor() { try { var v = window.localStorage.getItem("mygather.feedback.lastAuthor") || ""; return v.length > LIMITS.authorMaxChars ? v.slice(0, LIMITS.authorMaxChars) : v; } catch (_) { return ""; } }`.
+  - `function savePersistedAuthor(v) { try { if (v) window.localStorage.setItem("mygather.feedback.lastAuthor", v); } catch (_) {} }`.
+- [ ] T041 [US2] In `render/assets/app-js/03.js#openDialog`, after `form.hidden = false;` and before `dialog.showModal();`, add: `if (authorInput.value === "") { authorInput.value = loadPersistedAuthor(); }`.
+- [ ] T042 [US2] In `render/assets/app-js/04.js#doSubmit`, in the worker-success arm right where `renderSuccess(data.issueUrl, data.issueNumber);` is called, add `savePersistedAuthor(payload.author);` immediately before `renderSuccess(...)` so the value is captured on definitive success only (R5).
+- [ ] T043 [US2] Add browser-DOM coverage for the persistence behaviour. Since the existing repo has no JS test runner for the embedded report assets, document the manual acceptance walk in the quickstart (already present in Step 6 of `specs/021-feedback-author-field/quickstart.md`) and add a Go-side test in `render/feedback_test.go` (or a new file) that asserts the literal string `mygather.feedback.lastAuthor` appears exactly twice in the embedded JS bundle (once for `getItem`, once for `setItem`) — preventing typo drift between read and write call sites.
+
+**Checkpoint**: After T040–T043, manual walk: submit once, close,
+reopen — field pre-filled. Open in private window — field empty,
+submission still succeeds.
+
+---
+
+## Phase 5 — Polish & Cross-Cutting
+
+- [ ] T050 Run `go test ./...` from the repo root. The size test (`tests/coverage/file_size_test.go`), godoc coverage, and determinism test all must pass. Fix any failure caused by the diff.
+- [ ] T051 Run `cd feedback-worker && npm test`. All tests must pass.
+- [ ] T052 Run `bash scripts/hooks/pre-push-constitution-guard.sh` from the repo root. All gates must pass.
+- [ ] T053 Confirm CLAUDE.md, AGENTS.md, and `.specify/feature.json` already point at `021-feedback-author-field` (done in `/speckit.plan` step). Re-verify with `cat .specify/feature.json` and `head -15 CLAUDE.md AGENTS.md`.
+- [ ] T054 Update any committed `.golden` snapshots whose rendered HTML now includes the new Author field block, by running `go test ./... -update` once and reviewing the diff to confirm only the dialog markup changed (Principle VIII: golden refresh is an explicit reviewed step).
+- [ ] T055 Commit, push, open PR titled `Required Author field on Report Feedback (#56)` with body referencing GitHub issue #56 and summarising the four touched surfaces (contract JSON, Go view, frontend dialog wiring, Cloudflare Worker validate+body+contract).
+
+---
+
+## Dependencies
+
+- Phase 1 (T001) is informational; failures here block everything.
+- Phase 2 (T010, T011, T012) is blocking foundation. Both user stories
+  read `LIMITS.authorMaxChars` from the contract; without T010 the
+  field cannot be defined; without T011 the Go side cannot expose it
+  to the template; without T012 the worker cannot validate it.
+- Phase 3 (US1) depends on Phase 2 complete.
+- Phase 4 (US2) depends on Phase 3 complete (the Author field must
+  exist in the dialog markup before persistence can pre-fill it).
+- Phase 5 polish runs after both stories are implemented.
+
+## Parallel opportunities
+
+- T012 can run in parallel with T011 (different sub-projects).
+- T023, T024, T025 can run in parallel with each other (each updates
+  a separate worker test file).
+- T030 (HTML template) is independent of T020–T025 (worker side) and
+  could be drafted in parallel, but Phase 3 is best executed worker-
+  first so the JS gate matches a worker contract that already
+  validates author.
+
+## Implementation strategy
+
+- **MVP scope**: Phase 1 + 2 + 3 (User Story 1) only. That is the
+  full content of GitHub issue #56: "Author field is required, body
+  carries `Submitted by:`."
+- **Incremental delivery**: Phase 4 (US2 — localStorage pre-fill) is
+  a UX papercut fix and can ship in the same PR or a follow-up. Per
+  the user decision sheet for this feature it ships in the same PR.
+- **Constitution gates**: T050–T052 run all mechanical gates (file
+  size, godoc, determinism, English-only, CGO/network/write
+  forbidden in restricted packages). Fix red gates before push.


### PR DESCRIPTION
## Summary

Closes #56. The Report Feedback dialog now exposes a required Author input above Title; Submit is gated on Author non-empty (mirroring the existing Title gate). The trimmed Author value rides as a dedicated field on the worker payload, and the Cloudflare Worker prepends a `Submitted by: <name>` line as the first line of the GitHub issue body so triagers can attribute every report. The legacy `window.open` GitHub-prefill fallback path emits the same line so both submission paths produce equivalent issue bodies (Principle XIII canonical observable behaviour).

The last successfully-submitted Author is persisted in browser `localStorage` under key `mygather.feedback.lastAuthor` and rehydrated on the next dialog open. localStorage absence (private window, quota, security policy) silently degrades to an empty field — submission still succeeds (Principle III graceful degradation, observable browser-boundary).

The Author character cap (80) lives once in `render/assets/feedback-contract.json` and is consumed by both the Go renderer (frontend Submit gate, `<input maxlength=...>`) and the worker validator (`author_required` / `author_too_long`), so the two limits cannot drift (Principle XIII canonical path).

## Spec pipeline

- Spec: `specs/021-feedback-author-field/spec.md`
- Plan: `specs/021-feedback-author-field/plan.md`
- Research: `specs/021-feedback-author-field/research.md`
- Data model: `specs/021-feedback-author-field/data-model.md`
- Contract: `specs/021-feedback-author-field/contracts/author-field.md`
- Tasks: `specs/021-feedback-author-field/tasks.md`
- Quickstart: `specs/021-feedback-author-field/quickstart.md`

## Code-change surfaces

- **Canonical contract**: `render/assets/feedback-contract.json` (+`limits.authorMaxChars: 80`); mirrored type extensions in `render/feedback.go` (`AuthorMaxChars` on `feedbackContract.Limits` and exported on `FeedbackView`) and `feedback-worker/src/feedback-contract.ts`.
- **Frontend dialog**: `render/templates/report.html.tmpl` (Author input above Title with `required` + `maxlength`), `render/assets/app-css/03.css` (new `.feedback-field-req` badge style), `render/assets/app-js/03.js` (Author ref, Submit gate, `loadPersistedAuthor`/`savePersistedAuthor`, `maybePrefixBody` carries the `Submitted by:` line for the legacy fallback URL), `render/assets/app-js/04.js` (open-time pre-fill, close-time reset, `payload.author` field, persist on definitive worker success).
- **Cloudflare Worker**: `feedback-worker/src/validate.ts` (`author_required`/`author_too_long` errors, required+trim+cap), `feedback-worker/src/body.ts` (`Submitted by: <name>` as the first line of every composed issue body).

## Tests added

- `feedback-worker/test/validate.test.ts`: missing/non-string/empty/whitespace-only/over-cap author cases + happy-path trim assertion.
- `feedback-worker/test/body.test.ts`: inline snapshots updated; new test asserts the attribution line ordering.
- `feedback-worker/test/index.test.ts`: existing fixtures carry `author` so they do not regress on `author_required`.
- `render/feedback_test.go`: `AuthorMaxChars` exposed and matches contract; embedded JS bundle references `LIMITS.authorMaxChars`; `mygather.feedback.lastAuthor` literal appears in both read and write call sites (typo-drift guard).
- `render/report_feedback_test.go`: `feedback-field-author` present in markup with `required` + `maxlength`; positioned before `feedback-field-title`.

## Test plan

- [x] `go test ./...` passes (file size, godoc coverage, determinism gates included)
- [x] `cd feedback-worker && npm test` passes (60/60)
- [x] `CONSTITUTION_GUARD_CI=1 bash scripts/hooks/pre-push-constitution-guard.sh` passes
- [ ] Manual: build, generate report, open dialog, verify Author field above Title, submit successfully, verify GitHub issue body's first line is `Submitted by: <name>`
- [ ] Manual: close dialog, reopen, verify Author pre-filled from previous submission
- [ ] Manual: open in private window, verify Author empty + submission still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)