### PR TITLE
Changelog automation + v0.4.0 backfill (PR 022)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,14 +20,18 @@ concurrency:
 #
 #   lint    ──┐
 #   test    ──┼──► determinism   ──┐
-#   worker  ──┤                    ├──► release ──► publish-release (tags only)
-#             └──► cross-compile ──┘
+#   worker  ──┤                    ├──► release ──┐
+#             └──► cross-compile ──┘              ├──► publish-release (tags only)
+#                                changelog-gate ──┘
 #
 # - lint, test, and worker start in parallel from the worker pool (no `needs:`).
 # - determinism and cross-compile both wait for test to pass; they
 #   would otherwise duplicate the test job's compile work and consume
 #   runner minutes for nothing if the unit tests were broken.
 # - release waits for all four to be green.
+# - changelog-gate runs only on tag pushes and confirms CHANGELOG.md
+#   has a `## ${TAG} (` heading; publish-release `needs:` it so a tag
+#   without a curated changelog section cannot ship binaries.
 #
 # Module caching is handled by actions/setup-go@v5 (`cache: true` is
 # the default; we set it explicitly so the contract is visible).
@@ -206,21 +210,47 @@ jobs:
           name: my-gather-dist
           path: dist/
 
+  changelog-gate:
+    name: changelog gate
+    runs-on: ubuntu-latest
+    if: startsWith(github.ref, 'refs/tags/v')
+    steps:
+      - uses: actions/checkout@v4
+      - name: Verify CHANGELOG.md has a section for the pushed tag
+        run: |
+          set -eu
+          TAG="${GITHUB_REF#refs/tags/}"
+          if ! grep -qF "## ${TAG} (" CHANGELOG.md; then
+            echo "CHANGELOG.md is missing a \`## ${TAG} (YYYY-MM-DD)\` section. Add it before tagging." >&2
+            exit 1
+          fi
+
   publish-release:
     name: publish release artifacts
     runs-on: ubuntu-latest
-    needs: [release]
+    needs: [release, changelog-gate]
     if: startsWith(github.ref, 'refs/tags/v')
     permissions:
       contents: write
     steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - uses: actions/download-artifact@v4
         with:
           name: my-gather-dist
           path: dist/
+      - name: Build release notes from CHANGELOG.md
+        run: |
+          set -eu
+          TAG="${GITHUB_REF#refs/tags/}"
+          LC_ALL=C scripts/release/extract-changelog-section.sh "$TAG" CHANGELOG.md > dist/RELEASE_NOTES.md
+          ls -l dist/RELEASE_NOTES.md
+          wc -l dist/RELEASE_NOTES.md
       - name: Attach to GitHub Release
         uses: softprops/action-gh-release@v2.0.8
         with:
+          body_path: dist/RELEASE_NOTES.md
           files: |
             dist/my-gather_*.tar.gz
             dist/my-gather-darwin-amd64

--- a/.specify/feature.json
+++ b/.specify/feature.json
@@ -1,3 +1,3 @@
 {
-  "feature_directory": "specs/020-report-theming"
+  "feature_directory": "specs/022-changelog-release-pipeline"
 }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,18 +1,20 @@
 <!-- SPECKIT START -->
-Active feature: **020-report-theming**
+Active feature: **022-changelog-release-pipeline**
 
 For technologies, project structure, constitution gates, data model,
 contracts, and shell commands, read the current plan:
 
-- Plan: `specs/020-report-theming/plan.md`
-- Spec: `specs/020-report-theming/spec.md`
-- Research: `specs/020-report-theming/research.md`
-- Contracts: `specs/020-report-theming/contracts/theming.md`
-- Quickstart: `specs/020-report-theming/quickstart.md`
-- Tasks: `specs/020-report-theming/tasks.md`
+- Plan: `specs/022-changelog-release-pipeline/plan.md`
+- Spec: `specs/022-changelog-release-pipeline/spec.md`
+- Research: `specs/022-changelog-release-pipeline/research.md`
+- Contracts: `specs/022-changelog-release-pipeline/contracts/extract.md`
+- Quickstart: `specs/022-changelog-release-pipeline/quickstart.md`
+- Tasks: `specs/022-changelog-release-pipeline/tasks.md`
 - Constitution: `.specify/memory/constitution.md`
 
 Prior features:
+- **021-feedback-author-field** - `specs/021-feedback-author-field/plan.md`
+- **020-report-theming** - `specs/020-report-theming/plan.md`
 - **015-compliance-closure** - `specs/015-compliance-closure/plan.md`
 - **014-reconciliation-cleanup** - `specs/014-reconciliation-cleanup/plan.md`
 - **013-full-compliance-fixes** - `specs/013-full-compliance-fixes/plan.md`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,86 @@
 
 All notable changes to my-gather are tracked here. Dates are UTC.
 
+## v0.4.0 (2026-05-07)
+
+Six-feature roll-up since v0.3.1: streaming over the 1 GiB cap,
+synchronized chart zoom + windowed legend stats, top-CPU caption +
+mysqld pin, the InnoDB redo-log sizing panel, runtime theming, and a
+required Author field on the feedback dialog. Plus the release
+pipeline itself now sources GitHub Release bodies from this file.
+
+### Added
+
+- Synchronized chart zoom across the report: a single
+  `__chartSyncStore` singleton drives shared zoom state, and
+  per-series Min/Avg/Max in the legend recompute over the visible
+  window. Stacked processlist dimensions get windowed stats from raw
+  values; the HLL sparkline is canonically exempt (#51, #52, feature
+  017).
+- "Top CPU processes" caption ("Showing the top 3 processes by
+  average CPU. When mysqld is running, it is always included, even
+  when it is not in the top 3.") with an accurate aria-label and a
+  regression test on the mysqld-pin invariant (#54, feature 018).
+- InnoDB redo-log sizing panel with full MySQL version coverage:
+  5.6 / 5.7 use `innodb_log_file_size` x `innodb_log_files_in_group`,
+  8.0.30+ uses `innodb_redo_log_capacity`. Reports observed write
+  rate (negative-delta clamp), 15-minute rolling peak with full-window
+  guard, coverage minutes, 15-minute and 1-hour recommendations, and
+  a warning when coverage is under 15 minutes. Cites Percona
+  KB0010732 (#55, feature 019).
+- Three themes selectable at runtime: light, dark (default), and
+  Okabe-Ito color-blind-safe. Selection is persisted in
+  `localStorage["my-gather:theme"]`. A single CSS-variable token
+  block in `04.css` carries 16 distinct `--series-N` values per theme;
+  `color-scheme` is set per theme. A pre-paint script in `<head>`
+  applies the persisted theme before first paint to avoid FOUC. Live
+  theme switches re-paint open charts via a `mygather:theme` event;
+  the HLL sparkline has its own local listener; legend swatches use
+  `var(--series-N)` so they re-resolve automatically (#53, feature
+  020).
+- Required Author field on the Report Feedback dialog. Submit is
+  blocked while the trimmed value is empty. The last-used Author is
+  persisted in localStorage on definitive worker success only
+  (snapshot at submit time). The Worker rejects empty,
+  whitespace-only, and over-cap payloads with typed errors. Issue
+  bodies on both submission paths (worker and legacy `window.open`
+  fallback) are prepended with "Submitted by: <name>" so triagers can
+  attribute reports without scrolling git blame. The 80-character
+  Author cap is expressed once in `feedback-contract.json` and
+  consumed by the Go view, the JS form gate, and the TypeScript
+  worker (#56, feature 021).
+
+### Changed
+
+- Removed the hard 1 GiB collection-size cap. The streaming invariant
+  is now locked by a peak-heap-sampler regression test that parses
+  1.19 GB of input at roughly 3 MiB resident heap. The spec-required
+  64 GiB archive-extraction ceiling is preserved as a zip-bomb defence
+  (#50, feature 016).
+- Theming pass deletes parallel paths superseded by the runtime theme
+  selector: the `prefers-color-scheme` media-query block, the
+  `SERIES_COLORS` JavaScript array, and the hardcoded `#6b8eff`
+  swatch are gone. Single source of truth is the CSS variable block
+  in `04.css` (#53, feature 020).
+
+### Build / tooling
+
+- GitHub Release bodies are now sourced from this `CHANGELOG.md` via
+  `scripts/release/extract-changelog-section.sh`, which the
+  `publish-release` job in `.github/workflows/ci.yml` invokes to
+  produce `dist/RELEASE_NOTES.md` and pass it as `body_path` to
+  `softprops/action-gh-release@v2.0.8`.
+- New CI job `changelog-gate` runs on tag pushes and fails the
+  workflow if `CHANGELOG.md` has no `## vX.Y.Z (YYYY-MM-DD)` heading
+  matching the pushed tag. `publish-release` declares
+  `needs: [release, changelog-gate]` so a tag without a curated
+  section cannot ship binaries (feature 022).
+- Regression test under `tests/release/` exec's the extraction
+  script against the in-repo `CHANGELOG.md` for both `v0.3.1` and
+  `v0.4.0`, asserting the output is bounded by the next `## v`
+  heading and that every feature attribution (016 through 021) is
+  present in the v0.4.0 body (feature 022).
+
 ## v0.3.1 (2026-04-23)
 
 Patch release for the feedback Worker path and report integration.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,18 +1,20 @@
 <!-- SPECKIT START -->
-Active feature: **020-report-theming**
+Active feature: **022-changelog-release-pipeline**
 
 For technologies, project structure, constitution gates, data model,
 contracts, and shell commands, read the current plan:
 
-- Plan: `specs/020-report-theming/plan.md`
-- Spec: `specs/020-report-theming/spec.md`
-- Research: `specs/020-report-theming/research.md`
-- Contracts: `specs/020-report-theming/contracts/theming.md`
-- Quickstart: `specs/020-report-theming/quickstart.md`
-- Tasks: `specs/020-report-theming/tasks.md`
+- Plan: `specs/022-changelog-release-pipeline/plan.md`
+- Spec: `specs/022-changelog-release-pipeline/spec.md`
+- Research: `specs/022-changelog-release-pipeline/research.md`
+- Contracts: `specs/022-changelog-release-pipeline/contracts/extract.md`
+- Quickstart: `specs/022-changelog-release-pipeline/quickstart.md`
+- Tasks: `specs/022-changelog-release-pipeline/tasks.md`
 - Constitution: `.specify/memory/constitution.md`
 
 Prior features:
+- **021-feedback-author-field** - `specs/021-feedback-author-field/plan.md`
+- **020-report-theming** - `specs/020-report-theming/plan.md`
 - **015-compliance-closure** - `specs/015-compliance-closure/plan.md`
 - **014-reconciliation-cleanup** - `specs/014-reconciliation-cleanup/plan.md`
 - **013-full-compliance-fixes** - `specs/013-full-compliance-fixes/plan.md`

--- a/scripts/release/extract-changelog-section.sh
+++ b/scripts/release/extract-changelog-section.sh
@@ -1,0 +1,71 @@
+#!/bin/sh
+# extract-changelog-section.sh — canonical CHANGELOG.md section extractor.
+#
+# Synopsis:
+#   extract-changelog-section.sh <tag> [<changelog-path>]
+#
+# Prints to stdout the lines of the section whose heading begins with
+# "## <tag> (", excluding the heading line itself, terminating
+# immediately before the next "## v" heading or at end-of-file.
+#
+# Single canonical implementation (Principle XIII). Consumed unmodified
+# by .github/workflows/ci.yml (publish-release) and by
+# tests/release/extract_changelog_section_test.go.
+#
+# Exit codes:
+#   0  success
+#   1  no matching "## <tag> (" heading found in the changelog
+#   2  usage error or unreadable changelog
+set -eu
+
+LC_ALL=C
+export LC_ALL
+
+usage() {
+	echo "usage: extract-changelog-section.sh <tag> [<changelog-path>]" >&2
+}
+
+if [ $# -lt 1 ] || [ -z "$1" ]; then
+	usage
+	exit 2
+fi
+
+TAG=$1
+CHANGELOG=${2:-CHANGELOG.md}
+
+if [ ! -r "$CHANGELOG" ]; then
+	echo "extract-changelog-section.sh: cannot read $CHANGELOG" >&2
+	exit 2
+fi
+
+# Verify the heading exists before extracting, so a missing tag is a
+# distinct exit code (1) from "found, here's the body" (0).
+if ! grep -qF "## ${TAG} (" "$CHANGELOG"; then
+	echo "extract-changelog-section.sh: no section for tag ${TAG} in ${CHANGELOG}" >&2
+	exit 1
+fi
+
+# Extract: starting at the line AFTER the matching heading, print every
+# line up to (but not including) the next "## v" heading or end-of-file.
+# The "in_section" / "found" two-state machine handles both the
+# "section in the middle of the file" and "section is the last in the
+# file" cases without a fallback path.
+awk -v tag="$TAG" '
+BEGIN {
+	heading = "## " tag " ("
+	in_section = 0
+}
+{
+	if (in_section) {
+		if (index($0, "## v") == 1) {
+			exit
+		}
+		print
+		next
+	}
+	if (index($0, heading) == 1) {
+		in_section = 1
+		next
+	}
+}
+' "$CHANGELOG"

--- a/specs/022-changelog-release-pipeline/checklists/requirements.md
+++ b/specs/022-changelog-release-pipeline/checklists/requirements.md
@@ -1,0 +1,41 @@
+# Specification Quality Checklist: Changelog-driven release pipeline + v0.4.0 backfill
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-05-07
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- Items marked incomplete require spec updates before `/speckit.clarify` or `/speckit.plan`
+- This spec deliberately mentions concrete artifact names (`.github/workflows/ci.yml`,
+  `CHANGELOG.md`, `softprops/action-gh-release@v2.0.8`, `scripts/release/`) under
+  Functional Requirements and Canonical Path Expectations because the feature is a
+  pipeline/tooling change whose canonical-code location (Principle XIII) is itself
+  the contract under review. These references identify the canonical owner/path,
+  which the constitution requires; they are not implementation leakage into a
+  user-facing capability.

--- a/specs/022-changelog-release-pipeline/contracts/extract.md
+++ b/specs/022-changelog-release-pipeline/contracts/extract.md
@@ -1,0 +1,108 @@
+# Contract: `scripts/release/extract-changelog-section.sh`
+
+## Synopsis
+
+```sh
+scripts/release/extract-changelog-section.sh <tag> [<changelog-path>]
+```
+
+- `<tag>` (required): the git tag whose changelog section is
+  extracted, including the `v` prefix. Examples: `v0.4.0`,
+  `v0.3.1`, `v0.4.0-rc1`.
+- `<changelog-path>` (optional): path to the changelog file.
+  Defaults to `CHANGELOG.md` relative to the current working
+  directory.
+
+## Behaviour
+
+The script reads `<changelog-path>` and writes to standard output
+the lines of the section whose heading begins with `## <tag> (`,
+beginning with the first line AFTER the heading, and ending
+immediately BEFORE the next line that begins with `## v`. If the
+matching section is the last in the file, extraction terminates at
+end-of-file.
+
+The script:
+- MUST omit the `## <tag> (...)` heading line itself.
+- MUST include all blank lines and bullet lines between the matched
+  heading and the next `## v` heading verbatim.
+- MUST exit non-zero with a clear stderr message when no matching
+  heading is found.
+- MUST exit non-zero with a clear stderr message when the
+  required `<tag>` argument is absent or empty.
+- MUST be invoked with `LC_ALL=C` so byte ordering is locale-stable.
+
+## Output examples
+
+Given a `CHANGELOG.md` containing:
+
+```
+## v0.4.0 (2026-05-07)
+
+### Added
+
+- New thing A.
+
+### Fixed
+
+- Bug B.
+
+## v0.3.1 (2026-04-23)
+
+Patch.
+```
+
+Then `extract-changelog-section.sh v0.4.0` prints to stdout:
+
+```
+
+### Added
+
+- New thing A.
+
+### Fixed
+
+- Bug B.
+
+```
+
+(Note the leading and trailing blank lines, which are part of the
+section. The release-notes body on GitHub renders them harmlessly.)
+
+And `extract-changelog-section.sh v0.3.1` prints:
+
+```
+
+Patch.
+```
+
+## Error contract
+
+- Missing or empty `<tag>` argument: stderr "usage:
+  extract-changelog-section.sh <tag> [<changelog-path>]"; exit 2.
+- `<changelog-path>` does not exist or is unreadable: stderr
+  "extract-changelog-section.sh: cannot read <path>"; exit 2.
+- No matching `## <tag> (` heading found in the file: stderr
+  "extract-changelog-section.sh: no section for tag <tag> in
+  <path>"; exit 1.
+- Otherwise: exit 0.
+
+## Caller obligations
+
+- The CI workflow MUST `actions/checkout@v4` the repository before
+  invoking the script so `CHANGELOG.md` is on disk.
+- The Go regression test MUST exec the script via `os/exec` from
+  the repository root (where `CHANGELOG.md` lives) and compare
+  stdout to its assertions.
+
+## Rationale notes
+
+- The script is the SINGLE canonical parser of `CHANGELOG.md` for
+  release-note extraction. CI YAML MUST NOT inline `awk` or `sed`
+  duplicating this logic; the regression test MUST NOT
+  re-implement it. (Principle XIII canonical code path.)
+- The release-time gate `changelog-gate` does NOT call this script;
+  it only `grep -F`s for the literal heading. The two checks have
+  different shapes (gate = "exists?", extract = "give me the
+  body"), and entangling them would be over-engineering. Both
+  agree on the heading shape `## <tag> (`.

--- a/specs/022-changelog-release-pipeline/plan.md
+++ b/specs/022-changelog-release-pipeline/plan.md
@@ -1,0 +1,201 @@
+# Implementation Plan: Changelog-driven release pipeline + v0.4.0 backfill
+
+**Branch**: `022-changelog-release-pipeline` | **Date**: 2026-05-07 | **Spec**: [spec.md](./spec.md)
+**Input**: Feature specification from `specs/022-changelog-release-pipeline/spec.md`
+
+## Summary
+
+Wire `CHANGELOG.md` into the GitHub release pipeline so the GitHub
+Release page body is the curated section for the pushed tag, and add
+a release-time gate that fails the workflow when the tag has no
+matching `## vX.Y.Z (YYYY-MM-DD)` heading. Backfill the
+`## v0.4.0 (2026-05-07)` section above `## v0.3.1` covering the six
+features (016-021) merged into main since v0.3.1.
+
+Approach: a single canonical shell script under `scripts/release/`
+extracts the section for a given tag from `CHANGELOG.md`. The
+existing `publish-release` job in `.github/workflows/ci.yml` gains an
+`actions/checkout` step (currently absent), runs the script to write
+`dist/RELEASE_NOTES.md`, and passes `body_path: dist/RELEASE_NOTES.md`
+to the existing pinned `softprops/action-gh-release@v2.0.8`. A new
+job `changelog-gate` runs `grep -F` for the literal `## ${TAG} (`
+heading on tag pushes and is added to `publish-release`'s `needs:`.
+A Go regression test under `tests/release/` exec's the same script
+against the in-repo `CHANGELOG.md` and asserts on its output for both
+`v0.3.1` and `v0.4.0`.
+
+## Technical Context
+
+**Language/Version**: Go 1.23 (pinned in `go.mod`); POSIX `sh` + `awk`
+for the extraction script; GitHub Actions YAML.
+**Primary Dependencies**: `softprops/action-gh-release@v2.0.8` (pinned,
+unchanged); `actions/checkout@v4` (already used elsewhere in the
+workflow); `actions/download-artifact@v4` (already used). No new
+third-party Go modules. No new GitHub Actions.
+**Storage**: N/A. The release notes file `dist/RELEASE_NOTES.md` is
+ephemeral, materialised in the runner's workspace and consumed in the
+same job.
+**Testing**: `go test ./tests/release/...` exec's the shell script via
+`os/exec`. The shell script is also exercised in CI by being the
+production extraction path.
+**Target Platform**: GitHub Actions `ubuntu-latest` runner for the
+release jobs. Local developers (macOS, Linux) for the regression test.
+**Project Type**: Tooling / release pipeline. No application code
+changes.
+**Performance Goals**: N/A. Extraction runs once per release tag.
+**Constraints**: Zero new third-party Go dependencies (Principle X).
+Single static binary unaffected (Principle I) - this is workflow +
+docs + a shell script + a Go test, none of which alter the shipped
+binary. English-only artifacts (Principle XIV). No fallback paths
+(Principle XIII): the extraction script is the only parser of
+`CHANGELOG.md`; CI YAML calls it, the test calls it, no inline `awk`.
+**Scale/Scope**: One new shell script (~30 lines), one new Go test
+file (~80 lines), edits to one workflow file, one new section in
+`CHANGELOG.md`, three context-file pointer updates.
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+Walking the 15 principles:
+
+- **I. Single Static Binary**: Unaffected. The change is workflow
+  + docs + a shell script + a Go test; none touch the Go binary's
+  build path.
+- **II. Read-Only Inputs**: Unaffected. The extraction script reads
+  `CHANGELOG.md` (a tracked artifact, not a pt-stalk input) and
+  writes to `dist/RELEASE_NOTES.md` inside the runner's workspace.
+- **III. Graceful Degradation**: N/A. This feature is the release
+  pipeline; "graceful degradation" applies to runtime parsing of
+  user inputs, not to a maintainer-time release-tag workflow. The
+  gate is intentionally fail-fast: a missing changelog section is
+  a hard failure, not a degraded path.
+- **IV. Deterministic Output**: The extraction script produces
+  byte-identical output on byte-identical `CHANGELOG.md` input
+  (POSIX `awk` operating in a single-byte locale; we set
+  `LC_ALL=C`).
+- **V. Self-Contained HTML Reports**: Unaffected.
+- **VI. Library-First Architecture**: N/A. The extraction is a
+  10-line shell script, not Go code. Adding it to the Go renderer
+  would violate the "thin CLI over libraries" intent and Principle
+  X (minimal Go dependencies); a shell script is the correct tool
+  for "given a markdown file and a tag, print the section". The
+  Go test exec's it, which means the contract is enforced
+  type-safely from the test side.
+- **VII. Typed Errors**: Unaffected. The Go test uses standard
+  `t.Fatalf` / `t.Errorf`; no new error types are added.
+- **VIII. Reference Fixtures & Golden Tests**: N/A. No new collector
+  parser. The regression test under `tests/release/` exercises the
+  in-repo `CHANGELOG.md` directly rather than golden-diffing
+  because the input IS the artifact being tested - a separate
+  golden would just duplicate the source of truth and bit-rot.
+- **IX. Zero Network at Runtime**: Unaffected. The extraction
+  script is filesystem-only. The CI workflow already does network
+  in the publish step (uploading artifacts to the GitHub release);
+  this feature does not add new network calls.
+- **X. Minimal Dependencies**: No new Go modules. No new GitHub
+  Actions. The shell script uses POSIX `sh` + `awk`, both
+  pre-installed on `ubuntu-latest` and macOS.
+- **XI. Reports Optimized for Humans Under Pressure**: N/A
+  (release pipeline, not the report).
+- **XII. Pinned Go Version**: Unaffected.
+- **XIII. Canonical Code Path (NON-NEGOTIABLE)**: This is the
+  load-bearing principle for this feature. Audit follows below.
+- **XIV. English-Only Durable Artifacts**: All new artifacts
+  (spec, plan, tasks, research, quickstart, the shell script, the
+  Go test, the v0.4.0 changelog section) are English-only.
+- **XV. Bounded Source File Size**: All new files are well under
+  1000 lines. `CHANGELOG.md` is documentation, exempt from XV.
+
+**Canonical Path Audit (Principle XIII)**:
+- Canonical owner/path for touched behaviour:
+  - `.github/workflows/ci.yml` is the canonical CI workflow.
+  - `scripts/release/extract-changelog-section.sh` is the new
+    canonical extraction implementation.
+  - `tests/release/extract_changelog_section_test.go` is the
+    canonical regression test that exec's the script.
+  - `CHANGELOG.md` is the canonical changelog content.
+- Replaced or retired paths: The current `publish-release` step
+  invocation of `softprops/action-gh-release@v2.0.8` without
+  `body_path` is amended in place; no parallel step is added.
+  GitHub's auto-generated commit-list body is exactly what this
+  feature replaces.
+- External degradation paths, if any: A tag whose changelog section
+  is heading-only (no bullets) yields an empty release-notes body.
+  This is observable on the release page and is a content-author
+  problem, not a pipeline failure. The `changelog-gate` deliberately
+  checks only "heading exists", not "section is non-empty", because
+  the latter has too many failure modes (e.g., a section that is
+  intentionally just a date pointer to a follow-up). This boundary
+  is documented in `spec.md` and verified by the regression test
+  shape.
+- Review check: Reviewer verifies (a) the extraction script is the
+  only parser of `CHANGELOG.md` for release notes (no inline `awk`
+  in the workflow YAML, no second parser in the Go test); (b) the
+  gate is a separate job rather than a step inside `publish-release`
+  so the CI graph names the failure surface; (c) both
+  `changelog-gate` and `publish-release` perform `actions/checkout`
+  (the previous `publish-release` did not); (d) no
+  `changelog/unreleased/` fragment directory or fragment-merge step
+  is introduced (user explicitly rejected that approach in the
+  feature task).
+
+Constitution Check: PASS. No violations to track.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/022-changelog-release-pipeline/
+├── plan.md              # This file
+├── spec.md              # Feature specification
+├── research.md          # Phase 0 output
+├── quickstart.md        # Phase 1 output
+├── contracts/
+│   └── extract.md       # Extraction script contract
+├── checklists/
+│   └── requirements.md  # Spec quality checklist
+└── tasks.md             # Phase 2 output (created by /speckit.tasks)
+```
+
+A `data-model.md` is intentionally omitted: this feature has no
+domain entities beyond the trivial "tag -> changelog section"
+mapping already covered by `spec.md` Key Entities.
+
+### Source Code (repository root)
+
+```text
+.github/
+└── workflows/
+    └── ci.yml                    # MODIFIED: add changelog-gate job;
+                                  # add checkout + extraction step to
+                                  # publish-release; add body_path
+
+scripts/
+└── release/
+    └── extract-changelog-section.sh  # NEW: canonical extractor
+
+tests/
+└── release/
+    └── extract_changelog_section_test.go  # NEW: regression test
+
+CHANGELOG.md                       # MODIFIED: prepend v0.4.0 section
+CLAUDE.md                          # MODIFIED: point at 022
+AGENTS.md                          # MODIFIED: point at 022
+.specify/feature.json              # MODIFIED: point at 022
+```
+
+**Structure Decision**: This is a tooling/pipeline change, not an
+application change. There is no `src/` reorganisation. The new
+canonical paths are listed above and match the existing repository
+layout (`scripts/` for shell tooling, `tests/<package>/` for Go
+tests, `.github/workflows/` for CI).
+
+## Complexity Tracking
+
+No constitutional violations require justification. The complexity
+of "a separate job for the gate vs. a step inside publish-release"
+is documented in spec.md (FR-007, Canonical Path Audit) as a
+deliberate readability choice on the CI graph, not a complexity
+escalation.

--- a/specs/022-changelog-release-pipeline/quickstart.md
+++ b/specs/022-changelog-release-pipeline/quickstart.md
@@ -1,0 +1,80 @@
+# Quickstart: Changelog-driven release pipeline
+
+## Cut a release after this feature ships
+
+1. Decide the new version (e.g., `v0.4.1`).
+2. Edit `CHANGELOG.md`. Add a new section above the previous one:
+
+   ```markdown
+   ## v0.4.1 (YYYY-MM-DD)
+
+   ### Fixed
+
+   - One-line description of the fix, citing PR number.
+   ```
+
+   Use v0.2.0 / v0.4.0 as exemplars for the subsection structure
+   (`### Added`, `### Changed`, `### Fixed`, `### Build / tooling`).
+   Omit subsections that have no bullets.
+
+3. Commit the changelog edit on `main`.
+4. Tag the commit: `git tag v0.4.1 && git push origin v0.4.1`.
+5. Watch GitHub Actions:
+   - `changelog-gate` runs first on the tag and confirms
+     `## v0.4.1 (` exists in `CHANGELOG.md`.
+   - `release` builds and uploads the artifacts.
+   - `publish-release` checks out the repo, extracts the
+     v0.4.1 section into `dist/RELEASE_NOTES.md`, and attaches it
+     as the GitHub Release body.
+
+## What happens if the changelog section is missing
+
+The `changelog-gate` job fails with:
+
+```
+CHANGELOG.md is missing a `## v0.4.1 (YYYY-MM-DD)` section. Add it before tagging.
+```
+
+`publish-release` is skipped (not just failed - it has
+`needs: [release, changelog-gate]`, so the gate's failure prevents
+it from starting). The maintainer:
+
+1. Adds the missing section to `CHANGELOG.md`.
+2. Commits and pushes the fix to `main`.
+3. Deletes the failed tag locally and on GitHub:
+   `git push origin :v0.4.1 && git tag -d v0.4.1`.
+4. Re-tags the new commit and re-pushes.
+
+## Run the regression test locally
+
+```sh
+go test ./tests/release/...
+```
+
+The test exec's `scripts/release/extract-changelog-section.sh`
+against the in-repo `CHANGELOG.md` for both `v0.3.1` and `v0.4.0`
+and asserts:
+
+- The body does not contain any `## v` heading.
+- The body's first non-blank line is the section's first non-blank
+  line below the heading.
+- For `v0.4.0`, the body mentions each of `016`, `017`, `018`,
+  `019`, `020`, `021` as a substring.
+
+## Run the extraction script by hand
+
+From the repo root:
+
+```sh
+scripts/release/extract-changelog-section.sh v0.4.0
+```
+
+Output is the lines of the v0.4.0 section, excluding the
+`## v0.4.0 (...)` heading itself, terminating before the next
+`## v` heading.
+
+Set `LC_ALL=C` if you want byte-stable output across locales:
+
+```sh
+LC_ALL=C scripts/release/extract-changelog-section.sh v0.4.0 > /tmp/notes.md
+```

--- a/specs/022-changelog-release-pipeline/research.md
+++ b/specs/022-changelog-release-pipeline/research.md
@@ -1,0 +1,138 @@
+# Research: Changelog-driven release pipeline
+
+## Decision: extraction tool
+
+**Decision**: POSIX `sh` + `awk`, packaged as a single shell script
+under `scripts/release/extract-changelog-section.sh`.
+
+**Rationale**: The job is "given a markdown file and a tag string,
+print the lines of the matching `## vX.Y.Z (...)` section excluding
+the heading and stopping before the next `## v` heading". `awk`'s
+range-and-pattern model expresses this in one expression. Using Go
+would require either a new package under `tools/` (Principle X
+overhead) or shipping the parser in the release binary (Principle I:
+the binary's job is parsing pt-stalk, not its own changelog). A
+shell script is the right tool for a 30-line text transform invoked
+once per tag push.
+
+**Alternatives considered**:
+- Inline `awk` in workflow YAML: rejected by Principle XIII and by
+  testability. The user task explicitly requires the regression test
+  to exercise the same extraction logic that CI uses.
+- A new Go binary `cmd/extract-changelog`: rejected as overhead;
+  Principle X disfavours new dependencies and a 10-line shell
+  script does not justify a Go module + binary + test scaffolding.
+- `sed -n` + a hand-rolled state machine: works, but `awk`'s
+  built-in line-range matching is clearer.
+
+## Decision: heading inclusion in release-notes body
+
+**Decision**: Omit the `## vX.Y.Z (date)` heading line from the
+extracted body. Print only the lines AFTER the heading, up to (but
+not including) the next `## v` line.
+
+**Rationale**: The GitHub Release page renders the tag as the page
+title. Including the heading in the body duplicates that title and
+looks visually noisy. Other repositories (e.g., the Linux kernel
+changelogs are not relevant here, but cargo, rustc, and ripgrep all
+omit the heading from their GitHub release bodies) follow the same
+convention.
+
+**Alternatives considered**:
+- Include the heading: rejected on cosmetic grounds, documented in
+  spec.md Assumptions.
+
+## Decision: gate as separate job vs. step in publish-release
+
+**Decision**: Separate job `changelog-gate` with
+`if: startsWith(github.ref, 'refs/tags/v')` and
+`needs: []` (parallel to `release`).
+
+**Rationale**: A separate job names the failure surface in the CI
+graph - a maintainer looking at a failed run sees `changelog-gate`
+red and goes directly to "the changelog is wrong", without scrolling
+through the `publish-release` job's other steps. The job is cheap
+(one `checkout` + one `grep`); the runner-minute cost is negligible
+compared to the clarity benefit. `publish-release` declares
+`needs: [release, changelog-gate]` so the binary attach step cannot
+run when the gate fails.
+
+**Alternatives considered**:
+- Step inside `publish-release`: works mechanically but mixes the
+  failure surface with the binary upload's failure surface.
+  Rejected on UX grounds.
+
+## Decision: gate's grep pattern
+
+**Decision**: `grep -F "## ${TAG} ("` against `CHANGELOG.md`.
+
+**Rationale**: `grep -F` (fixed string) avoids regex escaping for
+the `.` in version numbers. The trailing `(` is the canonical
+heading shape (`## v0.4.0 (2026-05-07)`), so it disambiguates the
+heading from prose that incidentally mentions the version (e.g.,
+"upgraded from v0.3.1").
+
+**Alternatives considered**:
+- `grep -E "^## ${TAG} \\("`: equivalent under `set -o pipefail`
+  but requires regex escaping for the version's `.`. The fixed-string
+  version is one fewer thing to get wrong.
+
+## Decision: regression test placement
+
+**Decision**: `tests/release/extract_changelog_section_test.go`,
+exec'ing `scripts/release/extract-changelog-section.sh` via
+`os/exec` and asserting on stdout for `v0.3.1` and `v0.4.0` against
+the actual in-repo `CHANGELOG.md`.
+
+**Rationale**: Matches the existing repo convention of test
+packages under `tests/<area>/` (see `tests/coverage/`). Running
+under `go test ./...` means the constitution-guard pre-push hook
+already wraps it. Asserting against the live `CHANGELOG.md` rather
+than a fixture means a future bullet-cleanup that drops a feature
+attribution gets caught immediately.
+
+**Alternatives considered**:
+- A pure shell test under `scripts/release/`: works but doesn't
+  show up under `go test ./...`, which is the canonical "run all
+  tests" entry point in this repo.
+- A fixture changelog under `tests/release/testdata/`: rejected
+  because then the test wouldn't catch drift in the real
+  `CHANGELOG.md`; FR-013 (the substring assertions for feature
+  IDs 016-021) is the whole point.
+
+## Decision: actions/checkout in changelog-gate and publish-release
+
+**Decision**: Add `actions/checkout@v4` to both new/modified jobs.
+
+**Rationale**: The current `publish-release` only runs
+`actions/download-artifact@v4` and the release action; it does not
+check out the repository, so `CHANGELOG.md` is not on disk in that
+runner's workspace. Without checkout, both the extraction script
+and the gate's grep have nothing to read. This is a non-obvious
+correctness requirement called out by the advisor; the plan flags
+it as a load-bearing detail.
+
+**Alternatives considered**:
+- Pull `CHANGELOG.md` from the upload-artifact bundle: rejected
+  because `make release` does not put `CHANGELOG.md` into `dist/`,
+  and modifying `make release` is explicitly out of scope per the
+  task ("Do NOT change the existing release-artifact build steps").
+
+## Decision: backfill style for v0.4.0
+
+**Decision**: Use v0.2.0's `### Added` / `### Changed` / `### Fixed`
+/ `### Build / tooling` Keep-a-Changelog structure. Each feature
+gets bullets distributed across subsections by nature of change
+(e.g., 020 has a heavy ### Added of new themes plus a ### Changed
+note that the prefers-color-scheme block was deleted).
+
+**Rationale**: v0.2.0 is the only prior section that uses the full
+subsection structure; v0.3.0 and v0.3.1 are short paragraph entries
+because their releases were narrow patches. v0.4.0 covers six
+features with a mix of additive and replacement work, so it
+warrants the full structure. The user task explicitly names
+v0.2.0 as the structural exemplar.
+
+**Alternatives considered**:
+- Paragraph-style like v0.3.0/v0.3.1: rejected; six features need
+  bullets to be scannable.

--- a/specs/022-changelog-release-pipeline/spec.md
+++ b/specs/022-changelog-release-pipeline/spec.md
@@ -1,0 +1,314 @@
+# Feature Specification: Changelog-driven release pipeline + v0.4.0 backfill
+
+**Feature Branch**: `022-changelog-release-pipeline`
+**Created**: 2026-05-07
+**Status**: Draft
+**Input**: User description: "Wire CHANGELOG.md into the GitHub release pipeline (release notes sourced from the curated section, plus a release-time gate that fails when the tag has no matching section). Backfill the v0.4.0 (2026-05-07) section above v0.3.1 covering the six features (016 through 021) merged into main since v0.3.1."
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Curated release notes appear on the GitHub Releases page (Priority: P1)
+
+A maintainer cuts a tagged release by pushing `vX.Y.Z`. The CI release
+pipeline produces signed binaries and attaches them to a GitHub Release.
+The body of the GitHub Release page MUST be the curated
+`## vX.Y.Z (YYYY-MM-DD)` section copied verbatim from `CHANGELOG.md`,
+not GitHub's auto-generated commit list.
+
+**Why this priority**: This is the visible deliverable. Today the
+release page on `v0.3.1` has an empty body and a generic commit list,
+which is exactly the artifact a downstream user reads first when
+deciding whether to upgrade. Without this, the curated changelog might
+as well not exist.
+
+**Independent Test**: Push a `vX.Y.Z` tag whose matching `## vX.Y.Z (`
+heading exists in `CHANGELOG.md`. Open the resulting GitHub Release
+page. The body matches the lines from that heading down to (but not
+including) the next `## v` heading.
+
+**Acceptance Scenarios**:
+
+1. **Given** `CHANGELOG.md` contains a `## v0.4.0 (2026-05-07)`
+   section followed by `## v0.3.1 (2026-04-23)`, **When** the
+   maintainer pushes the tag `v0.4.0`, **Then** the GitHub Release
+   page body for `v0.4.0` contains exactly the lines of the v0.4.0
+   section through (but not including) the `## v0.3.1` heading.
+2. **Given** the previous scenario, **When** the body is rendered on
+   the GitHub Release page, **Then** the `## v0.4.0 (2026-05-07)`
+   heading line itself is omitted (the GitHub UI already shows the
+   tag as the page title; including the heading would duplicate it).
+3. **Given** the same tag is republished (workflow re-runs),
+   **When** the release notes are re-extracted, **Then** the body is
+   byte-identical to the first run for the same `CHANGELOG.md`
+   content.
+
+---
+
+### User Story 2 - Tag without a curated changelog entry is blocked (Priority: P1)
+
+A maintainer pushes a `vX.Y.Z` tag without first adding the matching
+`## vX.Y.Z (YYYY-MM-DD)` section to `CHANGELOG.md`. CI MUST fail the
+release workflow with a clear error message before any binary is
+attached to a GitHub Release. The maintainer adds the section,
+re-tags, and the release ships normally.
+
+**Why this priority**: Without the gate, the curated-changelog
+guarantee in User Story 1 is purely advisory. The whole point of
+sourcing release notes from the changelog is that there is always a
+curated section; if a missing section silently degrades to an empty
+body, the original problem returns.
+
+**Independent Test**: Locally, push (or simulate) a tag like
+`v9.9.9-test` for which `CHANGELOG.md` has no matching heading. The
+release workflow fails the gate job with the documented error
+message; no GitHub Release is created.
+
+**Acceptance Scenarios**:
+
+1. **Given** `CHANGELOG.md` has no `## v0.4.0 (` heading, **When**
+   the maintainer pushes the tag `v0.4.0`, **Then** the
+   `changelog-gate` CI job fails with the message
+   "CHANGELOG.md is missing a `## v0.4.0 (YYYY-MM-DD)` section. Add
+   it before tagging." and the `publish-release` job does not run.
+2. **Given** the previous failed run, **When** the maintainer adds
+   the v0.4.0 section to `CHANGELOG.md`, deletes and re-pushes the
+   tag, **Then** the gate passes and the release publishes with the
+   curated body from User Story 1.
+3. **Given** a non-tag push (branch push or pull request), **When**
+   CI runs, **Then** the `changelog-gate` and `publish-release` jobs
+   are both skipped (they run only on `refs/tags/v*`).
+
+---
+
+### User Story 3 - v0.4.0 changelog section reflects the six shipped features (Priority: P1)
+
+A user reading `CHANGELOG.md` after the v0.4.0 release sees a
+v0.4.0 (2026-05-07) section above v0.3.1 that lists every
+user-visible change merged since v0.3.1: streaming over the 1 GiB
+cap, synchronized chart zoom + windowed legend stats, top-CPU
+caption + mysqld pin, the InnoDB redo-log sizing panel, runtime
+theming, and the required Author field on the feedback dialog.
+
+**Why this priority**: The other two stories build the pipeline; this
+story populates the data the pipeline depends on for the next
+release. Without the backfill, User Story 1 ships an empty release
+body for `v0.4.0` and User Story 2's gate trips on the next tag.
+
+**Independent Test**: Open `CHANGELOG.md`. The first dated section
+is `## v0.4.0 (2026-05-07)`. It uses `### Added` / `### Changed` /
+`### Fixed` / `### Build / tooling` subsections (matching v0.2.0's
+structure). Each of features 016-021 is mentioned at least once,
+attributed by feature number and the merged PR number.
+
+**Acceptance Scenarios**:
+
+1. **Given** `CHANGELOG.md` after this feature ships, **When** a
+   reader scans the file top-down, **Then** the first dated entry is
+   `## v0.4.0 (2026-05-07)`, placed above `## v0.3.1 (2026-04-23)`.
+2. **Given** the v0.4.0 section, **When** the reader scans the
+   subsections, **Then** every feature 016, 017, 018, 019, 020, 021
+   is represented with a one-line bullet citing its PR number.
+3. **Given** the v0.4.0 section, **When** the extraction script
+   (User Story 1) is run with tag `v0.4.0`, **Then** the produced
+   release-notes body terminates immediately before the
+   `## v0.3.1 (2026-04-23)` heading and contains every bullet from
+   each subsection.
+
+---
+
+### Edge Cases
+
+- Tag named with extra suffix (e.g., `v0.4.0-rc1`): the gate looks
+  for a heading containing the literal tag including suffix
+  (`## v0.4.0-rc1 (`). If absent, the gate fails with the same
+  message. Pre-release tagging therefore requires a matching
+  pre-release section in `CHANGELOG.md`.
+- Tag whose section is the LAST section in the file (no following
+  `## v` heading): extraction terminates at end-of-file rather than
+  at a missing successor heading, so the bullet at the bottom of the
+  changelog is included.
+- `CHANGELOG.md` contains a heading line whose tag matches but uses
+  a non-date suffix (e.g., `## v0.4.0 (TBD)` rather than
+  `## v0.4.0 (YYYY-MM-DD)`): the gate accepts any text after `(`
+  because the gate's contract is "the section heading exists for
+  this tag", not "the date is well-formed". Date-formatting hygiene
+  is a review concern, not a release-blocking gate concern.
+- Maintainer pushes a tag, the gate fails, the maintainer fixes
+  `CHANGELOG.md` and re-pushes the tag without deleting the
+  GitHub-side tag first: GitHub rejects the push (tag already
+  exists). Documented in the gate's failure message? No - this is
+  standard git tag behaviour; the gate's job is to prevent the bad
+  release, not teach git. The gate message tells the maintainer to
+  fix the changelog before tagging; deleting and re-pushing the tag
+  is the maintainer's normal workflow.
+- Two release attempts for the same tag interleave (rare; would
+  require a force-push of the tag): each run independently extracts
+  from the current `CHANGELOG.md` on the tagged commit, so the
+  release body always matches the changelog at tag-creation time.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: The release publishing step MUST attach a release-notes
+  body to the GitHub Release that is the verbatim section of
+  `CHANGELOG.md` corresponding to the pushed tag, sourced from the
+  same `CHANGELOG.md` revision that is checked out at the tagged
+  commit.
+- **FR-002**: The extraction step MUST omit the `## vX.Y.Z (date)`
+  heading line from the produced release-notes body, on the rationale
+  that the GitHub Release page already displays the tag as the page
+  title and including the heading would duplicate that title in the
+  body.
+- **FR-003**: The extraction MUST terminate immediately before the
+  next `## v` heading (exclusive), or at end-of-file if the section
+  is the last in the changelog.
+- **FR-004**: The extraction MUST be implemented as a single canonical
+  shell script under `scripts/release/`, invoked unmodified by the
+  CI workflow and by the regression test. Inline `awk`/`sed` in
+  workflow YAML is prohibited so the extraction can be exercised by
+  tests.
+- **FR-005**: A new CI job `changelog-gate` MUST run before
+  `publish-release`, MUST trigger only on tag pushes
+  (`startsWith(github.ref, 'refs/tags/v')`), MUST check out the
+  repository so `CHANGELOG.md` is on disk, and MUST grep
+  `CHANGELOG.md` for the literal heading `## ${TAG} (` (where TAG
+  includes the `v` prefix).
+- **FR-006**: When the heading is missing, `changelog-gate` MUST
+  fail the workflow with the exact message
+  "CHANGELOG.md is missing a `## ${TAG} (YYYY-MM-DD)` section. Add
+  it before tagging." (with `${TAG}` interpolated to the actual
+  tag).
+- **FR-007**: The `publish-release` job MUST declare
+  `needs: [release, changelog-gate]` so a tag without a curated
+  section cannot ship binaries to a GitHub Release.
+- **FR-008**: The `publish-release` job MUST check out the
+  repository so `CHANGELOG.md` is on disk for the extraction step
+  (the existing job does not check out today; that omission is
+  load-bearing for this feature).
+- **FR-009**: `CHANGELOG.md` MUST gain a new section
+  `## v0.4.0 (2026-05-07)` placed immediately above the existing
+  `## v0.3.1 (2026-04-23)` heading.
+- **FR-010**: The v0.4.0 section MUST use the
+  Keep-a-Changelog subsection structure already established by
+  v0.2.0: `### Added`, `### Changed`, `### Fixed`,
+  `### Build / tooling` (omit a subsection only if it has no
+  bullets).
+- **FR-011**: The v0.4.0 section MUST cover every feature merged
+  into main since v0.3.1 (016, 017, 018, 019, 020, 021), with at
+  least one bullet per feature, attributed by PR number where the
+  bullet describes a single PR's outcome.
+- **FR-012**: A regression test under `tests/release/` MUST exec
+  the extraction script against the in-repo `CHANGELOG.md` for
+  both `v0.3.1` and `v0.4.0` and MUST assert (a) the produced body
+  starts with the first non-heading line of the section, (b) the
+  body does NOT contain any `## v` heading, and (c) the body's
+  last non-blank line is the last bullet of the section.
+- **FR-013**: The regression test for `v0.4.0` MUST additionally
+  assert that the body mentions each of `016`, `017`, `018`, `019`,
+  `020`, `021` as a substring, so a future cleanup of the v0.4.0
+  bullets cannot silently drop a feature attribution.
+
+### Canonical Path Expectations
+
+- **Canonical owner/path**: The release pipeline lives in
+  `.github/workflows/ci.yml` (the `release` and `publish-release`
+  jobs, plus the new `changelog-gate` job). The extraction logic
+  lives in a single shell script
+  `scripts/release/extract-changelog-section.sh` consumed by both
+  the CI step in `publish-release` and the regression test under
+  `tests/release/`. The curated content lives in `CHANGELOG.md` at
+  the repository root.
+- **Old path treatment**: The current `publish-release` step that
+  invokes `softprops/action-gh-release@v2.0.8` without `body_path`
+  is replaced in the same change: the action gains `body_path:
+  dist/RELEASE_NOTES.md` and a preceding step that materialises
+  that file. No parallel step is added; the existing one is
+  amended. The current absence of a release-notes file is not a
+  "fallback path" worth preserving - GitHub's auto-generated commit
+  list is exactly what this feature exists to replace.
+- **External degradation**: If the extraction script produces an
+  empty body for a tag that has a heading but no bullets (e.g., a
+  placeholder release entry), the release page body is empty. This
+  is observable on the release page and is a content-authoring
+  problem, not a pipeline failure. The gate's job is "section
+  exists"; the body's contents are the maintainer's responsibility.
+- **Review check**: Reviewer verifies (a) the extraction script is
+  the only place that parses `CHANGELOG.md` for release notes -
+  no inline `awk` in the workflow YAML, no second copy under
+  `tests/`; (b) the gate is a separate job rather than a step
+  inside `publish-release`, so the failure surface is explicit in
+  the CI graph; (c) `publish-release` and `changelog-gate` both
+  perform `actions/checkout` because the previous `publish-release`
+  job did not (it only downloaded the artifact); (d) no
+  `changelog/unreleased/` fragment directory or fragment-merge
+  step is introduced - the user explicitly rejected that approach.
+
+### Key Entities
+
+- **CHANGELOG section**: A contiguous block in `CHANGELOG.md` whose
+  first line is a heading of the form `## vX.Y.Z (YYYY-MM-DD)` and
+  whose subsequent lines run until the next `## v` heading or
+  end-of-file.
+- **Release notes file**: `dist/RELEASE_NOTES.md`, materialised
+  during the `publish-release` job by the extraction script,
+  consumed by `softprops/action-gh-release@v2.0.8` via `body_path`.
+- **Tag**: A git tag of the form `v*` (e.g., `v0.4.0`). The tag
+  name (including the `v`) is the lookup key for the changelog
+  section heading.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: 100% of tagged releases produced after this feature
+  ships display the curated `CHANGELOG.md` section as their GitHub
+  Release page body, with no GitHub auto-generated commit-list
+  fallback.
+- **SC-002**: 100% of attempts to push a `vX.Y.Z` tag whose
+  matching `## vX.Y.Z (` heading is missing from `CHANGELOG.md`
+  fail the CI release workflow before any binary is attached to a
+  GitHub Release.
+- **SC-003**: After this feature ships, `CHANGELOG.md` contains a
+  v0.4.0 (2026-05-07) section that documents all six features
+  (016 through 021) merged since v0.3.1, verifiable by reading the
+  file.
+- **SC-004**: The regression test under `tests/release/` runs as
+  part of `go test ./...` on every CI build and fails if either
+  the extraction script's behaviour drifts or the in-repo
+  `CHANGELOG.md` loses a documented feature attribution.
+
+## Assumptions
+
+- Tag prefix is always `v` (e.g., `v0.4.0`), matching the existing
+  workflow trigger `tags: ["v*"]` in `.github/workflows/ci.yml`.
+  Pre-release suffixes (e.g., `v0.4.0-rc1`) are looked up by their
+  full literal tag including suffix.
+- The release-notes body intentionally omits the `## vX.Y.Z (date)`
+  heading line. The GitHub Release page renders the tag as its title;
+  including the heading in the body would duplicate it. This is the
+  silent default chosen for this feature; the inverse choice
+  (include the heading) was rejected as cosmetically inferior.
+- The `softprops/action-gh-release@v2.0.8` pin is preserved; this
+  feature only adds `body_path:` to the existing `with:` block, it
+  does not bump the action.
+- The gate uses `grep -F` (fixed string) on the literal
+  `## ${TAG} (` to avoid regex escaping issues with `.` in version
+  numbers.
+- The extraction script is POSIX `sh` + `awk` so it runs unchanged
+  on the `ubuntu-latest` runner used by the workflow and on a
+  developer's macOS shell for local testing.
+- The regression test is a Go test under `tests/release/` (matching
+  the repo's `tests/coverage/...` convention) that exec's the
+  extraction script via `os/exec` and asserts on its stdout. This
+  keeps validation in the same `go test ./...` umbrella that CI
+  already runs.
+- No changelog-fragment automation under `changelog/unreleased/`
+  is introduced. The user explicitly rejected that approach;
+  the canonical content lives in `CHANGELOG.md` directly.
+- File-size budget under Principle XV: `CHANGELOG.md` is a doc file
+  (not first-party source code) so the 1000-line cap does not
+  apply. The new shell script and Go test are well under cap.
+- The v0.4.0 section text is English-only per Principle XIV. ASCII
+  punctuation only (no smart quotes, em-dashes only via the
+  permitted character set).

--- a/specs/022-changelog-release-pipeline/tasks.md
+++ b/specs/022-changelog-release-pipeline/tasks.md
@@ -1,0 +1,271 @@
+---
+description: "Tasks: Changelog-driven release pipeline + v0.4.0 backfill"
+---
+
+# Tasks: Changelog-driven release pipeline + v0.4.0 backfill
+
+**Input**: Design documents from `specs/022-changelog-release-pipeline/`
+**Prerequisites**: plan.md, spec.md, research.md, contracts/extract.md, quickstart.md
+
+**Tests**: Yes — FR-012 / FR-013 / SC-004 require a Go regression test
+under `tests/release/` that exec's the canonical extraction script.
+
+**Organization**: Tasks grouped by user story; T001 is shared
+foundation since US1 and US2 both depend on the canonical extraction
+script existing.
+
+## Canonical Path Metadata *(Principle XIII)*
+
+- **Canonical owner/path**:
+  - `.github/workflows/ci.yml` (CI workflow)
+  - `scripts/release/extract-changelog-section.sh` (extractor)
+  - `tests/release/extract_changelog_section_test.go` (regression test)
+  - `CHANGELOG.md` (curated content)
+- **Old path treatment**: The `publish-release` step that invoked
+  `softprops/action-gh-release@v2.0.8` without `body_path` is amended
+  in T003. No parallel implementation remains.
+- **External degradation evidence**: Section-with-empty-body case
+  is documented in spec.md and verified by the regression test's
+  shape (body must not contain `## v`, but is allowed to be content
+  only - blank-body is observable on the release page).
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Independent file, no ordering dependency
+- **[Story]**: US1 (release notes from changelog), US2 (gate),
+  US3 (v0.4.0 backfill)
+
+---
+
+## Phase 1: Foundation (canonical extraction script)
+
+- [ ] **T001** [Foundation] Create `scripts/release/extract-changelog-section.sh`
+  per `contracts/extract.md`. POSIX `sh` + `awk`. Reads
+  `CHANGELOG.md` (default) or an explicit path argument. Prints
+  the lines of the section matching `## <tag> (` excluding the
+  heading, terminating before the next `## v` heading or
+  end-of-file. Exits non-zero with a clear stderr message when
+  the tag has no matching heading. `chmod +x`.
+
+**Checkpoint**: T001 is the dependency for US1 (CI step) and for
+the regression test under US2/US3.
+
+---
+
+## Phase 2: User Story 1 — Curated release notes appear on Releases page (P1)
+
+**Goal**: The GitHub Release page body for any tag is the curated
+section from `CHANGELOG.md`.
+
+**Independent test**: Push (or re-run on) a tag with a matching
+section; the GitHub Release page body matches the section.
+
+- [ ] **T002** [US1] In `.github/workflows/ci.yml`, add
+  `actions/checkout@v4` (with `fetch-depth: 0`) as the first step
+  of `publish-release`. Without this, `CHANGELOG.md` is not on
+  disk in the runner's workspace.
+- [ ] **T003** [US1] In `.github/workflows/ci.yml`, BETWEEN the
+  `download-artifact` step and the `Attach to GitHub Release`
+  step, add a "Build release notes from CHANGELOG.md" step that:
+  - sets `TAG="${GITHUB_REF#refs/tags/}"`
+  - runs `LC_ALL=C scripts/release/extract-changelog-section.sh
+    "$TAG" CHANGELOG.md > dist/RELEASE_NOTES.md`
+  - prints the file size of `dist/RELEASE_NOTES.md` for log clarity.
+- [ ] **T004** [US1] In `.github/workflows/ci.yml`, modify the
+  `Attach to GitHub Release` step's `with:` block to add
+  `body_path: dist/RELEASE_NOTES.md`. Keep
+  `softprops/action-gh-release@v2.0.8` pin unchanged.
+
+**Checkpoint**: US1 mechanically complete. The release page body
+will be curated for any subsequent tag whose section exists.
+
+---
+
+## Phase 3: User Story 2 — Tag without curated section is blocked (P1)
+
+**Goal**: A tag with no matching `## vX.Y.Z (` heading fails CI
+before any binary is published.
+
+**Independent test**: Push a tag for which `CHANGELOG.md` has no
+heading; `changelog-gate` fails with the documented message.
+
+- [ ] **T005** [US2] In `.github/workflows/ci.yml`, add a new job
+  `changelog-gate` after the existing jobs:
+  - `runs-on: ubuntu-latest`
+  - `if: startsWith(github.ref, 'refs/tags/v')`
+  - steps:
+    1. `actions/checkout@v4`
+    2. shell step that sets `TAG="${GITHUB_REF#refs/tags/}"`,
+       runs `grep -F "## ${TAG} (" CHANGELOG.md` and on failure
+       echoes "CHANGELOG.md is missing a `## ${TAG} (YYYY-MM-DD)`
+       section. Add it before tagging." to stderr and `exit 1`.
+- [ ] **T006** [US2] In `.github/workflows/ci.yml`, change
+  `publish-release.needs` from `[release]` to
+  `[release, changelog-gate]` so a missing changelog section
+  prevents `publish-release` from starting.
+- [ ] **T007** [US2] Update the comment block at the top of
+  `.github/workflows/ci.yml` (the ASCII job-graph diagram) so
+  it shows `changelog-gate` as a precondition for
+  `publish-release`. The diagram is documentation and MUST stay
+  in sync with the actual job graph.
+
+**Checkpoint**: US2 mechanically complete. The pipeline gates
+correctly on the heading's presence.
+
+---
+
+## Phase 4: User Story 3 — v0.4.0 backfill (P1)
+
+**Goal**: `CHANGELOG.md` carries a v0.4.0 (2026-05-07) section
+above v0.3.1 covering features 016-021.
+
+**Independent test**: Read `CHANGELOG.md`. The first dated entry
+is `## v0.4.0 (2026-05-07)`, structured with subsections, and
+mentions PRs #50, #51, #52, #53, #54, #55, #56.
+
+- [ ] **T008** [US3] Edit `CHANGELOG.md`. Insert a new section
+  `## v0.4.0 (2026-05-07)` between line 3
+  (`All notable changes...`) and the existing
+  `## v0.3.1 (2026-04-23)` heading. Use v0.2.0's Keep-a-Changelog
+  structure (`### Added` / `### Changed` / `### Fixed` /
+  `### Build / tooling`, omit subsections that have no bullets).
+  Cover features:
+  - **016 (#50)** under Changed: 1 GiB cap removed; streaming
+    invariant enforced by peak-heap-sampler regression test (1.19
+    GB at ~3 MiB heap). Spec-required 64 GiB archive-extraction
+    ceiling kept.
+  - **017 (#51, #52)** under Added: synchronized chart zoom and
+    per-series Min/Avg/Max in the legend recomputed over the
+    visible window via a single `__chartSyncStore` singleton;
+    HLL sparkline canonically exempt; stacked processlist
+    dimensions get windowed stats from raw values.
+  - **018 (#54)** under Added: Top CPU processes caption +
+    accurate aria-label + regression test on the mysqld-pin
+    invariant.
+  - **019 (#55)** under Added: InnoDB redo-log sizing panel with
+    full MySQL version coverage (5.6/5.7
+    `innodb_log_file_size` x `innodb_log_files_in_group` and
+    8.0.30+ `innodb_redo_log_capacity`); observed write rate
+    with negative-delta clamp; 15-minute rolling peak with
+    full-window guard; coverage minutes; 15-minute and 1-hour
+    recommendations; warning when coverage is under 15 minutes;
+    Percona KB0010732 cited.
+  - **020 (#53)** under Added: three themes (light, dark default,
+    Okabe-Ito color-blind-safe) selectable at runtime, persisted
+    in `localStorage["my-gather:theme"]`. Single CSS-variable
+    token block in `04.css` (16 distinct `--series-N` per theme).
+    `color-scheme` per theme. Pre-paint `<head>` script avoids
+    FOUC. Live theme switches re-paint open charts via
+    `mygather:theme` event; HLL sparkline has its own local
+    listener; legend swatches use `var(--series-N)` so they
+    re-resolve automatically.
+  - **020 (#53)** under Changed: deleted parallel paths -
+    `prefers-color-scheme` block, `SERIES_COLORS` JS array,
+    hardcoded `#6b8eff` swatch.
+  - **021 (#56)** under Added: required Author field on the
+    Report Feedback dialog; Submit blocked when empty;
+    last-used Author persisted in localStorage on definitive
+    worker-success only (snapshot at submit time). "Submitted
+    by: <name>" prepended to issue body in both worker and
+    legacy `window.open` paths. Single canonical
+    `authorMaxChars: 80` in `feedback-contract.json` consumed
+    by the Go view, JS form gate, and TS worker.
+  - Under Build / tooling: the changelog itself is now sourced
+    into the GitHub Release body via
+    `scripts/release/extract-changelog-section.sh`; tag pushes
+    are gated by `changelog-gate` so a missing section blocks
+    the release.
+- [ ] **T009** [US3] Verify `CHANGELOG.md` is well-formed after
+  the edit: every `## v` heading is followed by a date in
+  parentheses; no markdown lint warnings; UTF-8 ASCII-only
+  punctuation per Principle XIV.
+
+**Checkpoint**: US3 done. Backfill complete.
+
+---
+
+## Phase 5: Regression test
+
+- [ ] **T010** [US1+US2+US3] Create
+  `tests/release/extract_changelog_section_test.go`. The test
+  exec's `scripts/release/extract-changelog-section.sh` via
+  `os/exec` from the repo root and asserts:
+  - `extract v0.3.1` succeeds, stdout contains "Patch release"
+    (existing v0.3.1 prose), stdout contains no `## v` substring.
+  - `extract v0.4.0` succeeds, stdout contains all of `016`,
+    `017`, `018`, `019`, `020`, `021` as substrings, stdout
+    contains no `## v` substring, stdout's first non-blank line
+    is `### Added` or another `### ` subsection heading.
+  - `extract v9.9.9-nope` exits non-zero (no matching heading).
+  - The test discovers the repo root via `runtime.Caller` so it
+    runs from any working directory.
+
+**Checkpoint**: regression test landed. Future drift caught.
+
+---
+
+## Phase 6: Context-file alignment
+
+- [ ] **T011** [P] Update `.specify/feature.json` to point at
+  `specs/022-changelog-release-pipeline`.
+- [ ] **T012** [P] Update `CLAUDE.md` so "Active feature" is
+  `022-changelog-release-pipeline`, plan/spec/contract/research/
+  quickstart/tasks pointers reflect the new directory, and the
+  prior-features list gains `020-report-theming` and
+  `021-feedback-author-field`.
+- [ ] **T013** [P] Update `AGENTS.md` to mirror `CLAUDE.md`'s
+  feature pointer change.
+
+**Checkpoint**: side-by-side agent contract honoured. CLAUDE.md,
+AGENTS.md, and `.specify/feature.json` agree.
+
+---
+
+## Phase 7: Validation
+
+- [ ] **T014** Run `gofmt -w .`
+- [ ] **T015** Run `go vet ./...`
+- [ ] **T016** Run `go test ./...` (includes
+  `tests/release/...`, `tests/coverage/...`)
+- [ ] **T017** Run the pre-push constitution guard locally
+  (`scripts/hooks/pre-push-constitution-guard.sh`).
+- [ ] **T018** Validate workflow YAML by parsing it (`python3 -c
+  "import yaml; yaml.safe_load(open('.github/workflows/ci.yml'))"`
+  or `actionlint` if available).
+- [ ] **T019** Smoke-test the extraction script locally:
+  `scripts/release/extract-changelog-section.sh v0.3.1 |
+  head -5` and `... v0.4.0 | head -5`.
+
+---
+
+## Phase 8: Ship
+
+- [ ] **T020** Commit (single commit; conventional message
+  citing PR-022, the three problems, and the three fixes).
+- [ ] **T021** Push the branch.
+- [ ] **T022** Open the PR via `gh pr create --title
+  "Changelog automation + v0.4.0 backfill (PR 022)"` with a
+  summary referencing the three problems and the three fixes
+  plus a one-line note that this is a prerequisite for cutting
+  v0.4.0.
+
+## Dependencies
+
+- T001 is required by T003, T010, T019.
+- T002, T003, T004 are sequential edits to the same file
+  (`ci.yml`) so they MUST run in that order on the same diff.
+- T005, T006, T007 are sequential edits to `ci.yml` for the gate.
+  T005 must precede T006 (the `needs:` reference must resolve).
+- T008 (CHANGELOG backfill) is required by T010 (regression test
+  asserts on v0.4.0 substrings).
+- T011/T012/T013 are independent of each other and of T002-T008.
+- T014-T019 follow all earlier tasks.
+- T020-T022 follow all validation tasks.
+
+## Parallelism notes
+
+- T011, T012, T013 marked `[P]` (different files, no order).
+- The script-creation T001, the YAML edits T002-T007, and the
+  Go test T010 touch different files; T010 only depends on T001
+  + T008 having landed. The CHANGELOG edit T008 is independent
+  of the YAML and script work, but T010 needs both.

--- a/tests/release/extract_changelog_section_test.go
+++ b/tests/release/extract_changelog_section_test.go
@@ -1,0 +1,139 @@
+// Package release_test exercises the canonical release-pipeline shell
+// scripts under scripts/release/.
+//
+// extract_changelog_section_test exec's
+// scripts/release/extract-changelog-section.sh against the in-repo
+// CHANGELOG.md and asserts (a) the produced body is bounded by the
+// next "## v" heading, (b) for v0.4.0 every shipped feature
+// (016..021) is mentioned, and (c) a missing tag exits non-zero.
+//
+// This is the regression test for FR-012, FR-013, and SC-004 of
+// feature 022-changelog-release-pipeline.
+package release_test
+
+import (
+	"bytes"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+// repoRoot returns the absolute path to the repository root, derived
+// from the location of this test file. Walks up two levels:
+// tests/release/<this-file> -> tests/release -> tests -> repo root.
+func repoRoot(t *testing.T) string {
+	t.Helper()
+	_, file, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("runtime.Caller(0) failed; cannot locate test file")
+	}
+	root, err := filepath.Abs(filepath.Join(filepath.Dir(file), "..", ".."))
+	if err != nil {
+		t.Fatalf("filepath.Abs: %v", err)
+	}
+	return root
+}
+
+// runExtract execs the canonical extraction script with the given tag
+// and returns stdout, stderr, and the exit error (nil on exit code 0).
+func runExtract(t *testing.T, tag string) (stdout, stderr string, err error) {
+	t.Helper()
+	root := repoRoot(t)
+	cmd := exec.Command("scripts/release/extract-changelog-section.sh", tag)
+	cmd.Dir = root
+	cmd.Env = append(cmd.Environ(), "LC_ALL=C")
+	var outBuf, errBuf bytes.Buffer
+	cmd.Stdout = &outBuf
+	cmd.Stderr = &errBuf
+	err = cmd.Run()
+	return outBuf.String(), errBuf.String(), err
+}
+
+// TestExtractV031 asserts the script returns the v0.3.1 body, that
+// the body contains the existing v0.3.1 prose ("Patch release"), and
+// that the body does not leak into the next ## v heading.
+func TestExtractV031(t *testing.T) {
+	stdout, stderr, err := runExtract(t, "v0.3.1")
+	if err != nil {
+		t.Fatalf("extract v0.3.1 failed: %v\nstderr: %s", err, stderr)
+	}
+	if !strings.Contains(stdout, "Patch release") {
+		t.Errorf("v0.3.1 body missing the expected 'Patch release' prose; stdout was:\n%s", stdout)
+	}
+	if hasHeading(stdout) {
+		t.Errorf("v0.3.1 body leaked into the next section heading; stdout was:\n%s", stdout)
+	}
+}
+
+// hasHeading reports whether body contains any line that starts with
+// "## v" (i.e., a Keep-a-Changelog version heading). Substring matches
+// inside prose (e.g., the literal "## vX.Y.Z (YYYY-MM-DD)" form
+// quoted in changelog text) do NOT count, only true line-anchored
+// headings, which is what the extractor must terminate before.
+func hasHeading(body string) bool {
+	for _, line := range strings.Split(body, "\n") {
+		if strings.HasPrefix(line, "## v") {
+			return true
+		}
+	}
+	return false
+}
+
+// TestExtractV040 asserts the script returns the v0.4.0 body, that
+// every shipped feature (016..021) is mentioned (FR-013), that the
+// body does not contain any ## v heading, and that the body's first
+// non-blank line is a Keep-a-Changelog subsection heading.
+func TestExtractV040(t *testing.T) {
+	stdout, stderr, err := runExtract(t, "v0.4.0")
+	if err != nil {
+		t.Fatalf("extract v0.4.0 failed: %v\nstderr: %s", err, stderr)
+	}
+	if hasHeading(stdout) {
+		t.Errorf("v0.4.0 body leaked into the next section heading; stdout was:\n%s", stdout)
+	}
+	for _, id := range []string{"016", "017", "018", "019", "020", "021"} {
+		if !strings.Contains(stdout, id) {
+			t.Errorf("v0.4.0 body missing feature attribution %q (FR-013)", id)
+		}
+	}
+	for _, pr := range []string{"#50", "#51", "#52", "#53", "#54", "#55", "#56"} {
+		if !strings.Contains(stdout, pr) {
+			t.Errorf("v0.4.0 body missing PR attribution %q", pr)
+		}
+	}
+}
+
+// TestExtractMissingTag asserts the script exits non-zero when the
+// requested tag has no matching heading, with a clear stderr message.
+func TestExtractMissingTag(t *testing.T) {
+	stdout, stderr, err := runExtract(t, "v9.9.9-nope")
+	if err == nil {
+		t.Fatalf("extract for missing tag should have failed; stdout was: %q", stdout)
+	}
+	if !strings.Contains(stderr, "no section for tag v9.9.9-nope") {
+		t.Errorf("stderr should explain the missing tag; got: %q", stderr)
+	}
+	if stdout != "" {
+		t.Errorf("missing-tag run should produce no stdout; got: %q", stdout)
+	}
+}
+
+// TestExtractMissingArg asserts the script exits with usage when no
+// tag argument is provided.
+func TestExtractMissingArg(t *testing.T) {
+	root := repoRoot(t)
+	cmd := exec.Command("scripts/release/extract-changelog-section.sh")
+	cmd.Dir = root
+	cmd.Env = append(cmd.Environ(), "LC_ALL=C")
+	var outBuf, errBuf bytes.Buffer
+	cmd.Stdout = &outBuf
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err == nil {
+		t.Fatalf("extract without args should have failed; stdout was: %q", outBuf.String())
+	}
+	if !strings.Contains(errBuf.String(), "usage:") {
+		t.Errorf("stderr should print usage; got: %q", errBuf.String())
+	}
+}


### PR DESCRIPTION
## Summary

Wires `CHANGELOG.md` into the GitHub release pipeline and backfills the v0.4.0 (2026-05-07) section.

### Three problems closed

1. **No curated release body.** `publish-release` was calling `softprops/action-gh-release@v2.0.8` with no `body` / `body_path`, so the GitHub Release page showed an auto-generated commit list and ignored the curated `CHANGELOG.md` (verified empty body on v0.3.1).
2. **No release-time gate.** Nothing prevented pushing a `vX.Y.Z` tag whose version had no matching `## vX.Y.Z (YYYY-MM-DD)` section in `CHANGELOG.md`, so a release could ship with no curated entry.
3. **Stale changelog.** Latest entry was v0.3.1 (2026-04-23). Features 016-021 had merged into main since then and were not in the changelog.

### Three fixes shipped

- **(A) Release notes from CHANGELOG.** New canonical extractor `scripts/release/extract-changelog-section.sh` (POSIX `sh` + `awk`) prints the section for a tag, omitting the heading and terminating before the next `## v` heading. `publish-release` now `actions/checkout`s the repo, runs the script into `dist/RELEASE_NOTES.md`, and passes `body_path: dist/RELEASE_NOTES.md` to the existing pinned `softprops/action-gh-release@v2.0.8`.
- **(B) Release-time gate.** New CI job `changelog-gate` runs only on tag pushes, `grep -F`s for the literal `## ${TAG} (` heading, and fails with a clear error message when the heading is missing. `publish-release` declares `needs: [release, changelog-gate]` so a tag without a curated section cannot ship binaries.
- **(C) v0.4.0 backfill.** `CHANGELOG.md` gains a `## v0.4.0 (2026-05-07)` section above v0.3.1 in v0.2.0's Keep-a-Changelog style (`### Added` / `### Changed` / `### Fixed` / `### Build / tooling`) covering features 016-021 with PR attribution.

Single canonical extraction implementation per Principle XIII: no inline `awk` in the workflow YAML, no second parser in the test. The new Go regression test under `tests/release/` exec's the same script against the in-repo `CHANGELOG.md` and asserts on bounds, feature coverage (016-021), PR attribution (#50-#56), and the missing-tag error path.

This PR is a prerequisite for cutting `v0.4.0`: the gate will fail any future tag push that does not have a matching `CHANGELOG.md` heading.

## Test plan

- [x] `gofmt -l .` clean
- [x] `go vet ./...` clean
- [x] `go test ./...` passes (includes `tests/release/...` and `tests/coverage/...`)
- [x] `make lint` passes
- [x] Pre-push constitution guard exits 0
- [x] `.github/workflows/ci.yml` parses as valid YAML
- [x] Smoke-tested `scripts/release/extract-changelog-section.sh v0.3.1` and `v0.4.0` against the in-repo `CHANGELOG.md` (correct bodies; missing-tag exits 1 with documented stderr)
- [ ] First post-merge tag push exercises the new pipeline end-to-end on GitHub Actions

🤖 Generated with [Claude Code](https://claude.com/claude-code)