### PR TITLE
chore: sync nested discovery artifacts

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,18 +1,15 @@
 <!-- SPECKIT START -->
-Active feature: **023-nested-root-discovery**
+Active feature: **none**
 
-For technologies, project structure, constitution gates, data model,
-contracts, and shell commands, read the current plan:
-
-- Plan: `specs/023-nested-root-discovery/plan.md`
-- Spec: `specs/023-nested-root-discovery/spec.md`
-- Research: `specs/023-nested-root-discovery/research.md`
-- Contracts: `specs/023-nested-root-discovery/contracts/discovery.md`
-- Quickstart: `specs/023-nested-root-discovery/quickstart.md`
-- Tasks: `specs/023-nested-root-discovery/tasks.md`
-- Constitution: `.specify/memory/constitution.md`
+No active feature. The latest shipped feature is **023-nested-root-discovery**
+(`specs/023-nested-root-discovery`).
+`.specify/feature.json` may point at the latest shipped feature for
+script/reference purposes, but do not run `/speckit-*` workflows on
+`main` until a new feature branch is created and all active-feature
+signals are updated together.
 
 Prior features:
+- **023-nested-root-discovery** - `specs/023-nested-root-discovery/plan.md`
 - **015-compliance-closure** - `specs/015-compliance-closure/plan.md`
 - **014-reconciliation-cleanup** - `specs/014-reconciliation-cleanup/plan.md`
 - **013-full-compliance-fixes** - `specs/013-full-compliance-fixes/plan.md`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,18 +1,15 @@
 <!-- SPECKIT START -->
-Active feature: **023-nested-root-discovery**
+Active feature: **none**
 
-For technologies, project structure, constitution gates, data model,
-contracts, and shell commands, read the current plan:
-
-- Plan: `specs/023-nested-root-discovery/plan.md`
-- Spec: `specs/023-nested-root-discovery/spec.md`
-- Research: `specs/023-nested-root-discovery/research.md`
-- Contracts: `specs/023-nested-root-discovery/contracts/discovery.md`
-- Quickstart: `specs/023-nested-root-discovery/quickstart.md`
-- Tasks: `specs/023-nested-root-discovery/tasks.md`
-- Constitution: `.specify/memory/constitution.md`
+No active feature. The latest shipped feature is **023-nested-root-discovery**
+(`specs/023-nested-root-discovery`).
+`.specify/feature.json` may point at the latest shipped feature for
+script/reference purposes, but do not run `/speckit-*` workflows on
+`main` until a new feature branch is created and all active-feature
+signals are updated together.
 
 Prior features:
+- **023-nested-root-discovery** - `specs/023-nested-root-discovery/plan.md`
 - **015-compliance-closure** - `specs/015-compliance-closure/plan.md`
 - **014-reconciliation-cleanup** - `specs/014-reconciliation-cleanup/plan.md`
 - **013-full-compliance-fixes** - `specs/013-full-compliance-fixes/plan.md`

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ make build
 Point at any pt-stalk output directory:
 
 ```bash
-my-gather /path/to/pt-stalk-output -o /tmp/report.html
+my-gather -o /tmp/report.html /path/to/pt-stalk-output
 open /tmp/report.html           # macOS
 xdg-open /tmp/report.html       # Linux
 ```
@@ -67,7 +67,7 @@ xdg-open /tmp/report.html       # Linux
 Or try it against the bundled anonymised fixture:
 
 ```bash
-my-gather testdata/example2 -o /tmp/report.html --overwrite
+my-gather --overwrite -o /tmp/report.html testdata/example2
 open /tmp/report.html
 ```
 

--- a/specs/001-ptstalk-report-mvp/contracts/cli.md
+++ b/specs/001-ptstalk-report-mvp/contracts/cli.md
@@ -34,8 +34,9 @@ or two or more positional arguments is a usage error (exit code 2).
 | `--help` | `-h` | boolean | `false` | Print usage and exit 0. |
 
 Flag parsing uses Go's `flag` package. Long flags use `--name`; short
-flags are the letters shown above. Unknown flags are a usage error
-(exit code 2).
+flags are the letters shown above. Flags must appear before `<input>`;
+tokens after the first positional argument are treated as additional
+positionals. Unknown flags are a usage error (exit code 2).
 
 No environment-variable fallbacks. No config file. Any future knob is
 an explicit flag.
@@ -140,8 +141,9 @@ USAGE
   my-gather [flags] <input>
 
 ARGUMENTS
-  <input>    Path to a pt-stalk output directory or supported archive
-             (.zip, .tar, .tar.gz, .tgz, .gz).
+  <input>    Path to a pt-stalk output directory (or a directory that
+             contains one, searched up to 8 levels) or a supported
+             archive (.zip, .tar, .tar.gz, .tgz, .gz).
 
 FLAGS
   -o, --out <path>    Output HTML file path (default: ./report.html).
@@ -151,14 +153,14 @@ FLAGS
   -h, --help          Print this help and exit.
 
 EXIT CODES
-  0  success
-  2  usage error
-  3  input path missing or unreadable
-  4  input is not a pt-stalk directory
-  5  input exceeds supported size bounds (1 GB total / 200 MB per file)
-  6  output path exists (use --overwrite to replace)
-  7  output path resolves inside input directory (refusing to write)
-  70 internal error (please report)
+  0   success
+  2   usage error
+  3   input path missing or unreadable
+  4   input is not a pt-stalk directory
+  5   input exceeds supported size bounds (1 GB total / 200 MB per file)
+  6   output path exists (use --overwrite to replace)
+  7   output path resolves inside input directory (refusing to write)
+  70  internal error (please report)
 ```
 
 Help output goes to stdout, never stderr.

--- a/specs/016-remove-collection-size-cap/spec.md
+++ b/specs/016-remove-collection-size-cap/spec.md
@@ -18,7 +18,7 @@ and produces a useful HTML report.
 for the case it is most needed for. Removing the cap is the single change
 that unblocks every large-capture user.
 
-**Independent Test**: Run `my-gather <largeCaptureDir> -o /tmp/r.html` against
+**Independent Test**: Run `my-gather -o /tmp/r.html <largeCaptureDir>` against
 a >1.1 GiB synthetic or real capture and verify the binary exits 0 with the
 report generated.
 

--- a/specs/023-nested-root-discovery/contracts/discovery.md
+++ b/specs/023-nested-root-discovery/contracts/discovery.md
@@ -121,12 +121,16 @@ replaced. The bytes-extracted cap on archive input
 ### Directory input
 
 ```text
-my-gather <directory> [-o <output>]
+my-gather [flags] <directory>
 ```
 
 - If `<directory>` is itself recognised as a pt-stalk root (top-level
-  signal present), it is parsed directly. No subdirectory walk runs.
-  Behaviour is bit-identical to today.
+  signal present) and no other pt-stalk root is found in its bounded
+  subtree, it is parsed directly. Behaviour is bit-identical to today
+  for clean single-root inputs. The canonical walker still checks
+  descendants so an input that is itself a root and also contains a
+  nested root surfaces the same multi-root ambiguity as any other
+  multi-root tree.
 - Otherwise, the CLI walks subdirectories of `<directory>` up to a
   depth of 8, skipping hidden subdirectories (`.git`, `.cache`, etc.)
   and not following symlinks. The walk stops after the first 100000

--- a/specs/023-nested-root-discovery/quickstart.md
+++ b/specs/023-nested-root-discovery/quickstart.md
@@ -26,10 +26,13 @@ my-pt-collection/
 ```
 
 ```bash
-my-gather my-pt-collection -o report.html
+my-gather -o report.html my-pt-collection
 ```
 
-Behaviour: bit-identical to today. No subdirectory walk runs.
+Behaviour: bit-identical to today for clean single-root inputs. The
+canonical discovery walker still checks the bounded subtree so a
+synthetic root-plus-nested-root ambiguity is reported instead of
+silently selecting the top-level root.
 
 ### Layout 2: Capture nested in a single subdirectory
 
@@ -41,7 +44,7 @@ case-folder/
 ```
 
 ```bash
-my-gather case-folder -o report.html
+my-gather -o report.html case-folder
 ```
 
 Behaviour after this feature: the tool walks the input tree, finds
@@ -64,7 +67,7 @@ case-folder/
 ```
 
 ```bash
-my-gather case-folder -o report.html
+my-gather -o report.html case-folder
 ```
 
 Behaviour after this feature: the tool walks 6 levels in to find the
@@ -86,7 +89,7 @@ multi-host-case/
 ```
 
 ```bash
-my-gather multi-host-case -o report.html
+my-gather -o report.html multi-host-case
 ```
 
 Stderr (deterministic, lexically ordered; root paths are absolute):
@@ -103,7 +106,7 @@ Exit code: 4 (`exitNotAPtStalkDir`). No output file is written.
 ### Folder with no pt-stalk capture anywhere
 
 ```bash
-my-gather random-folder -o report.html
+my-gather -o report.html random-folder
 ```
 
 Stderr:
@@ -128,7 +131,7 @@ For a real-world spot check against the operator's local capture
 corpus, the fastest example is:
 
 ```bash
-my-gather "/Users/matias/Documents/Incidents/CS0061420" -o /tmp/c61420.html
+my-gather -o /tmp/c61420.html "/Users/matias/Documents/Incidents/CS0061420"
 ```
 
 (`CS0061420` has the deepest layout in the corpus: 7 directories
@@ -138,7 +141,7 @@ case has multiple host folders, so the expected outcome is the
 report. To get a successful report, point at one host:)
 
 ```bash
-my-gather "/Users/matias/Documents/Incidents/CS0061420/DBCLTIFT01PDC_logs" -o /tmp/c61420-host1.html
+my-gather -o /tmp/c61420-host1.html "/Users/matias/Documents/Incidents/CS0061420/DBCLTIFT01PDC_logs"
 ```
 
 ## Operator-facing release-note line

--- a/specs/023-nested-root-discovery/tasks.md
+++ b/specs/023-nested-root-discovery/tasks.md
@@ -134,16 +134,16 @@ output file.
   walker body of `parse.FindPtStalkRoot` so it (a) absolutises
   rootDir, (b) calls `parse.LooksLikePtStalkRoot` on every visited
   directory including rootDir itself, (c) uses `filepath.WalkDir`
-  with a closure that increments an entry
-  counter, computes depth from the relative path, returns
-  `filepath.SkipDir` for hidden dirs (`name[0] == '.'`) and for
-  any directory at or beyond `MaxDepth`, swallows non-nil
-  `walkErr` returns by returning nil, and calls
-  appends matching directories to a slice. The function MUST keep
-  walking after a match so an input that is itself a pt-stalk root
-  and also contains a nested pt-stalk root surfaces as a multi-root
-  ambiguity. Return `parse.ErrNotAPtStalkDir` when the slice is
-  empty, the single match when length is 1, or a
+  with a closure that increments an entry counter, computes depth
+  from the relative path, returns `fs.SkipDir` for hidden dirs
+  (`name[0] == '.'`) and for any directory at or beyond `MaxDepth`,
+  tolerates non-root `walkErr` values by pruning unreadable
+  directories with `fs.SkipDir` (or returning nil for non-directory
+  entries), and appends matching directories to a slice. The
+  function MUST keep walking after a match so an input that is
+  itself a pt-stalk root and also contains a nested pt-stalk root
+  surfaces as a multi-root ambiguity. Return `parse.ErrNotAPtStalkDir`
+  when the slice is empty, the single match when length is 1, or a
   `*parse.MultiplePtStalkRootsError` (with `Roots` sorted
   lexically) when length is >= 2. Stop the walk when the entry
   counter reaches `MaxEntries` and report the result based on what

--- a/specs/023-nested-root-discovery/tasks.md
+++ b/specs/023-nested-root-discovery/tasks.md
@@ -132,28 +132,25 @@ output file.
 
 - [X] T008 [P] [US1] In `parse/discover_root.go` implement the
   walker body of `parse.FindPtStalkRoot` so it (a) absolutises
-  rootDir, (b) calls `parse.LooksLikePtStalkRoot` on rootDir
-  itself - if true, returns the absolute rootDir, (c) uses
-  `filepath.WalkDir` with a closure that increments an entry
+  rootDir, (b) calls `parse.LooksLikePtStalkRoot` on every visited
+  directory including rootDir itself, (c) uses `filepath.WalkDir`
+  with a closure that increments an entry
   counter, computes depth from the relative path, returns
   `filepath.SkipDir` for hidden dirs (`name[0] == '.'`) and for
   any directory at or beyond `MaxDepth`, swallows non-nil
   `walkErr` returns by returning nil, and calls
-  `parse.LooksLikePtStalkRoot` on every visited directory and
-  appends matches to a slice. The function MUST NOT recurse into
-  a matching root (i.e. when a match is recorded, return
-  `filepath.SkipDir` for that node so a parent-of-root that also
-  matches is not double-counted). Return `parse.ErrNotAPtStalkDir`
-  when the slice is empty, the single match when length is 1, or
-  a `*parse.MultiplePtStalkRootsError` (with `Roots` sorted
+  appends matching directories to a slice. The function MUST keep
+  walking after a match so an input that is itself a pt-stalk root
+  and also contains a nested pt-stalk root surfaces as a multi-root
+  ambiguity. Return `parse.ErrNotAPtStalkDir` when the slice is
+  empty, the single match when length is 1, or a
+  `*parse.MultiplePtStalkRootsError` (with `Roots` sorted
   lexically) when length is >= 2. Stop the walk when the entry
   counter reaches `MaxEntries` and report the result based on what
   was found.
 - [X] T009 [US1] Update `cmd/my-gather/archive_input.go`:
-  rewrite the `prepareInput` directory branch so that it first
-  calls `parse.LooksLikePtStalkRoot(inputPath)`. If true, return
-  the input path unchanged (the existing fast path). If false,
-  call `parse.FindPtStalkRoot(ctx, inputPath, parse.FindPtStalkRootOptions{})`
+  rewrite the `prepareInput` directory branch so that it calls
+  `parse.FindPtStalkRoot(ctx, inputPath, parse.FindPtStalkRootOptions{})`
   using the existing `ctx` parameter on `prepareInput` (no
   signature change needed) and place the returned root in the
   `parseDir` field of the returned `*preparedInput`.

--- a/tests/coverage/agent_alignment_test.go
+++ b/tests/coverage/agent_alignment_test.go
@@ -36,11 +36,14 @@ func TestAgentContextFeaturePointersStayAligned(t *testing.T) {
 	for name, text := range map[string]string{"AGENTS.md": agents, "CLAUDE.md": claude} {
 		block := speckitBlock(t, text)
 		if strings.Contains(block, "No active feature.") {
-			if pointer.FeatureDirectory != "specs/014-reconciliation-cleanup" {
-				t.Fatalf("%s says no active feature but .specify/feature.json = %q, want specs/014-reconciliation-cleanup", name, pointer.FeatureDirectory)
+			if !strings.Contains(block, "Active feature: **none**") {
+				t.Fatalf("%s no-active block must mark active feature as none", name)
 			}
-			if !strings.Contains(block, "latest shipped feature is **014-reconciliation-cleanup**") {
-				t.Fatalf("%s no-active block must name 014-reconciliation-cleanup as latest shipped", name)
+			if !strings.Contains(strings.ToLower(block), "latest shipped feature is **"+featureName+"**") {
+				t.Fatalf("%s no-active block must name %s as latest shipped", name, featureName)
+			}
+			if !strings.Contains(block, pointer.FeatureDirectory) {
+				t.Fatalf("%s no-active block must reference %q", name, pointer.FeatureDirectory)
 			}
 			continue
 		}


### PR DESCRIPTION
## Summary
- mark AGENTS.md and CLAUDE.md as no-active-feature while keeping .specify/feature.json as the latest shipped feature pointer
- align nested-root discovery contracts, tasks, quickstart, README, and older CLI examples with the merged behavior and Go flag parsing
- update the coverage alignment test so the no-active-feature contract is enforced generically instead of hard-coding an old shipped feature

## Validation
- go test ./...
- go test ./tests/coverage/...
- scripts/hooks/pre-push-constitution-guard.sh
- go run ./cmd/my-gather --help matches specs/001-ptstalk-report-mvp/contracts/cli.md help excerpt
- go run ./cmd/my-gather --overwrite -o /tmp/my-gather-doc-check.html testdata/example2 && test -s /tmp/my-gather-doc-check.html